### PR TITLE
fix: compute vLLM prefix cache hit rate from counters

### DIFF
--- a/src/engines/prometheus.rs
+++ b/src/engines/prometheus.rs
@@ -61,3 +61,51 @@ pub fn parse_prometheus_text(body: &str) -> Option<ParsedMetrics> {
 
     Some(ParsedMetrics { gauges, counters })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// vLLM exposes prefix cache activity as two counters. The Prometheus
+    /// client library auto-appends `_total` in the exposition format, and our
+    /// normalizer rewrites `vllm:` to `vllm_`. Both names must land in
+    /// `counters` for the hit-rate computation in vllm.rs to work.
+    #[test]
+    fn captures_prefix_cache_counters() {
+        let body = "\
+# HELP vllm:prefix_cache_queries Cached tokens queried.
+# TYPE vllm:prefix_cache_queries counter
+vllm:prefix_cache_queries_total 100.0
+# HELP vllm:prefix_cache_hits Cached tokens hit.
+# TYPE vllm:prefix_cache_hits counter
+vllm:prefix_cache_hits_total 42.0
+";
+        let parsed = parse_prometheus_text(body).expect("parse");
+        assert_eq!(
+            parsed.counters.get("vllm_prefix_cache_queries_total"),
+            Some(&100.0)
+        );
+        assert_eq!(
+            parsed.counters.get("vllm_prefix_cache_hits_total"),
+            Some(&42.0)
+        );
+    }
+
+    #[test]
+    fn missing_prefix_cache_counters_parse_cleanly() {
+        let body = "\
+# HELP vllm:num_requests_running Running requests.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running 0.0
+";
+        let parsed = parse_prometheus_text(body).expect("parse");
+        assert!(parsed
+            .counters
+            .get("vllm_prefix_cache_hits_total")
+            .is_none());
+        assert!(parsed
+            .counters
+            .get("vllm_prefix_cache_queries_total")
+            .is_none());
+    }
+}

--- a/src/engines/prometheus.rs
+++ b/src/engines/prometheus.rs
@@ -99,9 +99,7 @@ vllm:prefix_cache_hits_total 42.0
 vllm:num_requests_running 0.0
 ";
         let parsed = parse_prometheus_text(body).expect("parse");
-        assert!(!parsed
-            .counters
-            .contains_key("vllm_prefix_cache_hits_total"));
+        assert!(!parsed.counters.contains_key("vllm_prefix_cache_hits_total"));
         assert!(!parsed
             .counters
             .contains_key("vllm_prefix_cache_queries_total"));

--- a/src/engines/prometheus.rs
+++ b/src/engines/prometheus.rs
@@ -99,13 +99,11 @@ vllm:prefix_cache_hits_total 42.0
 vllm:num_requests_running 0.0
 ";
         let parsed = parse_prometheus_text(body).expect("parse");
-        assert!(parsed
+        assert!(!parsed
             .counters
-            .get("vllm_prefix_cache_hits_total")
-            .is_none());
-        assert!(parsed
+            .contains_key("vllm_prefix_cache_hits_total"));
+        assert!(!parsed
             .counters
-            .get("vllm_prefix_cache_queries_total")
-            .is_none());
+            .contains_key("vllm_prefix_cache_queries_total"));
     }
 }

--- a/src/engines/vllm.rs
+++ b/src/engines/vllm.rs
@@ -285,11 +285,18 @@ impl EngineAdapter for VllmAdapter {
             .get("vllm_num_requests_swapped")
             .map(|v| *v as u64);
 
-        // GPU prefix cache hit rate (0.0-1.0 gauge → 0-100%)
-        let prefix_cache_hit_rate = parsed
-            .gauges
-            .get("vllm_gpu_prefix_cache_hit_rate")
-            .map(|v| v * 100.0);
+        // Prefix cache hit rate as percentage, computed from the two counters
+        // vLLM exposes (vllm:prefix_cache_hits / vllm:prefix_cache_queries).
+        // Guard against queries == 0 so the tile stays blank until the engine
+        // has served at least one prompt.
+        let prefix_cache_hit_rate = {
+            let hits = parsed.counters.get("vllm_prefix_cache_hits_total");
+            let queries = parsed.counters.get("vllm_prefix_cache_queries_total");
+            match (hits, queries) {
+                (Some(&h), Some(&q)) if q > 0.0 => Some((h / q) * 100.0),
+                _ => None,
+            }
+        };
 
         // Average queue wait time (from histogram)
         let queue_time_ms = {


### PR DESCRIPTION
The dashboard looked up a gauge `vllm:gpu_prefix_cache_hit_rate` that vLLM does not expose, so the Prefix Hit tile always rendered `-- %`. Per the vLLM Prometheus docs, hit rate is derived from two counters: `vllm:prefix_cache_hits` / `vllm:prefix_cache_queries`.

Compute the cumulative ratio and guard against queries == 0 so the tile stays blank until the engine has served its first prompt. Add parser tests covering the counter names the computation depends on.