### PR TITLE
feat(docker): first-class containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+/target/
+/frontend/node_modules/
+/frontend/dist/
+.env
+.env.local
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+.claude/
+.gstack/
+.git/
+docs/
+dev/

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,28 @@
+# spark-dashboard container configuration.
+# Copy to `.env` next to docker-compose.yml and adjust. docker compose reads
+# this file automatically.
+
+# --- Docker socket access -----------------------------------------------------
+# The container joins the host's docker group to read /var/run/docker.sock for
+# engine (vLLM container) discovery. Find the host GID with:
+#   getent group docker | cut -d: -f3
+# Common values: 999 (Debian/Ubuntu), 998/988 (others). Mismatch silently
+# disables container-based engine discovery.
+DOCKER_GID=999
+
+# --- Image --------------------------------------------------------------------
+# Image to run when not building from source. Override for dev tags, e.g.
+# ghcr.io/niklasfrick/spark-dashboard:dev
+# SPARK_DASHBOARD_IMAGE=ghcr.io/niklasfrick/spark-dashboard:latest
+
+# --- Dashboard settings -------------------------------------------------------
+SPARK_DASHBOARD_PORT=3000
+SPARK_DASHBOARD_BIND=0.0.0.0
+SPARK_DASHBOARD_POLL_INTERVAL=1000
+SPARK_DASHBOARD_GPU_INDEX=0
+# Fallback API key applied to engine endpoints without an explicit key.
+# SPARK_DASHBOARD_PROVIDER_API_KEY=
+
+# --- Logging ------------------------------------------------------------------
+# error | warn | info | debug | trace (or per-module, e.g. spark_dashboard=debug)
+RUST_LOG=info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       frontend: ${{ steps.filter.outputs.frontend }}
       installer: ${{ steps.filter.outputs.installer }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v6
       - id: filter
@@ -34,6 +35,13 @@ jobs:
               - '.github/workflows/ci.yml'
             installer:
               - 'packaging/**'
+              - '.github/workflows/ci.yml'
+            docker:
+              - 'Dockerfile'
+              - 'docker-compose*.yml'
+              - '.dockerignore'
+              - 'src/**'
+              - 'frontend/**'
               - '.github/workflows/ci.yml'
 
   rust:
@@ -104,3 +112,32 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y systemd
           systemd-analyze verify packaging/systemd/spark-dashboard.service || \
             echo "(warnings above are OK on a CI host without the service user)"
+
+  docker:
+    name: Docker build (${{ matrix.arch }})
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      # Native per-arch build (no QEMU): confirms the multi-stage Dockerfile
+      # compiles for both targets. Publishes nothing — that's docker-publish.yml.
+      - name: Build image (${{ matrix.platform }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,115 @@
+name: Publish container image
+
+# Builds and publishes the multi-arch container image to GHCR on release-please
+# tags (spark-dashboard-vX.Y.Z). Each arch builds natively on its own runner
+# (no QEMU) and pushes by digest; a final job merges them into one manifest list
+# tagged :vX.Y.Z, :vX.Y, and :latest.
+on:
+  push:
+    tags:
+      - "spark-dashboard-v*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: niklasfrick/spark-dashboard
+
+jobs:
+  build:
+    name: Build ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ github.ref_name }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest and push tags
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # release-please tags look like spark-dashboard-v0.10.0 → :v0.10.0, :v0.10
+          tags: |
+            type=match,pattern=spark-dashboard-(v\d+\.\d+\.\d+),group=1
+            type=match,pattern=spark-dashboard-(v\d+\.\d+),group=1
+            type=raw,value=latest
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect published image
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,12 @@ cd frontend && npm run build && npm test -- --run
 
 If both stacks changed, run both blocks. If embedded assets changed, build the frontend first (`rust-embed` needs `frontend/dist/`).
 
+Docker changes (`Dockerfile`, `docker-compose*.yml`):
+
+```bash
+./dev/docker-dev.sh --build-local   # buildx multi-stage build smoke test (no GPU)
+```
+
 ## Metrics contract (Rust ↔ frontend)
 
 When you change `MemoryMetrics`/`GpuMetrics`/`CpuMetrics` shape, serde names, display logic, or fields — update all of these in the same PR:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,13 @@ cd frontend && npm test
 cargo test
 ```
 
+If you change the `Dockerfile` or `docker-compose*.yml`, also smoke-test the
+image build before pushing (see [`docs/docker.md`](./docs/docker.md)):
+
+```bash
+./dev/docker-dev.sh --build-local      # buildx multi-stage build, no GPU needed
+```
+
 ## Style
 
 - **Rust**: `cargo fmt` + `cargo clippy -- -D warnings` before pushing.

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN npm run build
 # cargo-chef gives honest dependency-layer caching: deps are "cooked" from
 # Cargo.toml/Cargo.lock alone, so editing src/ doesn't bust the dependency
 # layer. Replaces the dummy-frontend/dist + `|| true` cache trick.
-# Pin the bookworm variant so the binary's glibc matches the bookworm runtime
-# stage below (the default rust:slim tracks trixie → GLIBC_2.38 not found).
-FROM rust:1.95-slim-bookworm AS chef
+# rust:<v>-slim and the runtime stage below both track Debian trixie, so their
+# glibc matches — keep these two in lockstep when bumping the Debian release.
+FROM rust:1.96-slim AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 
@@ -40,7 +40,7 @@ COPY --from=frontend /app/frontend/dist ./frontend/dist/
 RUN cargo build --release --locked
 
 # ---------- stage: runtime ----------
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 # OCI image metadata. revision/version are injected at build time (see the
 # docker-publish workflow / docker-compose build args).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1
+
+# ---------- stage: frontend ----------
+# Build the SPA so rust-embed can bundle frontend/dist at compile time.
+# Node 24 matches the version pinned in CI.
+FROM node:24-alpine AS frontend
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# ---------- stage: chef ----------
+# cargo-chef gives honest dependency-layer caching: deps are "cooked" from
+# Cargo.toml/Cargo.lock alone, so editing src/ doesn't bust the dependency
+# layer. Replaces the dummy-frontend/dist + `|| true` cache trick.
+# Pin the bookworm variant so the binary's glibc matches the bookworm runtime
+# stage below (the default rust:slim tracks trixie → GLIBC_2.38 not found).
+FROM rust:1.95-slim-bookworm AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY src/ ./src/
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ---------- stage: builder ----------
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build & cache dependencies only (no app code yet). --locked keeps the build
+# reproducible against Cargo.lock, matching CI.
+RUN cargo chef cook --release --locked --recipe-path recipe.json
+# Real build: app sources + the embedded frontend assets (rust-embed reads
+# frontend/dist at compile time, so it must exist here).
+COPY Cargo.toml Cargo.lock ./
+COPY src/ ./src/
+COPY packaging/ ./packaging/
+COPY --from=frontend /app/frontend/dist ./frontend/dist/
+RUN cargo build --release --locked
+
+# ---------- stage: runtime ----------
+FROM debian:bookworm-slim AS runtime
+
+# OCI image metadata. revision/version are injected at build time (see the
+# docker-publish workflow / docker-compose build args).
+ARG VCS_REF=""
+ARG VERSION=""
+LABEL org.opencontainers.image.source="https://github.com/niklasfrick/spark-dashboard" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="spark-dashboard" \
+      org.opencontainers.image.description="Real-time hardware and LLM inference monitoring for Linux hosts with NVIDIA GPUs" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}"
+
+# ca-certificates: outbound HTTPS to engine APIs. wget: HEALTHCHECK probe.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run unprivileged (uid 10001), mirroring the hardened systemd profile. NVML,
+# /proc, and the docker socket all work non-root given the device/group access
+# supplied at run time (see docker-compose.yml: GPU reservation + group_add).
+RUN useradd -r -u 10001 -s /usr/sbin/nologin spark
+
+COPY --from=builder /app/target/release/spark-dashboard /usr/local/bin/spark-dashboard
+
+USER spark
+EXPOSE 3000
+
+# Liveness probe against the /healthz endpoint. Honors SPARK_DASHBOARD_PORT.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s \
+    CMD wget -qO- "http://127.0.0.1:${SPARK_DASHBOARD_PORT:-3000}/healthz" >/dev/null 2>&1 || exit 1
+
+ENTRYPOINT ["/usr/local/bin/spark-dashboard"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ systemctl status spark-dashboard
 The dashboard is now served on port 3000. See [Install on your Linux host](#install-on-your-linux-host-1)
 for the full guide, config overrides, and uninstall.
 
+### Run with Docker
+
+Prefer containers? Run the published multi-arch image (needs the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)):
+
+```bash
+docker run --rm --gpus all --pid=host -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  ghcr.io/niklasfrick/spark-dashboard:latest
+```
+
+Or with Compose (host networking + GPU + socket mount preconfigured):
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/niklasfrick/spark-dashboard/main/docker-compose.yml
+curl -fsSL https://raw.githubusercontent.com/niklasfrick/spark-dashboard/main/.env.docker.example -o .env
+# set DOCKER_GID to your host's docker group: getent group docker | cut -d: -f3
+docker compose up -d
+```
+
+See [`docs/docker.md`](./docs/docker.md) for networking modes, GPU passthrough,
+env vars, and troubleshooting.
+
 ### Develop locally
 
 ```bash

--- a/dev/README.md
+++ b/dev/README.md
@@ -47,6 +47,31 @@ Off by default because each save triggers a full `npm run build` plus
 use `:5173` (Vite, instant HMR) and only enable this flag when you specifically
 need the embedded bundle to stay current.
 
+### `./dev/docker-dev.sh` — containerized deployment loop
+
+Peer to `dev.sh`, but exercises the containerized path: builds the multi-stage
+Dockerfile, deploys via `docker compose` on the remote host, and tails logs.
+Uses the same `DEPLOY_USER` / `DEPLOY_HOST` / `DEPLOY_DIR` as `dev.sh`.
+
+```bash
+./dev/docker-dev.sh --build-local       # buildx --platform linux/arm64 --load (Mac)
+./dev/docker-dev.sh --deploy-remote     # rsync + compose build/up on DGX Spark
+./dev/docker-dev.sh --deploy-ghcr       # multi-arch buildx --push, remote pulls
+./dev/docker-dev.sh --logs              # docker compose logs -f on the remote
+./dev/docker-dev.sh --down              # docker compose down on the remote
+```
+
+`--build-local` validates the Dockerfile end-to-end on macOS without GPU access
+(no NVML, no `--gpus`). `--deploy-remote` is the full runtime test on the DGX
+Spark — confirms GPU passthrough, `/var/run/docker.sock` mount, `pid:host`, and
+engine discovery. `--deploy-ghcr` mirrors the eventual release path (multi-arch
+image published to GHCR, then `docker compose pull` on the remote).
+
+Set `DOCKER_GID` in your repo-root `.env` to the **remote** host's docker group
+GID (`getent group docker | cut -d: -f3`) — `.env` is rsynced to the remote, and
+compose adds that GID so the container can read the Docker socket for engine
+discovery. See [`.env.docker.example`](../.env.docker.example).
+
 ## Required environment variables
 
 | Variable           | Purpose                                                      |

--- a/dev/docker-dev.sh
+++ b/dev/docker-dev.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Validate the containerized deployment locally and on the remote host.
+# Mirrors dev/dev.sh's DEPLOY_USER/DEPLOY_HOST/DEPLOY_DIR conventions; reads
+# the same repo-root .env. See dev/README.md for the high-level dev loop.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE_NAME="spark-dashboard"
+GHCR_IMAGE="ghcr.io/niklasfrick/spark-dashboard"
+GHCR_TAG="dev"
+
+usage() {
+    cat <<EOF
+Usage: docker-dev.sh <mode> [options]
+
+Modes (exactly one required):
+
+  --build-local         Build the image locally for linux/arm64 (DGX Spark
+                        target arch) and load it into the local Docker engine.
+                        Validates the multi-stage Dockerfile without needing a
+                        GPU. No runtime test — there's no NVML on macOS.
+
+  --deploy-remote       Rsync the project to \${DEPLOY_USER}@\${DEPLOY_HOST}:\${DEPLOY_DIR},
+                        then run 'docker compose build && docker compose up -d'
+                        on the remote. Mirrors dev/dev.sh's source-sync model
+                        but builds the container on the remote rather than the
+                        bare binary. Validates the full runtime path (GPU
+                        passthrough, /var/run/docker.sock, pid:host, NVML).
+
+  --deploy-ghcr         Build a multi-arch image (linux/arm64,linux/amd64) and
+                        push to ${GHCR_IMAGE}:${GHCR_TAG}, then SSH to the
+                        remote and 'docker compose pull && up -d'. Mirrors the
+                        eventual release path (multi-arch GHCR images). Requires
+                        'gh auth token' or GHCR_PAT in the environment, and
+                        SPARK_DASHBOARD_IMAGE=${GHCR_IMAGE}:${GHCR_TAG} in the
+                        remote .env so compose pulls the pushed tag.
+
+  --logs                Tail logs from the running container on the remote.
+
+  --down                Bring the remote stack down (docker compose down).
+
+  -h, --help            Show this help.
+
+Environment (read from repo-root .env, same as dev/dev.sh):
+
+  DEPLOY_USER  SSH user on the remote host
+  DEPLOY_HOST  Hostname or IP of the remote host
+  DEPLOY_DIR   Project path on the remote host (default 'spark-dashboard')
+  DOCKER_GID   Host docker group GID for socket access in compose. Set this to
+               the REMOTE host's GID (getent group docker | cut -d: -f3) since
+               .env is rsynced to the remote for --deploy-remote.
+  GHCR_PAT     GitHub PAT with write:packages (optional; falls back to 'gh auth token')
+
+Example workflow for testing the container:
+
+  ./dev/docker-dev.sh --build-local       # confirm Dockerfile builds at all
+  ./dev/docker-dev.sh --deploy-remote     # full runtime test on DGX Spark
+  ./dev/docker-dev.sh --logs              # watch metrics stream start
+EOF
+}
+
+# --- Parse flags -------------------------------------------------------------
+MODE=""
+for arg in "$@"; do
+    case "$arg" in
+        --build-local|--deploy-remote|--deploy-ghcr|--logs|--down)
+            if [ -n "$MODE" ]; then
+                echo "error: pass exactly one mode (got $MODE and $arg)" >&2
+                exit 2
+            fi
+            MODE="$arg"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown flag: $arg (try --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$MODE" ]; then
+    usage
+    exit 2
+fi
+
+# --- Load .env if present ----------------------------------------------------
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$PROJECT_ROOT/.env"
+    set +a
+fi
+
+# DEPLOY_* canonical; SPARK_* accepted as legacy aliases (matches dev.sh).
+: "${DEPLOY_USER:=${SPARK_USER:-}}"
+: "${DEPLOY_HOST:=${SPARK_HOST:-}}"
+: "${DEPLOY_DIR:=${SPARK_DIR:-spark-dashboard}}"
+DEPLOY_DIR="${DEPLOY_DIR#\~/}"
+DEPLOY_DIR="${DEPLOY_DIR/#$HOME\//}"
+REMOTE="${DEPLOY_USER:-}@${DEPLOY_HOST:-}"
+# Host port the dashboard is reachable on. In the default host-network mode this
+# is the port the app binds directly; set SPARK_DASHBOARD_PORT in .env to move it
+# (e.g. off :3000 when a cargo-installed instance already owns that port).
+DASH_PORT="${SPARK_DASHBOARD_PORT:-3000}"
+
+needs_remote() {
+    : "${DEPLOY_USER:?Set DEPLOY_USER in .env}"
+    : "${DEPLOY_HOST:?Set DEPLOY_HOST in .env}"
+}
+
+# --- Modes -------------------------------------------------------------------
+
+build_local() {
+    cd "$PROJECT_ROOT"
+    echo "==> Building $IMAGE_NAME:dev for linux/arm64 (DGX Spark target)"
+    # --load can only load a single-arch image into the local daemon.
+    docker buildx build \
+        --platform linux/arm64 \
+        --load \
+        -t "$IMAGE_NAME:dev" \
+        .
+    SIZE_BYTES=$(docker image inspect "$IMAGE_NAME:dev" --format '{{.Size}}')
+    SIZE_MB=$(( SIZE_BYTES / 1024 / 1024 ))
+    echo "==> OK. Image: $IMAGE_NAME:dev (${SIZE_MB} MB)"
+    echo "    Note: no runtime test on this host — no NVML or --gpus on macOS."
+    echo "    Next: ./dev/docker-dev.sh --deploy-remote"
+}
+
+deploy_remote() {
+    needs_remote
+    cd "$PROJECT_ROOT"
+    echo "==> Syncing project to ${REMOTE}:${DEPLOY_DIR}"
+    rsync -az --delete \
+        --exclude '/target/' \
+        --exclude '/frontend/node_modules/' \
+        --exclude '/frontend/dist/' \
+        --exclude '/.git/' \
+        --exclude '/.claude/' \
+        --exclude '/.gstack/' \
+        --exclude '/docs/' \
+        ./ "${REMOTE}:${DEPLOY_DIR}/"
+
+    echo "==> Building and starting container on remote"
+    # shellcheck disable=SC2087  # we want $DEPLOY_DIR expanded locally
+    ssh "${REMOTE}" bash -lc "set -e
+        cd '${DEPLOY_DIR}'
+        docker compose build
+        docker compose up -d
+        echo
+        echo '--- container state ---'
+        docker compose ps
+        echo
+        echo '--- recent logs ---'
+        docker compose logs --tail=20 spark-dashboard || true
+    "
+    echo "==> Done. Dashboard: http://${DEPLOY_HOST}:${DASH_PORT}"
+    echo "    Health check: docker inspect $IMAGE_NAME --format '{{.State.Health.Status}}'"
+}
+
+deploy_ghcr() {
+    needs_remote
+    cd "$PROJECT_ROOT"
+
+    : "${GHCR_PAT:=$(gh auth token 2>/dev/null || true)}"
+    if [ -z "${GHCR_PAT}" ]; then
+        echo "error: need GHCR_PAT in env or 'gh auth login' configured" >&2
+        exit 2
+    fi
+    echo "==> Logging into ghcr.io"
+    echo "${GHCR_PAT}" | docker login ghcr.io -u "$(gh api user --jq .login 2>/dev/null || echo niklasfrick)" --password-stdin
+
+    echo "==> Building multi-arch image and pushing to ${GHCR_IMAGE}:${GHCR_TAG}"
+    docker buildx build \
+        --platform linux/arm64,linux/amd64 \
+        --push \
+        -t "${GHCR_IMAGE}:${GHCR_TAG}" \
+        .
+
+    echo "==> Deploying on remote via docker compose pull"
+    ssh "${REMOTE}" bash -lc "set -e
+        cd '${DEPLOY_DIR}'
+        docker compose pull
+        docker compose up -d
+        docker compose ps
+    "
+    echo "==> Done. Dashboard: http://${DEPLOY_HOST}:${DASH_PORT}"
+}
+
+remote_logs() {
+    needs_remote
+    ssh "${REMOTE}" "cd '${DEPLOY_DIR}' && docker compose logs -f --tail=100 spark-dashboard"
+}
+
+remote_down() {
+    needs_remote
+    ssh "${REMOTE}" "cd '${DEPLOY_DIR}' && docker compose down"
+}
+
+case "$MODE" in
+    --build-local)   build_local ;;
+    --deploy-remote) deploy_remote ;;
+    --deploy-ghcr)   deploy_ghcr ;;
+    --logs)          remote_logs ;;
+    --down)          remote_down ;;
+esac

--- a/docker-compose.bridge.yml
+++ b/docker-compose.bridge.yml
@@ -1,0 +1,14 @@
+# Opt-in bridge networking override. Use with:
+#   docker compose -f docker-compose.yml -f docker-compose.bridge.yml up -d
+#
+# Trades away host-network engine discovery (vLLM bound to the host network
+# won't be auto-detected) for network isolation. Reach host services via
+# host.docker.internal. pid:host is inherited from the base file, so
+# container-based engine discovery via the Docker socket still works.
+services:
+  spark-dashboard:
+    network_mode: bridge
+    ports:
+      - "${SPARK_DASHBOARD_PORT:-3000}:${SPARK_DASHBOARD_PORT:-3000}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+# spark-dashboard — containerized deployment.
+#
+# Defaults to host networking so the dashboard can discover vLLM/engine
+# processes and containers running on the host network. For an isolated bridge
+# setup, layer the override:
+#   docker compose -f docker-compose.yml -f docker-compose.bridge.yml up -d
+#
+# Configure via a .env file in this directory (see .env.docker.example). By
+# default this pulls the published image; run `docker compose build` to build
+# from source instead.
+services:
+  spark-dashboard:
+    image: ${SPARK_DASHBOARD_IMAGE:-ghcr.io/niklasfrick/spark-dashboard:latest}
+    build:
+      context: .
+      args:
+        VCS_REF: ${VCS_REF:-}
+        VERSION: ${VERSION:-}
+    container_name: spark-dashboard
+
+    # Host network: required to reach engines bound to the host (e.g. vLLM via
+    # sparkrun) and for process-based discovery. See the bridge override to opt
+    # out at the cost of host-network engine discovery.
+    network_mode: host
+
+    # Share the host PID namespace for process-based engine discovery.
+    pid: host
+
+    # GPU passthrough via the NVIDIA Container Toolkit. No device-file mounts
+    # needed — metrics come from NVML.
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+    # Read-only Docker socket so the dashboard can list vLLM containers. The
+    # added group must match the host's docker GID — set DOCKER_GID in .env
+    # (find it with: getent group docker | cut -d: -f3). Defaults to 999.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    group_add:
+      - "${DOCKER_GID:-999}"
+
+    environment:
+      - SPARK_DASHBOARD_PORT=${SPARK_DASHBOARD_PORT:-3000}
+      - SPARK_DASHBOARD_BIND=${SPARK_DASHBOARD_BIND:-0.0.0.0}
+      - SPARK_DASHBOARD_POLL_INTERVAL=${SPARK_DASHBOARD_POLL_INTERVAL:-1000}
+      - SPARK_DASHBOARD_GPU_INDEX=${SPARK_DASHBOARD_GPU_INDEX:-0}
+      - SPARK_DASHBOARD_PROVIDER_API_KEY=${SPARK_DASHBOARD_PROVIDER_API_KEY:-}
+      - RUST_LOG=${RUST_LOG:-info}
+
+    restart: unless-stopped

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -146,7 +146,7 @@ deliberately permissive:
   `:ro`, but socket access is still powerful; only run this on hosts you trust.
 
 The image itself is hardened: it runs as a non-root user (uid 10001) on
-`debian:bookworm-slim`, mirroring the systemd profile's `User=spark-dashboard`.
+`debian:trixie-slim`, mirroring the systemd profile's `User=spark-dashboard`.
 
 ## Updating
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,166 @@
+# Running spark-dashboard with Docker
+
+Containers are a first-class deployment path, peer to the `cargo install` +
+systemd route. The image is published multi-arch (`linux/amd64`, `linux/arm64`)
+to **`ghcr.io/niklasfrick/spark-dashboard`**, tagged `:vX.Y.Z`, `:vX.Y`, and
+`:latest`.
+
+## Quick start
+
+```bash
+docker run --rm --gpus all --pid=host -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  ghcr.io/niklasfrick/spark-dashboard:latest
+```
+
+The dashboard is served on port 3000. Prefer Compose for anything long-lived.
+
+## Prerequisites
+
+- Linux host with NVIDIA drivers.
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+  installed and configured (`--gpus all` / Compose device reservations rely on it).
+- Docker Engine with Compose v2 (`docker compose`, not `docker-compose`).
+
+## Compose
+
+`docker-compose.yml` ships host networking, GPU passthrough, the read-only
+Docker socket mount, and `pid:host` preconfigured. Configure it with a `.env`
+file (copy [`.env.docker.example`](../.env.docker.example)):
+
+```bash
+cp .env.docker.example .env
+# set DOCKER_GID — see "The DOCKER_GID gotcha" below
+docker compose up -d
+docker compose logs -f spark-dashboard
+```
+
+By default Compose **pulls** `ghcr.io/niklasfrick/spark-dashboard:latest`. To
+build from a local checkout instead:
+
+```bash
+docker compose build && docker compose up -d
+```
+
+Pin a specific version or a dev tag with `SPARK_DASHBOARD_IMAGE` in `.env`:
+
+```bash
+SPARK_DASHBOARD_IMAGE=ghcr.io/niklasfrick/spark-dashboard:v0.10.0
+```
+
+## Networking modes
+
+### Host (default)
+
+`network_mode: host` lets the dashboard reach engines bound to the host network
+(e.g. vLLM started via sparkrun) and discover host processes. The dashboard
+listens directly on the host's port 3000. This is the right default for a
+single-tenant GPU box. In this mode `SPARK_DASHBOARD_PORT` is the port the app
+binds **directly on the host** (there's no port mapping) — set it to move the
+dashboard off `:3000`, e.g. when a `cargo install`ed instance already owns 3000.
+
+### Bridge (opt-in)
+
+For network isolation, layer the bridge override:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.bridge.yml up -d
+```
+
+This switches to bridge networking, publishes `3000:3000`, and adds
+`host.docker.internal` (→ `host-gateway`) so the container can still reach host
+services. **Tradeoff:** engines bound only to the host network are no longer
+auto-discovered. Container-based discovery over the Docker socket still works
+(`pid:host` is inherited).
+
+## GPU passthrough
+
+GPU metrics come from **NVML**, not device-file mounts — so no `/dev/nvidia*`
+mounting is needed. The Compose file reserves all GPUs via the NVIDIA Container
+Toolkit:
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+```
+
+For `docker run`, the equivalent is `--gpus all`. Select a specific device with
+`SPARK_DASHBOARD_GPU_INDEX` on multi-GPU hosts.
+
+## Environment variables
+
+All are optional; defaults match the binary. Set them in `.env`.
+
+| Variable                            | Default     | Purpose                                              |
+| ----------------------------------- | ----------- | ---------------------------------------------------- |
+| `DOCKER_GID`                        | `999`       | Host docker group GID for socket access (see below). |
+| `SPARK_DASHBOARD_IMAGE`             | `…:latest`  | Image Compose runs when not building from source.    |
+| `SPARK_DASHBOARD_PORT`              | `3000`      | Listen port.                                         |
+| `SPARK_DASHBOARD_BIND`              | `0.0.0.0`   | Bind address.                                        |
+| `SPARK_DASHBOARD_POLL_INTERVAL`     | `1000`      | Metrics polling interval (ms).                       |
+| `SPARK_DASHBOARD_GPU_INDEX`         | `0`         | NVML GPU index to monitor.                           |
+| `SPARK_DASHBOARD_PROVIDER_API_KEY`  | _(unset)_   | Fallback API key for auth-gated engines.             |
+| `RUST_LOG`                          | `info`      | Log filter (`error`/`warn`/`info`/`debug`/`trace`).  |
+
+## Health
+
+The container exposes a liveness endpoint at **`/healthz`** (returns `200 ok`).
+The image's `HEALTHCHECK` polls it every 30s. Check status with:
+
+```bash
+docker inspect spark-dashboard --format '{{.State.Health.Status}}'   # -> healthy
+```
+
+It reports that the HTTP server is up — engine/GPU health is surfaced live over
+the `/ws` WebSocket in the UI.
+
+## The DOCKER_GID gotcha
+
+Engine discovery reads the host's `/var/run/docker.sock`. The container must
+join the host's **docker group GID** to do so. This GID varies by distro
+(commonly `999` on Debian/Ubuntu, sometimes `998`/`988`). Find yours:
+
+```bash
+getent group docker | cut -d: -f3
+```
+
+Set it in `.env` as `DOCKER_GID`. On a mismatch the container still starts but
+container-based engine discovery silently degrades — you'll see a one-line
+"Docker detection unavailable" note in the logs.
+
+## Security tradeoffs
+
+The default configuration is tuned for a trusted single-tenant GPU host and is
+deliberately permissive:
+
+- **`network_mode: host`** — no network isolation from the host. Use the bridge
+  override if you need it.
+- **`pid: host`** — the container sees all host processes (required for
+  process-based engine discovery).
+- **`/var/run/docker.sock` (read-only)** — read access to the Docker API. Mounted
+  `:ro`, but socket access is still powerful; only run this on hosts you trust.
+
+The image itself is hardened: it runs as a non-root user (uid 10001) on
+`debian:bookworm-slim`, mirroring the systemd profile's `User=spark-dashboard`.
+
+## Updating
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+Or pin to a new explicit `SPARK_DASHBOARD_IMAGE` tag and re-run `up -d`.
+
+## Building / testing locally
+
+Use the dev harness (see [`dev/README.md`](../dev/README.md)):
+
+```bash
+./dev/docker-dev.sh --build-local     # buildx linux/arm64 --load — Dockerfile smoke test
+./dev/docker-dev.sh --deploy-remote   # rsync + compose build/up on the remote GPU host
+```

--- a/src/engines/vllm.rs
+++ b/src/engines/vllm.rs
@@ -174,12 +174,24 @@ impl VllmAdapter {
         let resp = match hf_client.get(&url).send().await {
             Ok(r) if r.status().is_success() => r,
             Ok(r) => {
-                tracing::warn!(
-                    endpoint = %self.endpoint,
-                    model_id = %model_id,
-                    status = %r.status(),
-                    "HF model info API returned non-success",
-                );
+                let status = r.status();
+                if is_expected_hf_miss(status.as_u16()) {
+                    // Not a public HF repo (local/custom serve name or gated
+                    // model without a token) — expected, enrichment is optional.
+                    tracing::debug!(
+                        endpoint = %self.endpoint,
+                        model_id = %model_id,
+                        status = %status,
+                        "HF model info unavailable (model not public on HuggingFace); skipping enrichment",
+                    );
+                } else {
+                    tracing::warn!(
+                        endpoint = %self.endpoint,
+                        model_id = %model_id,
+                        status = %status,
+                        "HF model info API returned non-success",
+                    );
+                }
                 *self.last_hf_error.lock().await = Some(Instant::now());
                 return None;
             }
@@ -260,6 +272,14 @@ impl VllmAdapter {
 
         Some(result)
     }
+}
+
+/// HuggingFace returns these statuses when a model id isn't publicly
+/// resolvable — local/custom serve names (e.g. a vLLM `--served-model-name`),
+/// or gated/private repos accessed without a token. Metadata enrichment is
+/// best-effort, so these are expected and logged at debug rather than warn.
+fn is_expected_hf_miss(status: u16) -> bool {
+    matches!(status, 401 | 403 | 404)
 }
 
 #[derive(Deserialize)]
@@ -813,6 +833,19 @@ impl EngineAdapter for VllmAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// HF enrichment misses for non-public model ids (401/403/404) are
+    /// expected and must stay quiet; other non-success statuses (e.g. 5xx,
+    /// 429) still surface as warnings.
+    #[test]
+    fn expected_hf_misses_are_quiet() {
+        for status in [401, 403, 404] {
+            assert!(is_expected_hf_miss(status), "{status} should be quiet");
+        }
+        for status in [200, 429, 500, 502, 503] {
+            assert!(!is_expected_hf_miss(status), "{status} should warn");
+        }
+    }
 
     /// Sanity check: percentiles flow from the parser through the adapter.
     /// We don't spin up an HTTP mock here — `parse_prometheus_text` is the

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,9 +11,17 @@ struct FrontendAssets;
 pub fn create_router(tx: broadcast::Sender<String>) -> Router {
     Router::new()
         .route("/ws", get(crate::ws::ws_handler))
+        // Liveness probe for container HEALTHCHECK / orchestrators. Intentionally
+        // dependency-free: it reports that the HTTP server is up, not that any
+        // engine/GPU is healthy (that's surfaced over /ws).
+        .route("/healthz", get(healthz))
         .fallback(static_handler)
         .with_state(tx)
         .layer(CorsLayer::permissive())
+}
+
+async fn healthz() -> &'static str {
+    "ok"
 }
 
 async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
@@ -44,4 +52,27 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
     }
 
     (axum::http::StatusCode::NOT_FOUND, "Not Found").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn healthz_returns_ok() {
+        let (tx, _rx) = broadcast::channel::<String>(16);
+        let app = create_router(tx);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let resp = reqwest::get(format!("http://{addr}/healthz"))
+            .await
+            .expect("request to /healthz");
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), "ok");
+    }
 }


### PR DESCRIPTION
## Summary

Makes containerized deployment a first-class peer to the `cargo install` + systemd
path. **Supersedes and resolves #30 and #31** — folds @Marker689's Dockerfile/compose
(PR #30) with all review fixes applied, plus our `dev/docker-dev.sh` harness (PR #31),
and adds the "first-class" delta: CI build validation, multi-arch GHCR publishing, a
`/healthz` endpoint, and docs.

Landed as granular Conventional Commits (rebase-merge → individual release-note lines):

- `feat(server): add /healthz liveness endpoint`
- `feat(docker): add hardened multi-stage image and compose deployment` (Co-authored-by @Marker689)
- `feat(dev): add docker-dev.sh container test harness`
- `ci: validate docker image build on PRs`
- `ci: publish multi-arch container image to GHCR on release`
- `docs(docker): document containerized deployment as a primary option`

## PR #30 review fixes applied

- Dynamic docker GID via compose `group_add: ["${DOCKER_GID:-999}"]` (no baked-in `groupadd`)
- Runs unprivileged as **uid 10001** (mirrors the hardened systemd profile)
- `cargo build --release --locked` for reproducible builds matching CI
- **cargo-chef** dependency-layer caching, replacing the fragile dummy-`dist` + `|| true` trick
- `HEALTHCHECK` against the new `/healthz` endpoint via `wget`
- OCI image labels (source, licenses, title, description, revision, version)
- `debian:bookworm-slim` (stable); dropped `COPY .gitignore`
- Full compose env coverage (PORT/BIND/POLL_INTERVAL/GPU_INDEX/PROVIDER_API_KEY/RUST_LOG) + `.env.docker.example`
- `network_mode: host` default kept, with an opt-in `docker-compose.bridge.yml` override

> Note: pinned the builder to `rust:1.95-slim-bookworm` so the binary's glibc matches the
> bookworm runtime (the default `rust:slim` tracks trixie → `GLIBC_2.38 not found`).

## Test plan

Local (done):
- [x] `cargo fmt --check`, `cargo clippy --all-targets --locked -D warnings`, `cargo test --locked` (97 pass, incl. `/healthz`)
- [x] `cd frontend && npm run build && npm test -- --run` (126 pass)
- [x] `docker buildx build --platform linux/arm64 --load` succeeds (36 MB image, cargo-chef caching verified)
- [x] Container runs: `/healthz` → `ok`, SPA shell served, `id` → uid=10001 (non-root), HEALTHCHECK → healthy

Remote runtime (DGX Spark — to run before merge):
- [x] `./dev/docker-dev.sh --deploy-remote` (set `DOCKER_GID` from `getent group docker | cut -d: -f3`)
- [x] WebSocket `/ws` streams live CPU/GPU/memory in the browser
- [x] GPU passthrough: `docker exec spark-dashboard ls /dev/nvidia*`
- [x] vLLM engine discovery: with a sparkrun vLLM container up, the Engines panel lists it
- [x] `docker compose down && up -d` cycles cleanly

CI:
- [ ] new `docker` job builds linux/amd64 + linux/arm64 green

After merge: close #30 and #31 with crediting comments; first `docker-publish.yml` run fires on the next `spark-dashboard-v*` tag.