### PR TITLE
chore: surface dependency commits in release notes; switch to rebase-merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Project-specific. Global rules in `~/.claude/rules/` still apply.
 
 - `main` is protected. No direct pushes. Every change goes through a PR.
 - Branch name: `<type>/<slug>` (`feat/...`, `fix/...`, `docs/...`).
-- Squash-merge PR title = the commit on `main` → it must be a valid Conventional Commit.
+- **Rebase-merge** PRs (never squash) so every commit lands individually on `main` and appears in the release notes. **Every commit** must be a valid Conventional Commit, not just the PR title.
 - All `ci.yml` jobs (rust, frontend, installer) must pass before merge.
 
 ## Commits drive releases
@@ -19,6 +19,8 @@ Project-specific. Global rules in `~/.claude/rules/` still apply.
 | `fix:`                                                     | patch                           |
 | `feat!:` / `BREAKING CHANGE:`                              | minor (becomes major after 1.0) |
 | `chore`, `docs`, `refactor`, `test`, `ci`, `perf`, `style` | none                            |
+
+"Bump" is version impact only — `chore`/`deps` still appear in the changelog under "Dependencies & Chores" (see `changelog-sections` in `release-please-config.json`); only `docs`/`style`/`refactor`/`test`/`build`/`ci` stay hidden.
 
 Tags: `vX.Y.Z`. After merge, release-please opens a rolling release PR; merging it tags + triggers `publish.yml` (`cargo publish`).
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,19 @@
   "release-type": "rust",
   "bump-minor-pre-major": true,
   "include-v-in-tag": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "chore", "section": "Dependencies & Chores" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {
       "package-name": "spark-dashboard",


### PR DESCRIPTION
Follow-up to #26. These two commits were pushed to the #26 branch but were **not included** when that PR was rebase-merged (it merged at the `chore(deps)` commit), so they never reached `main`. As a result `0.9.0` was released with the dependency update hidden from its changelog. This PR lands them so the config takes effect for the next release.

## Changes

- **`release-please-config.json`** — explicit `changelog-sections` overriding release-please defaults so `chore` commits (e.g. `chore(deps)` dependency bumps) render under a **"Dependencies & Chores"** section instead of being hidden. `docs`/`style`/`refactor`/`test`/`build`/`ci` stay hidden. No effect on version-bump behavior.
- **`CLAUDE.md`** — merge convention changed from squash-merge to **rebase-merge** so every commit lands individually on `main` and appears in release notes; documents that every commit (not just the PR title) must be a valid Conventional Commit.

## Notes

- 0.9.0's changelog can't be retroactively fixed (CHANGELOG.md is release-please-owned). The "Dependencies & Chores" section will appear starting with the **next** release.
- Per the new convention, **rebase-merge this PR** (do not squash).

## Test plan

- [x] `release-please-config.json` is valid JSON
- [x] No code changes — config/docs only; CI rust/frontend unaffected
