### PR TITLE
fix: GPU power gauge that never moves on GB10

### DIFF
--- a/frontend/src/__tests__/gpuPower.test.ts
+++ b/frontend/src/__tests__/gpuPower.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { niceCeiling, powerPeak, computePowerScale } from '../lib/gpuPower'
+
+describe('niceCeiling', () => {
+  it('rounds up to a 1-2-5 grid', () => {
+    expect(niceCeiling(4)).toBe(5)
+    expect(niceCeiling(5)).toBe(5)
+    expect(niceCeiling(5.1)).toBe(10)
+    expect(niceCeiling(1)).toBe(1)
+    expect(niceCeiling(10)).toBe(10)
+    expect(niceCeiling(130)).toBe(200)
+    expect(niceCeiling(1.5)).toBe(2)
+  })
+
+  it('returns null for non-positive or non-finite input', () => {
+    expect(niceCeiling(0)).toBeNull()
+    expect(niceCeiling(-5)).toBeNull()
+    expect(niceCeiling(NaN)).toBeNull()
+    expect(niceCeiling(Infinity)).toBeNull()
+  })
+})
+
+describe('powerPeak', () => {
+  it('returns the max across history and the current sample', () => {
+    expect(powerPeak([{ value: 3 }, { value: 7 }, { value: 5 }], 4)).toBe(7)
+    expect(powerPeak([{ value: 3 }, { value: 7 }], 12)).toBe(12)
+  })
+
+  it('handles a missing current reading', () => {
+    expect(powerPeak([{ value: 3 }, { value: 7 }], null)).toBe(7)
+  })
+
+  it('returns null when nothing usable is present', () => {
+    expect(powerPeak([], null)).toBeNull()
+  })
+
+  it('uses current alone when history is empty', () => {
+    expect(powerPeak([], 4)).toBe(4)
+  })
+})
+
+describe('computePowerScale', () => {
+  it('uses the hardware limit when present', () => {
+    const scale = computePowerScale(150, 400, 200)
+    expect(scale.source).toBe('limit')
+    expect(scale.effectiveMax).toBe(400)
+    expect(scale.percent).toBeCloseTo(37.5)
+  })
+
+  it('clamps to 100% when draw exceeds the limit', () => {
+    const scale = computePowerScale(500, 400, 500)
+    expect(scale.percent).toBe(100)
+  })
+
+  it('falls back to a nice-rounded peak when the limit is null', () => {
+    const scale = computePowerScale(4, null, 4)
+    expect(scale.source).toBe('peak')
+    expect(scale.effectiveMax).toBe(5) // niceCeiling(4)
+    expect(scale.percent).toBeCloseTo(80)
+  })
+
+  it('treats a zero limit as absent and uses the peak', () => {
+    const scale = computePowerScale(4, 0, 4)
+    expect(scale.source).toBe('peak')
+    expect(scale.effectiveMax).toBe(5)
+  })
+
+  it('returns 0% with no max when neither limit nor peak is usable', () => {
+    const scale = computePowerScale(4, null, null)
+    expect(scale.percent).toBe(0)
+    expect(scale.effectiveMax).toBeNull()
+    expect(scale.source).toBeNull()
+  })
+
+  it('returns 0% when the current reading is null', () => {
+    const scale = computePowerScale(null, null, 50)
+    expect(scale.percent).toBe(0)
+  })
+})

--- a/frontend/src/components/GpuCard.tsx
+++ b/frontend/src/components/GpuCard.tsx
@@ -3,6 +3,7 @@ import { MetricRow } from './MetricRow'
 import { ArcGauge } from './gauges/ArcGauge'
 import { TimeSeriesChart } from './charts/TimeSeriesChart'
 import { formatPercent, formatPower, formatMhz } from '../lib/format'
+import { computePowerScale, powerPeak } from '../lib/gpuPower'
 import { THRESHOLDS } from '../lib/theme'
 import type { GpuMetrics } from '../types/metrics'
 import type { GpuEvent, InferenceRequest } from '../types/events'
@@ -28,9 +29,13 @@ interface GpuCardProps {
 export function GpuCard({ metrics, chartData, events, requests, showCharts = false }: GpuCardProps) {
   if (!metrics) return <MetricCard title="GPU"><p className="text-zinc-500">Waiting for data...</p></MetricCard>
 
-  const powerPercent = (metrics.power_watts !== null && metrics.power_limit_watts !== null && metrics.power_limit_watts > 0)
-    ? (metrics.power_watts / metrics.power_limit_watts) * 100
-    : 0
+  // No hardware power cap is exposed on the GB10 (unified-memory SoC), so scale
+  // the gauge against the observed peak draw when the limit is absent.
+  const powerPercent = computePowerScale(
+    metrics.power_watts,
+    metrics.power_limit_watts,
+    powerPeak(chartData?.power ?? [], metrics.power_watts),
+  ).percent
 
   // Map events for chart overlays
   const thermalEvents = events?.filter(e => e.event_type === 'thermal').map(e => ({

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -6,6 +6,7 @@ import { EngineSection } from '@/components/engines/EngineSection'
 import { useElementSize } from '@/hooks/useElementSize'
 import { THRESHOLDS } from '@/lib/theme'
 import { formatBytes, formatGiB, formatMhz, formatRate } from '@/lib/format'
+import { computePowerScale, powerPeak } from '@/lib/gpuPower'
 import type { MetricsSnapshot } from '@/types/metrics'
 import type { GpuEvent, InferenceRequest } from '@/types/events'
 
@@ -62,9 +63,14 @@ export function Dashboard({
 }: DashboardProps) {
   if (!metrics) return null
 
-  const powerPercent = (metrics.gpu.power_watts !== null && metrics.gpu.power_limit_watts !== null && metrics.gpu.power_limit_watts > 0)
-    ? (metrics.gpu.power_watts / metrics.gpu.power_limit_watts) * 100
-    : 0
+  // No hardware power cap is exposed on the GB10 (unified-memory SoC), so scale
+  // the gauge against the observed peak draw when the limit is absent.
+  const powerHistory = history.getChartData('gpuPower')
+  const powerPercent = computePowerScale(
+    metrics.gpu.power_watts,
+    metrics.gpu.power_limit_watts,
+    powerPeak(powerHistory, metrics.gpu.power_watts),
+  ).percent
 
   const memUsedPercent = metrics.memory.total_bytes > 0
     ? (metrics.memory.used_bytes / metrics.memory.total_bytes) * 100

--- a/frontend/src/lib/gpuPower.ts
+++ b/frontend/src/lib/gpuPower.ts
@@ -1,0 +1,87 @@
+/**
+ * GPU power gauge scaling.
+ *
+ * The gauge fill is a 0–100 percentage of power draw against a denominator.
+ * Ideally that denominator is the hardware power limit, but unified-memory SoCs
+ * like the DGX Spark GB10 report no power cap via NVML (`power_limit_watts` is
+ * null). In that case we fall back to an adaptive max derived from the observed
+ * peak draw, rounded up to a human-readable step so the gauge moves and only
+ * rescales in discrete jumps instead of pegging at full whenever the current
+ * reading is itself the peak.
+ */
+
+export interface PowerScale {
+  /** 0–100 for the gauge arc / horizontal bar. */
+  percent: number
+  /** Denominator actually used, in watts. Null when nothing usable is known. */
+  effectiveMax: number | null
+  /** Where `effectiveMax` came from. */
+  source: 'limit' | 'peak' | null
+}
+
+/**
+ * Round a value up to a "nice" 1–2–5×10ⁿ grid so an adaptive gauge max stays
+ * human-readable and only steps between recognizable bands
+ * (4→5, 5→5, 5.1→10, 130→200). Returns null for non-positive / non-finite input.
+ */
+export function niceCeiling(value: number): number | null {
+  if (!Number.isFinite(value) || value <= 0) return null
+
+  const magnitude = Math.pow(10, Math.floor(Math.log10(value)))
+  const fraction = value / magnitude // in [1, 10)
+
+  let niceFraction: number
+  if (fraction <= 1) niceFraction = 1
+  else if (fraction <= 2) niceFraction = 2
+  else if (fraction <= 5) niceFraction = 5
+  else niceFraction = 10
+
+  return niceFraction * magnitude
+}
+
+/**
+ * Highest power reading across the history window and the current sample.
+ * Returns null when there is nothing usable (empty history and null current).
+ */
+export function powerPeak(
+  history: ReadonlyArray<{ value: number }>,
+  current: number | null,
+): number | null {
+  let peak = -Infinity
+  if (current !== null && Number.isFinite(current)) peak = current
+  for (const point of history) {
+    if (Number.isFinite(point.value) && point.value > peak) peak = point.value
+  }
+  return peak > -Infinity ? peak : null
+}
+
+/**
+ * Compute the gauge scale: prefer the real hardware limit when present,
+ * otherwise fall back to a nice-rounded observed peak.
+ */
+export function computePowerScale(
+  current: number | null,
+  limit: number | null,
+  peak: number | null,
+): PowerScale {
+  let effectiveMax: number | null = null
+  let source: PowerScale['source'] = null
+
+  if (limit !== null && limit > 0) {
+    effectiveMax = limit
+    source = 'limit'
+  } else {
+    const ceiling = peak !== null ? niceCeiling(peak) : null
+    if (ceiling !== null && ceiling > 0) {
+      effectiveMax = ceiling
+      source = 'peak'
+    }
+  }
+
+  const percent =
+    current !== null && Number.isFinite(current) && effectiveMax !== null && effectiveMax > 0
+      ? Math.min(Math.max((current / effectiveMax) * 100, 0), 100)
+      : 0
+
+  return { percent, effectiveMax, source }
+}

--- a/src/metrics/gpu.rs
+++ b/src/metrics/gpu.rs
@@ -27,6 +27,23 @@ pub fn nvml_optional<T>(result: Result<T, NvmlError>) -> Option<T> {
     }
 }
 
+/// Resolve the GPU power limit (in milliwatts) by trying NVML sources in order
+/// of preference, returning the first supported, non-zero value.
+///
+/// On unified-memory SoCs like the DGX Spark GB10, `power_management_limit()`
+/// returns `NotSupported` (nvidia-smi shows `Pwr:Usage/Cap` as `"4W / N/A"`), so
+/// we fall through to the enforced/default/constraint limits. Some discrete GPUs
+/// or future firmware expose a cap through one of these even when the primary
+/// query is unsupported. Returns `None` when no source reports a usable limit.
+#[cfg(target_os = "linux")]
+fn resolve_power_limit_mw(device: &nvml_wrapper::Device) -> Option<u32> {
+    nvml_optional(device.power_management_limit())
+        .or_else(|| nvml_optional(device.enforced_power_limit()))
+        .or_else(|| nvml_optional(device.power_management_limit_default()))
+        .or_else(|| nvml_optional(device.power_management_limit_constraints()).map(|c| c.max_limit))
+        .filter(|&mw| mw > 0)
+}
+
 /// Collect GPU metrics from an NVML device.
 /// Returns all-None GpuMetrics when no device is available.
 #[cfg(target_os = "linux")]
@@ -55,8 +72,7 @@ pub fn collect_gpu_metrics(device: &Option<nvml_wrapper::Device>) -> GpuMetrics 
 
     // NVML returns milliwatts, convert to watts as f64
     let power_watts = nvml_optional(device.power_usage()).map(|mw| mw as f64 / 1000.0);
-    let power_limit_watts =
-        nvml_optional(device.power_management_limit()).map(|mw| mw as f64 / 1000.0);
+    let power_limit_watts = resolve_power_limit_mw(device).map(|mw| mw as f64 / 1000.0);
 
     // Each clock query wrapped individually -- memory clock may be N/A on some GPUs
     let clock_graphics_mhz =


### PR DESCRIPTION
## Summary

The GPU **Power** gauge never moved even though the power number updated. The fill was computed as `power_watts / power_limit_watts`, hard-falling to `0` when the limit was `null`. On the **DGX Spark GB10** (unified-memory SoC) NVML exposes no power cap — `nvidia-smi` shows `Pwr:Usage/Cap` as `"4W / N/A"` — so `power_limit_watts` is genuinely `null` and the arc was pinned at empty.

## Changes

- **`fix(metrics)`** — `resolve_power_limit_mw()` tries NVML sources in order: `power_management_limit()` → `enforced_power_limit()` → `power_management_limit_default()` → `power_management_limit_constraints().max_limit`, taking the first supported non-zero value. Recovers a real cap on hardware/firmware that exposes one. `GpuMetrics` shape unchanged.
- **`fix(frontend)`** — new pure helper `lib/gpuPower.ts`:
  - `computePowerScale()` uses the real limit when present, else an **adaptive observed peak** from the power history buffer.
  - `niceCeiling()` rounds the peak up to a 1‑2‑5×10ⁿ grid so the scale is readable and steps cleanly instead of pegging at 100% when the current reading *is* the peak.
  - Wired into `Dashboard` (compact `HBar` + full `ArcGauge`) and `GpuCard`; gauge components and `formatPower` unchanged.

## Metrics contract

`GpuMetrics` struct/serde and `MetricsSnapshot` wire shape are unchanged, so `types/metrics.ts` and `format.ts` need no edits. The applicable contract item — display logic — is covered by new Vitest specs.

## Test plan

- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked` (104 pass)
- [x] `cd frontend && npm run build && npm test -- --run` (151 pass, incl. 12 new `gpuPower` specs)
- [x] End-to-end on the DGX Spark (`deploy.sh`): confirm the GPU Power gauge tracks draw with the hardware limit absent (cannot be exercised locally — the non-Linux dev stub returns `power_watts: null`)

> Note: stacked on `feat/spec-decode-metrics` because the Dashboard change depends on that branch's compact-layout code. Retarget to `main` once spec-decode merges.