### PR TITLE
feat(docker): add containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,27 +1,15 @@
-# Rust
 /target/
-
-# Frontend
 /frontend/node_modules/
 /frontend/dist/
-
-# Environment
 .env
 .env.local
-
-# IDE
 .vscode/
 .idea/
 *.swp
 *.swo
-
-# OS
 .DS_Store
-Thumbs.db
-
-# Claude Code workspace
 .claude/
 .gstack/
-
-# Docker
-.dockerenv
+.git/
+docs/
+dev/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# ---------- stage 0: frontend ----------
+FROM node:22-alpine AS frontend
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# ---------- stage 1: rust ----------
+FROM rust:1.95-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY .gitignore .
+# create a dummy frontend/dist so `cargo build` succeeds before the real one
+RUN mkdir -p frontend/dist
+# cache downloads
+RUN cargo build --release 2>&1 | tail -5 || true
+COPY src/ ./src/
+COPY packaging/ ./packaging/
+COPY --from=frontend /app/frontend/dist ./frontend/dist/
+RUN cargo build --release
+
+# ---------- stage 2: runtime ----------
+FROM debian:trixie-slim
+# GPU: uses NVIDIA Container Toolkit (--gpus all), no libnvidia-ml mount needed
+# Add docker group with GID 988 (must match host) for Docker socket access
+RUN groupadd -g 988 docker && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/spark-dashboard /usr/local/bin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  spark-dashboard:
+    build: .
+    container_name: spark-dashboard
+    # Use host network to access vLLM containers running with host networking
+    network_mode: host
+    # GPU passthrough — requires NVIDIA Container Toolkit on the host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    # Docker socket — needed to discover vLLM containers running alongside
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    # Share host PID namespace — needed for process-based engine discovery
+    pid: host
+    # Add docker group (GID 988) to access the Docker socket
+    group_add:
+      - "docker"
+
+    environment:
+      - SPARK_DASHBOARD_PORT=3000
+      - SPARK_DASHBOARD_POLL_INTERVAL=1000
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
Add ability to run spark-dashboard as a Docker container.

## Changes
- **Dockerfile**: Multi-stage build (Node frontend → Rust → Debian runtime) with NVIDIA GPU support
- **docker-compose.yml**: Production configuration with:
  - Host networking for vLLM host networking discovery
  - NVIDIA GPU passthrough
  - Docker socket mount for container discovery
  - Host PID namespace for process scanning
- **.dockerignore**: Exclude build artifacts and dev files
- **.gitignore**: Updated to exclude `.dockerenv`

## Usage
```bash
docker compose up --build
```
Dashboard accessible at http://localhost:3000
## Notes
- Tested on my DGX Spark with vLLM served via [sparkrun](https://github.com/spark-arena/sparkrun). 
- Sparkrun uses host networking for vLLM by default, thats why I use host networking for docker-compose too.