### PR TITLE
ci: auto-publish on release-please release + bump actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ jobs:
     name: Rust (aarch64-linux)
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
 
       # rust-embed needs frontend/dist/ present at build time.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Build frontend
@@ -48,10 +48,10 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
@@ -62,7 +62,7 @@ jobs:
     name: Installer lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: shellcheck install.sh
         run: shellcheck packaging/install.sh
       - name: systemd-analyze verify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,30 @@
 name: publish
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to publish (e.g. spark-dashboard-v0.2.0)"
+        required: true
+        type: string
 
 jobs:
   crates-io:
     name: Publish to crates.io
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag_name }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,20 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: rp
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Wire `publish.yml` as a reusable workflow called by `release-please.yml`, gated on the action's `release_created` output. `workflow_dispatch` retained for manual/backfill runs (e.g. v0.2.0).
- Replace `release: published` trigger on `publish.yml` — it doesn't fire when the release is created by an action using `GITHUB_TOKEN`, which is why v0.2.0 never made it to crates.io.
- Bump `actions/checkout` v4 → v6 (×4) and `actions/setup-node` v4 → v6 (×3) across `ci.yml` and `publish.yml`. Bump Node runtime 20 → 24 (active LTS).

No changes to `release-please-config.json` or `.release-please-manifest.json`. `Swatinem/rust-cache@v2`, `dtolnay/rust-toolchain@stable`, and `googleapis/release-please-action@v4` are already on their latest majors.

## Test plan

- [ ] CI goes green on this PR — confirms Node 24 + `checkout`/`setup-node` v6 work
- [ ] After merge, `release-please` workflow run for the merge commit shows the `release-please` job running and the `publish` job being **skipped** (no release created) — confirms the conditional wiring
- [ ] Manually publish v0.2.0: `gh workflow run publish.yml --ref main -f tag_name=spark-dashboard-v0.2.0`
- [ ] `cargo search spark-dashboard` reports 0.2.0
- [ ] Next real release: both jobs run, tag is published to crates.io automatically