### PR TITLE
ci: switch docs-skip to per-job paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,43 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - '.gitignore'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - '.gitignore'
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      installer: ${{ steps.filter.outputs.installer }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust:
+              - 'src/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'frontend/**'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/ci.yml'
+            installer:
+              - 'packaging/**'
+              - '.github/workflows/ci.yml'
+
   rust:
     name: Rust (aarch64-linux)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
@@ -53,6 +71,8 @@ jobs:
 
   frontend:
     name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -70,6 +90,8 @@ jobs:
 
   installer:
     name: Installer lint
+    needs: changes
+    if: needs.changes.outputs.installer == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Replace workflow-level \`paths-ignore\` (added in 825a8c8) with a \`changes\` detector job + per-job \`if:\` conditions using \`dorny/paths-filter@v3\`.
- Fixes required-status-check compatibility: docs-only PRs now see required checks report as **skipped** (treated as passing by the Protect main ruleset) instead of hanging forever.
- Each job runs only when its inputs changed:
  - \`Rust (aarch64-linux)\` — \`src/**\`, \`Cargo.{toml,lock}\`, \`frontend/**\`, \`.github/workflows/ci.yml\`
  - \`Frontend\` — \`frontend/**\`, \`.github/workflows/ci.yml\`
  - \`Installer lint\` — \`packaging/**\`, \`.github/workflows/ci.yml\`

## Why
Workflow-level \`paths-ignore\` prevents the workflow from running at all on docs-only changes. Because \`Rust (aarch64-linux)\`, \`Frontend\`, and \`Installer lint\` are required status checks in the ruleset, not reporting them at all leaves PRs pending indefinitely. Per-job conditions keep the checks reporting while still skipping real build work.

## Test plan
- [ ] This PR touches only \`.github/workflows/ci.yml\`. Since that path is in every filter, all three jobs should run and pass — proving the baseline.
- [ ] After merge: open a follow-up PR with a docs-only change (e.g. README tweak). Confirm all three required checks report "skipped" and the PR is mergeable.
- [ ] After merge: push a \`src/\` change on a branch. Confirm all three jobs execute normally.