### PR TITLE
feat: surface vLLM speculative-decoding metrics + responsive hardware cards

### DIFF
--- a/frontend/src/__tests__/EngineCardSpecDecode.test.tsx
+++ b/frontend/src/__tests__/EngineCardSpecDecode.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EngineCard } from '../components/engines/EngineCard'
+import type { EngineMetrics, EngineSnapshot } from '../types/metrics'
+
+/** Minimal but complete EngineMetrics, spec-decode fields null by default. */
+function metrics(overrides: Partial<EngineMetrics> = {}): EngineMetrics {
+  return {
+    tokens_per_sec: 100,
+    avg_tokens_per_sec: 80,
+    per_request_tps: 50,
+    ttft_ms: 120,
+    active_requests: 1,
+    queued_requests: 0,
+    kv_cache_percent: 40,
+    kv_cache_is_estimated: false,
+    total_requests: 10,
+    e2e_latency_ms: 500,
+    prompt_tokens_per_sec: 200,
+    avg_prompt_tokens_per_sec: 180,
+    per_request_prompt_tps: 70,
+    swapped_requests: 0,
+    prefix_cache_hit_rate: 30,
+    queue_time_ms: 50,
+    inter_token_latency_ms: 25,
+    preemptions_total: 0,
+    total_prompt_tokens: 1000,
+    total_generation_tokens: 2000,
+    prefix_cache_queries_total: 5000,
+    avg_batch_size: 4,
+    ttft_percentiles: null,
+    itl_percentiles: null,
+    e2e_percentiles: null,
+    ttft_goodput_pct: null,
+    itl_goodput_pct: null,
+    e2e_goodput_pct: null,
+    ttft_buckets: null,
+    itl_buckets: null,
+    e2e_buckets: null,
+    tpot_ms: 28,
+    tpot_percentiles: null,
+    tpot_goodput_pct: null,
+    tpot_buckets: null,
+    spec_decode_draft_tokens_total: null,
+    spec_decode_accepted_tokens_total: null,
+    spec_decode_drafts_total: null,
+    spec_decode_acceptance_rate: null,
+    spec_decode_acceptance_rate_live: null,
+    spec_decode_mean_acceptance_length: null,
+    ...overrides,
+  }
+}
+
+function snapshot(m: EngineMetrics | null): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint: 'http://localhost:8000',
+    status: { type: 'Running' },
+    model: {
+      name: 'test/model',
+      parameter_size: null,
+      quantization: null,
+      precision: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: m,
+    recent_requests: [],
+    deployment_mode: 'Docker',
+  }
+}
+
+describe('EngineCard speculative-decoding section', () => {
+  it('always renders the renamed cache card header', () => {
+    render(<EngineCard engine={snapshot(metrics())} />)
+    expect(screen.getByText('Cache & Speculative Decoding')).toBeTruthy()
+  })
+
+  it('hides the spec-decode section when the model has no spec-decode metrics', () => {
+    render(<EngineCard engine={snapshot(metrics())} />)
+    expect(screen.queryByText('Speculative Decoding')).toBeNull()
+    expect(screen.queryByText('Accept Len')).toBeNull()
+  })
+
+  it('renders TAR, acceptance length, and accepted/draft counters when enabled', () => {
+    render(
+      <EngineCard
+        engine={snapshot(
+          metrics({
+            spec_decode_draft_tokens_total: 100_000,
+            spec_decode_accepted_tokens_total: 72_000,
+            spec_decode_drafts_total: 24_000,
+            spec_decode_acceptance_rate: 72,
+            spec_decode_acceptance_rate_live: 68,
+            spec_decode_mean_acceptance_length: 3,
+          }),
+        )}
+      />,
+    )
+    expect(screen.getByText('Speculative Decoding')).toBeTruthy()
+    expect(screen.getByText('Acceptance · TAR')).toBeTruthy()
+    expect(screen.getByText('72')).toBeTruthy()
+    expect(screen.getByText('live 68%')).toBeTruthy()
+    expect(screen.getByText('Accept Len')).toBeTruthy()
+    expect(screen.getByText('Accepted')).toBeTruthy()
+    expect(screen.getByText('Draft')).toBeTruthy()
+  })
+})

--- a/frontend/src/__tests__/EngineCardSpecDecode.test.tsx
+++ b/frontend/src/__tests__/EngineCardSpecDecode.test.tsx
@@ -99,9 +99,8 @@ describe('EngineCard speculative-decoding section', () => {
       />,
     )
     expect(screen.getByText('Speculative Decoding')).toBeTruthy()
-    expect(screen.getByText('Acceptance · TAR')).toBeTruthy()
     expect(screen.getByText('72')).toBeTruthy()
-    expect(screen.getByText('live 68%')).toBeTruthy()
+    expect(screen.getByText(/68% live/)).toBeTruthy()
     expect(screen.getByText('Accept Len')).toBeTruthy()
     expect(screen.getByText('Accepted')).toBeTruthy()
     expect(screen.getByText('Draft')).toBeTruthy()

--- a/frontend/src/__tests__/HBar.test.tsx
+++ b/frontend/src/__tests__/HBar.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HBar } from '../components/gauges/HBar'
+import type { GaugeSegment } from '../components/gauges/ArcGauge'
+
+describe('HBar', () => {
+  it('renders a single value with label and unit', () => {
+    render(<HBar value={42} label="GPU Util" unit="%" />)
+    expect(screen.getByText('GPU Util')).toBeTruthy()
+    expect(screen.getByText('42')).toBeTruthy()
+    expect(screen.getByText('%')).toBeTruthy()
+  })
+
+  it('fills the bar proportionally to value/max', () => {
+    render(<HBar value={30} max={120} label="X" unit="W" />)
+    const fill = screen.getByTestId('hbar-fill') as HTMLElement
+    // 30/120 = 25%
+    expect(fill.style.width).toBe('25%')
+  })
+
+  it('clamps the fill width to [0, 100]%', () => {
+    render(<HBar value={500} max={100} label="X" unit="%" />)
+    expect((screen.getByTestId('hbar-fill') as HTMLElement).style.width).toBe('100%')
+  })
+
+  it('prefers displayValue over value for the readout', () => {
+    render(<HBar value={75} displayValue={150} label="GPU Power" unit="W" />)
+    expect(screen.getByText('150')).toBeTruthy()
+  })
+
+  it('renders stacked segments with a legend and no single-value fill', () => {
+    // Mirrors how the Memory card calls it: an explicit `value` (used %) plus
+    // segments for the stacked breakdown.
+    const segments: GaugeSegment[] = [
+      { value: 25, total: 100, color: '#76B900', label: 'GPU: 25' },
+      { value: 25, total: 100, color: '#3B82F6', label: 'CPU: 25' },
+      { value: 50, total: 100, color: '#27272A', label: 'Free: 50' },
+    ]
+    render(<HBar value={50} label="" unit="%" segments={segments} />)
+    // No single-value fill is rendered in segment mode.
+    expect(screen.queryByTestId('hbar-fill')).toBeNull()
+    // Legend labels present.
+    expect(screen.getByText('GPU: 25')).toBeTruthy()
+    expect(screen.getByText('Free: 50')).toBeTruthy()
+    // Readout uses the explicit value (used %), matching ArcGauge precedence.
+    expect(screen.getByText('50')).toBeTruthy()
+  })
+})

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatBytes, formatGiB, formatCompactTokens } from '../lib/format'
+import { formatBytes, formatGiB, formatCompactTokens, formatAcceptanceLength } from '../lib/format'
 
 const GIB = 1_073_741_824
 const MIB = 1_048_576
@@ -51,5 +51,20 @@ describe('formatCompactTokens', () => {
     expect(formatCompactTokens(1_000_000)).toBe('1M')
     expect(formatCompactTokens(1_250_000_000)).toBe('1.3B')
     expect(formatCompactTokens(3.4e12)).toBe('3.4T')
+  })
+})
+
+describe('formatAcceptanceLength', () => {
+  it('renders -- for null, negative, or non-finite', () => {
+    expect(formatAcceptanceLength(null)).toBe('--')
+    expect(formatAcceptanceLength(-1)).toBe('--')
+    expect(formatAcceptanceLength(Number.NaN)).toBe('--')
+    expect(formatAcceptanceLength(Number.POSITIVE_INFINITY)).toBe('--')
+  })
+
+  it('formats accepted-tokens-per-draft to two decimals', () => {
+    expect(formatAcceptanceLength(3)).toBe('3.00')
+    expect(formatAcceptanceLength(3.4167)).toBe('3.42')
+    expect(formatAcceptanceLength(0)).toBe('0.00')
   })
 })

--- a/frontend/src/components/engines/EngineCard.tsx
+++ b/frontend/src/components/engines/EngineCard.tsx
@@ -10,6 +10,7 @@ import {
   KvBar,
   TrendArrow,
   GoodputTile,
+  SpecDecodeSection,
   computeTrend,
   fmtVal,
   fmtInt,
@@ -134,6 +135,17 @@ export function EngineCard({
   const prefixCacheHit = v('prefix_cache_hit_rate')
   const prefixCacheQueries = v('prefix_cache_queries_total')
   const preemptions = v('preemptions_total')
+  // Speculative decoding — present only when the served model has it enabled.
+  const specDraftTokens = v('spec_decode_draft_tokens_total')
+  const specAcceptedTokens = v('spec_decode_accepted_tokens_total')
+  const specAcceptanceRate = v('spec_decode_acceptance_rate')
+  const specAcceptanceRateLive = v('spec_decode_acceptance_rate_live')
+  const specMeanAcceptanceLength = v('spec_decode_mean_acceptance_length')
+  // Show the section only once the engine has actually drafted tokens. The
+  // counter is present (non-null) whenever spec decoding is configured, but it
+  // sits at 0 on a freshly-started idle engine — gating on >0 keeps the card
+  // from showing an all-dashes section until the metrics carry real values.
+  const hasSpecDecode = specDraftTokens !== null && specDraftTokens > 0
   const engineKey = `${engine.engine_type}-${engine.endpoint}`
   const modelName = engine.model?.name ?? null
   const { thresholds: slo, setThresholds: setSlo, reset: resetSlo, isCustomized: sloCustomized } =
@@ -289,9 +301,9 @@ export function EngineCard({
               </div>
             </div>
 
-            {/* Cache */}
+            {/* Cache & Speculative Decoding */}
             <div className="bg-white/[0.02] rounded-md px-3 py-2.5 2xl:px-4 2xl:py-3 min-w-0">
-              <div className="text-[11px] 2xl:text-xs min-[1920px]:text-sm font-semibold text-zinc-300 tracking-tight mb-1.5 truncate">Cache</div>
+              <div className="text-[11px] 2xl:text-xs min-[1920px]:text-sm font-semibold text-zinc-300 tracking-tight mb-1.5 truncate">Cache &amp; Speculative Decoding</div>
               <div className="grid grid-cols-2 gap-1.5">
                 <div className="flex flex-col gap-0.5 min-w-0">
                   <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider truncate">KV Cache</span>
@@ -316,6 +328,15 @@ export function EngineCard({
                   className="text-lg xl:text-xl 2xl:text-2xl min-[1920px]:text-3xl min-[2560px]:text-4xl font-bold text-zinc-100 font-mono tabular-nums leading-none"
                 />
               </div>
+              {hasSpecDecode && (
+                <SpecDecodeSection
+                  acceptanceRate={specAcceptanceRate}
+                  acceptanceRateLive={specAcceptanceRateLive}
+                  meanAcceptanceLength={specMeanAcceptanceLength}
+                  acceptedTokens={specAcceptedTokens}
+                  draftTokens={specDraftTokens}
+                />
+              )}
             </div>
           </div>
 

--- a/frontend/src/components/engines/EngineCard.tsx
+++ b/frontend/src/components/engines/EngineCard.tsx
@@ -230,7 +230,7 @@ export function EngineCard({
       ) : (
         <>
           {/* ── Grouped metrics with trend arrows — 6 categories ── */}
-          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-2 py-1">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 py-1">
             {/* Prefill Throughput */}
             <div className="bg-white/[0.02] rounded-md px-3 py-2.5 2xl:px-4 2xl:py-3 min-w-0">
               <div className="text-[11px] 2xl:text-xs min-[1920px]:text-sm font-semibold text-zinc-300 tracking-tight mb-1.5 truncate">Prompt Processing / Prefill Throughput</div>
@@ -345,7 +345,7 @@ export function EngineCard({
            *   1 Prefill · 2 Decode · 3 Latency · 4 SLO Goodput · 5 Requests · 6 Cache
            * E2E sits under SLO Goodput (col 4); Requests under col 5; KV under Cache (col 6). */}
           {showCharts && chartData && (
-            <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3 pt-1">
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 pt-1">
               <TimeSeriesChart
                 title="Prefill Throughput (tok/s)"
                 hideTooltipLabel

--- a/frontend/src/components/engines/EngineCardPrimitives.tsx
+++ b/frontend/src/components/engines/EngineCardPrimitives.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { LatencyPercentiles } from '@/types/metrics'
-import { formatCompactTokens } from '@/lib/format'
+import { formatCompactTokens, formatAcceptanceLength } from '@/lib/format'
 import { AnimatedCounter } from './AnimatedCounter'
 
 export interface ChartDataPoint {
@@ -164,6 +164,104 @@ export function KvBar({ percent }: KvBarProps) {
 
 export function fmtVal(v: number | null, fmt: (n: number) => string): string {
   return v === null ? '--' : fmt(v)
+}
+
+interface SpecDecodeSectionProps {
+  /** Lifetime token acceptance rate (TAR), 0-100. */
+  acceptanceRate: number | null
+  /** Live (windowed) TAR, 0-100. Shown as a secondary line when present. */
+  acceptanceRateLive: number | null
+  /** Mean accepted tokens per draft attempt. */
+  meanAcceptanceLength: number | null
+  /** Cumulative accepted tokens (counts up). */
+  acceptedTokens: number | null
+  /** Cumulative drafted tokens (counts up). */
+  draftTokens: number | null
+}
+
+/**
+ * Speculative-decoding sub-section of the Cache card. Rendered only when the
+ * served model has speculative decoding enabled (the caller gates on metric
+ * presence). Surfaces the token acceptance rate (lifetime + live), mean
+ * acceptance length, and the cumulative accepted/draft token counters that
+ * animate upward. Higher acceptance is better, so TAR is colored green (≥70%),
+ * yellow (≥40%), else red.
+ */
+export function SpecDecodeSection({
+  acceptanceRate,
+  acceptanceRateLive,
+  meanAcceptanceLength,
+  acceptedTokens,
+  draftTokens,
+}: SpecDecodeSectionProps) {
+  const tarColor =
+    acceptanceRate === null
+      ? 'text-zinc-100'
+      : acceptanceRate >= 70
+        ? 'text-[#76B900]'
+        : acceptanceRate >= 40
+          ? 'text-yellow-400'
+          : 'text-red-400'
+  return (
+    <div className="flex flex-col gap-0.5 mt-2 pt-2 border-t border-white/[0.04] min-w-0">
+      <span className="text-[10px] 2xl:text-xs min-[1920px]:text-sm font-medium text-zinc-400 uppercase tracking-wider truncate">
+        Speculative Decoding
+      </span>
+      <div className="grid grid-cols-2 gap-1.5 mt-0.5">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider truncate">
+            Acceptance · TAR
+          </span>
+          <div className="flex items-baseline">
+            <span
+              className={`text-lg xl:text-xl 2xl:text-2xl min-[1920px]:text-3xl min-[2560px]:text-4xl font-bold font-mono tabular-nums leading-none ${tarColor}`}
+            >
+              {acceptanceRate === null ? '--' : Math.round(acceptanceRate)}
+            </span>
+            <span className="text-xs text-zinc-500 ml-1">%</span>
+          </div>
+          {acceptanceRateLive !== null && (
+            <span className="text-[9px] text-zinc-500 font-mono tabular-nums tracking-tight truncate">
+              live {Math.round(acceptanceRateLive)}%
+            </span>
+          )}
+        </div>
+        <MetricTile
+          label="Accept Len"
+          value={fmtVal(meanAcceptanceLength, formatAcceptanceLength)}
+          unit="tok/draft"
+        />
+      </div>
+      <div className="flex items-start justify-between gap-2 mt-2 min-w-0">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-[10px] 2xl:text-xs min-[1920px]:text-sm font-medium uppercase tracking-wider truncate text-zinc-400">
+            Accepted
+          </span>
+          <div className="flex items-baseline min-w-0">
+            <AnimatedCounter
+              value={acceptedTokens}
+              format={formatCompactTokens}
+              className="text-base xl:text-lg 2xl:text-xl min-[1920px]:text-2xl min-[2560px]:text-3xl font-bold font-mono tabular-nums leading-none text-zinc-100 truncate"
+            />
+            <span className="text-[10px] 2xl:text-xs ml-1 text-zinc-500">tok</span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-0.5 min-w-0 items-end text-right">
+          <span className="text-[10px] 2xl:text-xs min-[1920px]:text-sm font-medium uppercase tracking-wider truncate text-zinc-400">
+            Draft
+          </span>
+          <div className="flex items-baseline min-w-0">
+            <AnimatedCounter
+              value={draftTokens}
+              format={formatCompactTokens}
+              className="text-base xl:text-lg 2xl:text-xl min-[1920px]:text-2xl min-[2560px]:text-3xl font-bold font-mono tabular-nums leading-none text-zinc-100 truncate"
+            />
+            <span className="text-[10px] 2xl:text-xs ml-1 text-zinc-500">tok</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export function fmtInt(v: number | null): string {

--- a/frontend/src/components/engines/EngineCardPrimitives.tsx
+++ b/frontend/src/components/engines/EngineCardPrimitives.tsx
@@ -210,7 +210,12 @@ export function SpecDecodeSection({
       <div className="grid grid-cols-2 gap-1.5 mt-0.5">
         <div className="flex flex-col gap-0.5 min-w-0">
           <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider truncate">
-            Acceptance · TAR
+            TAR
+            {acceptanceRateLive !== null && (
+              <span className="ml-1 normal-case tracking-normal text-zinc-600">
+                {Math.round(acceptanceRateLive)}% live
+              </span>
+            )}
           </span>
           <div className="flex items-baseline">
             <span
@@ -220,11 +225,6 @@ export function SpecDecodeSection({
             </span>
             <span className="text-xs text-zinc-500 ml-1">%</span>
           </div>
-          {acceptanceRateLive !== null && (
-            <span className="text-[9px] text-zinc-500 font-mono tabular-nums tracking-tight truncate">
-              live {Math.round(acceptanceRateLive)}%
-            </span>
-          )}
         </div>
         <MetricTile
           label="Accept Len"
@@ -232,31 +232,34 @@ export function SpecDecodeSection({
           unit="tok/draft"
         />
       </div>
-      <div className="flex items-start justify-between gap-2 mt-2 min-w-0">
+      {/* Cumulative accepted/draft tokens. Each value gets its own line (label
+          above) so the abbreviated counters never clip on narrow cards, while
+          smaller fonts than the headline numbers keep the section compact. */}
+      <div className="grid grid-cols-2 gap-1.5 mt-1.5 min-w-0">
         <div className="flex flex-col gap-0.5 min-w-0">
-          <span className="text-[10px] 2xl:text-xs min-[1920px]:text-sm font-medium uppercase tracking-wider truncate text-zinc-400">
+          <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider truncate">
             Accepted
           </span>
           <div className="flex items-baseline min-w-0">
             <AnimatedCounter
               value={acceptedTokens}
               format={formatCompactTokens}
-              className="text-base xl:text-lg 2xl:text-xl min-[1920px]:text-2xl min-[2560px]:text-3xl font-bold font-mono tabular-nums leading-none text-zinc-100 truncate"
+              className="text-sm xl:text-base 2xl:text-lg min-[1920px]:text-xl font-bold font-mono tabular-nums leading-none text-zinc-100 truncate"
             />
-            <span className="text-[10px] 2xl:text-xs ml-1 text-zinc-500">tok</span>
+            <span className="text-[10px] ml-1 text-zinc-500">tok</span>
           </div>
         </div>
-        <div className="flex flex-col gap-0.5 min-w-0 items-end text-right">
-          <span className="text-[10px] 2xl:text-xs min-[1920px]:text-sm font-medium uppercase tracking-wider truncate text-zinc-400">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider truncate">
             Draft
           </span>
           <div className="flex items-baseline min-w-0">
             <AnimatedCounter
               value={draftTokens}
               format={formatCompactTokens}
-              className="text-base xl:text-lg 2xl:text-xl min-[1920px]:text-2xl min-[2560px]:text-3xl font-bold font-mono tabular-nums leading-none text-zinc-100 truncate"
+              className="text-sm xl:text-base 2xl:text-lg min-[1920px]:text-xl font-bold font-mono tabular-nums leading-none text-zinc-100 truncate"
             />
-            <span className="text-[10px] 2xl:text-xs ml-1 text-zinc-500">tok</span>
+            <span className="text-[10px] ml-1 text-zinc-500">tok</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/engines/GlobalEngineCard.tsx
+++ b/frontend/src/components/engines/GlobalEngineCard.tsx
@@ -1,6 +1,6 @@
 import { formatTps, formatTtft, formatDurationMs, formatCompactTokens } from '@/lib/format'
 import type { AggregateSnapshot } from '@/lib/engineAggregate'
-import { MetricTile, LiveWithTotal, KvBar, GoodputTile, fmtVal, fmtInt } from './EngineCardPrimitives'
+import { MetricTile, LiveWithTotal, KvBar, GoodputTile, SpecDecodeSection, fmtVal, fmtInt } from './EngineCardPrimitives'
 import { AnimatedCounter } from './AnimatedCounter'
 import { type LatencyMode, latencyModeLabel, pickLatencyValue } from './LatencyModeControl'
 import { SLO, combinedGoodput } from '@/lib/slo'
@@ -49,6 +49,11 @@ export function GlobalEngineCard({ snapshot, latencyMode = 'avg' }: GlobalEngine
     kv_cache_percent,
     prefix_cache_hit_rate,
     prefix_cache_queries_total,
+    spec_decode_draft_tokens_total,
+    spec_decode_accepted_tokens_total,
+    spec_decode_acceptance_rate,
+    spec_decode_acceptance_rate_live,
+    spec_decode_mean_acceptance_length,
     ttft_percentiles,
     itl_percentiles,
     e2e_percentiles,
@@ -157,10 +162,10 @@ export function GlobalEngineCard({ snapshot, latencyMode = 'avg' }: GlobalEngine
           </div>
         </div>
 
-        {/* Cache */}
+        {/* Cache & Speculative Decoding */}
         <div className="bg-white/[0.02] rounded-md px-3 py-2.5 2xl:px-4 2xl:py-3 min-w-0">
           <div className="text-[11px] 2xl:text-xs min-[1920px]:text-sm font-semibold text-zinc-300 tracking-tight mb-1.5 truncate">
-            Cache
+            Cache &amp; Speculative Decoding
             <span className="ml-1 text-[9px] font-normal text-zinc-500">(avg)</span>
           </div>
           <div className="grid grid-cols-2 gap-1.5">
@@ -190,6 +195,15 @@ export function GlobalEngineCard({ snapshot, latencyMode = 'avg' }: GlobalEngine
               className="text-lg xl:text-xl 2xl:text-2xl min-[1920px]:text-3xl min-[2560px]:text-4xl font-bold text-zinc-100 font-mono tabular-nums leading-none"
             />
           </div>
+          {spec_decode_draft_tokens_total !== null && spec_decode_draft_tokens_total > 0 && (
+            <SpecDecodeSection
+              acceptanceRate={spec_decode_acceptance_rate}
+              acceptanceRateLive={spec_decode_acceptance_rate_live}
+              meanAcceptanceLength={spec_decode_mean_acceptance_length}
+              acceptedTokens={spec_decode_accepted_tokens_total}
+              draftTokens={spec_decode_draft_tokens_total}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/engines/GlobalEngineCard.tsx
+++ b/frontend/src/components/engines/GlobalEngineCard.tsx
@@ -87,7 +87,7 @@ export function GlobalEngineCard({ snapshot, latencyMode = 'avg' }: GlobalEngine
       <RunningCountCard count={running_count} />
 
       {/* ── Grouped aggregate metrics — matches EngineCard layout ── */}
-      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-2 py-1">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 py-1">
         {/* Prefill Throughput */}
         <div className="bg-white/[0.02] rounded-md px-3 py-2.5 2xl:px-4 2xl:py-3 min-w-0">
           <div className="text-[11px] 2xl:text-xs min-[1920px]:text-sm font-semibold text-zinc-300 tracking-tight mb-1.5 truncate">

--- a/frontend/src/components/gauges/HBar.tsx
+++ b/frontend/src/components/gauges/HBar.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { NVIDIA_THEME, thresholdColor } from '@/lib/theme'
+import type { GaugeSegment } from './ArcGauge'
+
+interface HBarProps {
+  value?: number
+  max?: number
+  label: string
+  unit: string
+  thresholds?: { warning: number; critical: number }
+  /** Override the displayed number (e.g. show watts instead of percentage). */
+  displayValue?: number
+  /** When provided, renders a stacked multi-segment bar with a legend. */
+  segments?: GaugeSegment[]
+}
+
+/**
+ * Compact horizontal-bar alternative to {@link ArcGauge}, used by the hardware
+ * cards when vertical space is too tight for a square gauge. Accepts the same
+ * data shape (single value+threshold, or stacked segments) so a card can swap
+ * between the two without reshaping its props.
+ */
+export const HBar = React.memo(function HBar({
+  value,
+  max = 100,
+  label,
+  unit,
+  thresholds,
+  displayValue,
+  segments,
+}: HBarProps) {
+  const segs = segments?.filter((s) => s.value > 0 && s.total > 0) ?? []
+
+  const centerValue = (() => {
+    if (displayValue !== undefined) return Math.round(displayValue)
+    if (value !== undefined) return Math.round(value)
+    if (segs.length > 0) {
+      const total = segs[0].total
+      if (total === 0) return 0
+      const used = segs.filter((s) => s.label !== 'Free').reduce((sum, s) => sum + s.value, 0)
+      return Math.round((used / total) * 100)
+    }
+    return 0
+  })()
+
+  return (
+    <div className="flex flex-col gap-0.5 lg:gap-1 w-full min-w-0">
+      <div className="flex items-baseline gap-2 min-w-0">
+        {label && (
+          <span className="text-[9px] lg:text-[10px] text-zinc-400 uppercase tracking-wider truncate min-w-0">
+            {label}
+          </span>
+        )}
+        <span className="ml-auto shrink-0 font-mono font-bold tabular-nums text-xs lg:text-sm 2xl:text-base text-zinc-100 leading-none">
+          {centerValue}
+          <span className="ml-0.5 text-[9px] lg:text-[10px] text-zinc-500">{unit}</span>
+        </span>
+      </div>
+      <div className="flex h-1.5 lg:h-2 w-full rounded-full overflow-hidden bg-zinc-700/40">
+        {segs.length > 0 ? (
+          segs.map((seg, i) => (
+            <div
+              key={i}
+              className="h-full transition-all duration-500"
+              style={{ width: `${Math.min(100, (seg.value / seg.total) * 100)}%`, backgroundColor: seg.color }}
+            />
+          ))
+        ) : (
+          (() => {
+            const v = value ?? 0
+            const percent = Math.min(Math.max(v / max, 0), 1) * 100
+            const color = thresholds
+              ? thresholdColor(v, thresholds.warning, thresholds.critical)
+              : NVIDIA_THEME.accent
+            return (
+              <div
+                className="h-full transition-all duration-500"
+                style={{ width: `${percent}%`, backgroundColor: color }}
+                data-testid="hbar-fill"
+              />
+            )
+          })()
+        )}
+      </div>
+      {segs.length > 0 && (
+        <div className="flex flex-wrap gap-x-1.5 gap-y-0.5">
+          {segs.map((seg, i) => (
+            <div key={i} className="flex items-center gap-0.5 min-w-0">
+              <span className="inline-block w-1 h-1 rounded-full shrink-0" style={{ backgroundColor: seg.color }} />
+              <span className="text-[8px] lg:text-[9px] text-zinc-300 truncate">{seg.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+})

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -1,7 +1,9 @@
 import { ArcGauge, type GaugeSegment } from '@/components/gauges/ArcGauge'
+import { HBar } from '@/components/gauges/HBar'
 import { CoreHeatmap } from '@/components/charts/CoreHeatmap'
 import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
 import { EngineSection } from '@/components/engines/EngineSection'
+import { useElementSize } from '@/hooks/useElementSize'
 import { THRESHOLDS } from '@/lib/theme'
 import { formatBytes, formatGiB, formatMhz, formatRate } from '@/lib/format'
 import type { MetricsSnapshot } from '@/types/metrics'
@@ -37,6 +39,20 @@ function HwCard({ title, subtitle, children }: { title?: string; subtitle?: stri
  *  cramped screens (13" laptops); upper bounds let big monitors breathe. */
 const HW_CHART_HEIGHT = 'clamp(28px, 7vh, 140px)'
 const HW_GAUGE_PX = 'clamp(36px, 5vw, 96px)'
+
+/** Number of hardware cards in the grid (used to estimate per-card height). */
+const HW_CARD_COUNT = 8
+/** Below this per-card height (px) the cards drop their line charts and swap
+ *  square gauges for compact horizontal bars, so the dashboard stays a
+ *  one-pager when vertical space is tight. */
+const HW_COMPACT_HEIGHT_PX = 124
+/** Below this dashboard-content height (px) the engine section drops its
+ *  per-metric trend charts. The engine block is content-sized (shrink-0), so on
+ *  short viewports its charts would otherwise crowd the hardware grid off-screen
+ *  — hiding them frees the room the hardware cards need to stay visible. Keyed
+ *  off the (viewport-driven, content-independent) root height so it cannot
+ *  feedback-loop with the hardware per-card measurement below. */
+const ENGINE_CHARTS_MIN_HEIGHT_PX = 640
 
 export function Dashboard({
   metrics,
@@ -100,13 +116,30 @@ export function Dashboard({
   const NET_RX_COLOR = '#3B82F6'
   const NET_TX_COLOR = '#A855F7'
 
+  // Measure the hardware grid to adapt to available *vertical* space. The grid
+  // uses auto-rows-fr, so per-card height depends only on the container height
+  // and the column count (2 below the `sm` breakpoint, 4 at/above it) — not on
+  // card content, which keeps this free of layout feedback loops. `compact`
+  // stays false until measured (height 0) so the full layout renders first.
+  const [hwGridRef, hwGridSize] = useElementSize<HTMLDivElement>()
+  const hwCols = hwGridSize.width >= 640 ? 4 : 2
+  const hwRows = Math.ceil(HW_CARD_COUNT / hwCols)
+  const perCardHeight =
+    hwGridSize.height > 0 ? (hwGridSize.height - (hwRows - 1) * 6) / hwRows : 0
+  const compact = perCardHeight > 0 && perCardHeight < HW_COMPACT_HEIGHT_PX
+
+  // Engine trend charts collapse on short viewports (see constant). Default to
+  // showing them until the root is measured (height 0).
+  const [rootRef, rootSize] = useElementSize<HTMLDivElement>()
+  const showEngineCharts = rootSize.height === 0 || rootSize.height >= ENGINE_CHARTS_MIN_HEIGHT_PX
+
   return (
-    <div className="flex flex-col flex-1 min-h-0 gap-2">
+    <div ref={rootRef} className="flex flex-col flex-1 min-h-0 gap-2">
       {/* ── LLM Engines — auto-height, fits content; hardware fills remainder ── */}
       <div className="shrink-0 min-h-0">
         <EngineSection
           engines={metrics.engines}
-          showCharts={true}
+          showCharts={showEngineCharts}
           getChartData={history.getChartData}
           requests={requests}
         />
@@ -114,127 +147,186 @@ export function Dashboard({
 
       {/* ── Hardware Overview — fills the rest of the viewport ── */}
       <div className="flex-1 min-h-0 bg-[#0a0a0d]/80 rounded-xl border border-white/[0.03] p-1 lg:p-1.5 2xl:p-2 flex flex-col">
-        <div className="flex-1 min-h-0 grid grid-cols-2 sm:grid-cols-4 gap-1 lg:gap-1.5 auto-rows-fr">
+        <div ref={hwGridRef} className="flex-1 min-h-0 grid grid-cols-2 sm:grid-cols-4 gap-1 lg:gap-1.5 auto-rows-fr">
 
           {/* GPU Utilization */}
           <HwCard title="GPU Utilization" subtitle={metrics.gpu.name ?? undefined}>
-            <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-              <ArcGauge value={metrics.gpu.utilization_percent ?? 0} label="GPU Util" unit="%" size={HW_GAUGE_PX} />
-              <div className="flex-1 min-w-0">
-                <TimeSeriesChart data={history.getChartData('gpuUtil')} yDomain={[0, 100]} unit="%" events={allEvents} requests={requestSpans} height={HW_CHART_HEIGHT} />
+            {compact ? (
+              <HBar value={metrics.gpu.utilization_percent ?? 0} label="GPU Util" unit="%" />
+            ) : (
+              <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
+                <ArcGauge value={metrics.gpu.utilization_percent ?? 0} label="GPU Util" unit="%" size={HW_GAUGE_PX} />
+                <div className="flex-1 min-w-0">
+                  <TimeSeriesChart data={history.getChartData('gpuUtil')} yDomain={[0, 100]} unit="%" events={allEvents} requests={requestSpans} height={HW_CHART_HEIGHT} />
+                </div>
               </div>
-            </div>
+            )}
           </HwCard>
 
           {/* GPU Temperature */}
           <HwCard title="GPU Temp" subtitle={metrics.gpu.name ?? undefined}>
-            <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-              <ArcGauge value={metrics.gpu.temperature_celsius ?? 0} label="GPU Temp" unit="°C" thresholds={THRESHOLDS.gpuTemp} size={HW_GAUGE_PX} />
-              <div className="flex-1 min-w-0">
-                <TimeSeriesChart data={history.getChartData('gpuTemp')} yDomain={[0, 100]} unit="°C" height={HW_CHART_HEIGHT} />
+            {compact ? (
+              <HBar value={metrics.gpu.temperature_celsius ?? 0} label="GPU Temp" unit="°C" thresholds={THRESHOLDS.gpuTemp} />
+            ) : (
+              <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
+                <ArcGauge value={metrics.gpu.temperature_celsius ?? 0} label="GPU Temp" unit="°C" thresholds={THRESHOLDS.gpuTemp} size={HW_GAUGE_PX} />
+                <div className="flex-1 min-w-0">
+                  <TimeSeriesChart data={history.getChartData('gpuTemp')} yDomain={[0, 100]} unit="°C" height={HW_CHART_HEIGHT} />
+                </div>
               </div>
-            </div>
+            )}
           </HwCard>
 
           {/* GPU Power */}
           <HwCard title="GPU Power" subtitle={metrics.gpu.name ?? undefined}>
-            <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-              <ArcGauge
+            {compact ? (
+              <HBar
                 value={powerPercent}
                 label="GPU Power"
                 unit="W"
                 thresholds={THRESHOLDS.gpuPower}
                 displayValue={metrics.gpu.power_watts !== null ? Math.round(metrics.gpu.power_watts) : 0}
-                size={HW_GAUGE_PX}
               />
-              <div className="flex-1 min-w-0">
-                <TimeSeriesChart data={history.getChartData('gpuPower')} unit="W" height={HW_CHART_HEIGHT} />
+            ) : (
+              <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
+                <ArcGauge
+                  value={powerPercent}
+                  label="GPU Power"
+                  unit="W"
+                  thresholds={THRESHOLDS.gpuPower}
+                  displayValue={metrics.gpu.power_watts !== null ? Math.round(metrics.gpu.power_watts) : 0}
+                  size={HW_GAUGE_PX}
+                />
+                <div className="flex-1 min-w-0">
+                  <TimeSeriesChart data={history.getChartData('gpuPower')} unit="W" height={HW_CHART_HEIGHT} />
+                </div>
               </div>
-            </div>
+            )}
           </HwCard>
 
           {/* GPU Clock */}
           <HwCard title="GPU Clock" subtitle={metrics.gpu.name ?? undefined}>
-            <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-              <div className="flex flex-col items-center justify-center shrink-0" style={{ width: HW_GAUGE_PX, height: HW_GAUGE_PX }}>
-                <span className="text-sm 2xl:text-base min-[1920px]:text-lg font-bold text-zinc-100 font-mono">{formatMhz(metrics.gpu.clock_graphics_mhz)}</span>
+            {compact ? (
+              <div className="flex items-baseline justify-between gap-2 min-w-0">
+                <span className="text-[9px] lg:text-[10px] text-zinc-400 uppercase tracking-wider truncate">Graphics</span>
+                <span className="ml-auto shrink-0 text-xs lg:text-sm 2xl:text-base font-bold text-zinc-100 font-mono tabular-nums">{formatMhz(metrics.gpu.clock_graphics_mhz)}</span>
               </div>
-              <div className="flex-1 min-w-0">
-                <TimeSeriesChart data={history.getChartData('gpuClockGraphics')} unit="MHz" height={HW_CHART_HEIGHT} />
+            ) : (
+              <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
+                <div className="flex flex-col items-center justify-center shrink-0" style={{ width: HW_GAUGE_PX, height: HW_GAUGE_PX }}>
+                  <span className="text-sm 2xl:text-base min-[1920px]:text-lg font-bold text-zinc-100 font-mono">{formatMhz(metrics.gpu.clock_graphics_mhz)}</span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <TimeSeriesChart data={history.getChartData('gpuClockGraphics')} unit="MHz" height={HW_CHART_HEIGHT} />
+                </div>
               </div>
-            </div>
+            )}
           </HwCard>
 
           {/* CPU */}
           <HwCard title="CPU" subtitle={metrics.cpu.name ?? undefined}>
-            <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-              <ArcGauge value={metrics.cpu.aggregate_percent} label="CPU" unit="%" thresholds={THRESHOLDS.cpuUsage} size={HW_GAUGE_PX} />
-              <div className="flex-1 min-w-0">
-                <TimeSeriesChart data={history.getChartData('cpuAggregate')} yDomain={[0, 100]} unit="%" height={HW_CHART_HEIGHT} />
+            {compact ? (
+              <HBar value={metrics.cpu.aggregate_percent} label="CPU" unit="%" thresholds={THRESHOLDS.cpuUsage} />
+            ) : (
+              <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
+                <ArcGauge value={metrics.cpu.aggregate_percent} label="CPU" unit="%" thresholds={THRESHOLDS.cpuUsage} size={HW_GAUGE_PX} />
+                <div className="flex-1 min-w-0">
+                  <TimeSeriesChart data={history.getChartData('cpuAggregate')} yDomain={[0, 100]} unit="%" height={HW_CHART_HEIGHT} />
+                </div>
               </div>
-            </div>
-            {metrics.cpu.per_core.length > 0 && <CoreHeatmap cores={metrics.cpu.per_core} />}
+            )}
+            {!compact && metrics.cpu.per_core.length > 0 && <CoreHeatmap cores={metrics.cpu.per_core} />}
           </HwCard>
 
           {/* Memory */}
           <HwCard title="Memory" subtitle={`${totalGB} Unified`}>
-            <div className="flex items-center justify-center min-h-0 flex-1 overflow-hidden">
-              <ArcGauge value={memUsedPercent} label="" unit="%" segments={memorySegments} size={HW_GAUGE_PX} />
-            </div>
+            {compact ? (
+              <HBar value={memUsedPercent} label="" unit="%" segments={memorySegments} />
+            ) : (
+              <div className="flex items-center justify-center min-h-0 flex-1 overflow-hidden">
+                <ArcGauge value={memUsedPercent} label="" unit="%" segments={memorySegments} size={HW_GAUGE_PX} />
+              </div>
+            )}
           </HwCard>
 
           {/* Disk I/O */}
           <HwCard title="Disk I/O" subtitle={metrics.disk.name ?? undefined}>
-            <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-              <div className="flex flex-col items-center justify-center gap-0.5 shrink-0" style={{ width: HW_GAUGE_PX, height: HW_GAUGE_PX }}>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">R</span>
-                  <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.disk.read_bytes_per_sec)}</span>
+            {compact ? (
+              <div className="flex items-baseline justify-between gap-2 min-w-0 font-mono">
+                <span className="flex items-baseline gap-1 min-w-0">
+                  <span className="text-[9px] lg:text-[10px] text-zinc-500">R</span>
+                  <span className="text-xs lg:text-sm font-bold text-zinc-100 tabular-nums truncate">{formatRate(metrics.disk.read_bytes_per_sec)}</span>
+                </span>
+                <span className="flex items-baseline gap-1 min-w-0">
+                  <span className="text-[9px] lg:text-[10px] text-zinc-500">W</span>
+                  <span className="text-xs lg:text-sm font-bold text-zinc-100 tabular-nums truncate">{formatRate(metrics.disk.write_bytes_per_sec)}</span>
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
+                <div className="flex flex-col items-center justify-center gap-0.5 shrink-0" style={{ width: HW_GAUGE_PX, height: HW_GAUGE_PX }}>
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">R</span>
+                    <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.disk.read_bytes_per_sec)}</span>
+                  </div>
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">W</span>
+                    <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.disk.write_bytes_per_sec)}</span>
+                  </div>
                 </div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">W</span>
-                  <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.disk.write_bytes_per_sec)}</span>
+                <div className="flex-1 min-w-0">
+                  <TimeSeriesChart
+                    series={[
+                      { data: diskTotal, label: 'Total', color: TOTAL_COLOR },
+                      { data: diskRead, label: 'Read', color: DISK_READ_COLOR },
+                      { data: diskWrite, label: 'Write', color: DISK_WRITE_COLOR },
+                    ]}
+                    unit="B/s"
+                    height={HW_CHART_HEIGHT}
+                  />
                 </div>
               </div>
-              <div className="flex-1 min-w-0">
-                <TimeSeriesChart
-                  series={[
-                    { data: diskTotal, label: 'Total', color: TOTAL_COLOR },
-                    { data: diskRead, label: 'Read', color: DISK_READ_COLOR },
-                    { data: diskWrite, label: 'Write', color: DISK_WRITE_COLOR },
-                  ]}
-                  unit="B/s"
-                  height={HW_CHART_HEIGHT}
-                />
-              </div>
-            </div>
+            )}
           </HwCard>
 
           {/* Network I/O */}
           <HwCard title="Network" subtitle={metrics.network.name ?? undefined}>
-            <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-              <div className="flex flex-col items-center justify-center gap-0.5 shrink-0" style={{ width: HW_GAUGE_PX, height: HW_GAUGE_PX }}>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">RX</span>
-                  <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.network.rx_bytes_per_sec)}</span>
+            {compact ? (
+              <div className="flex items-baseline justify-between gap-2 min-w-0 font-mono">
+                <span className="flex items-baseline gap-1 min-w-0">
+                  <span className="text-[9px] lg:text-[10px] text-zinc-500">RX</span>
+                  <span className="text-xs lg:text-sm font-bold text-zinc-100 tabular-nums truncate">{formatRate(metrics.network.rx_bytes_per_sec)}</span>
+                </span>
+                <span className="flex items-baseline gap-1 min-w-0">
+                  <span className="text-[9px] lg:text-[10px] text-zinc-500">TX</span>
+                  <span className="text-xs lg:text-sm font-bold text-zinc-100 tabular-nums truncate">{formatRate(metrics.network.tx_bytes_per_sec)}</span>
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
+                <div className="flex flex-col items-center justify-center gap-0.5 shrink-0" style={{ width: HW_GAUGE_PX, height: HW_GAUGE_PX }}>
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">RX</span>
+                    <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.network.rx_bytes_per_sec)}</span>
+                  </div>
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">TX</span>
+                    <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.network.tx_bytes_per_sec)}</span>
+                  </div>
                 </div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-[9px] 2xl:text-[10px] min-[1920px]:text-xs text-zinc-500">TX</span>
-                  <span className="text-xs 2xl:text-sm min-[1920px]:text-base font-bold text-zinc-100 font-mono">{formatRate(metrics.network.tx_bytes_per_sec)}</span>
+                <div className="flex-1 min-w-0">
+                  <TimeSeriesChart
+                    series={[
+                      { data: networkTotal, label: 'Total', color: TOTAL_COLOR },
+                      { data: networkRx, label: 'RX', color: NET_RX_COLOR },
+                      { data: networkTx, label: 'TX', color: NET_TX_COLOR },
+                    ]}
+                    unit="B/s"
+                    height={HW_CHART_HEIGHT}
+                  />
                 </div>
               </div>
-              <div className="flex-1 min-w-0">
-                <TimeSeriesChart
-                  series={[
-                    { data: networkTotal, label: 'Total', color: TOTAL_COLOR },
-                    { data: networkRx, label: 'RX', color: NET_RX_COLOR },
-                    { data: networkTx, label: 'TX', color: NET_TX_COLOR },
-                  ]}
-                  unit="B/s"
-                  height={HW_CHART_HEIGHT}
-                />
-              </div>
-            </div>
+            )}
           </HwCard>
 
         </div>

--- a/frontend/src/hooks/useElementSize.ts
+++ b/frontend/src/hooks/useElementSize.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface ElementSize {
+  width: number
+  height: number
+}
+
+/**
+ * Observe an element's content-box size via ResizeObserver. Returns a ref to
+ * attach and the latest `{ width, height }` (both 0 until first measured, and
+ * when ResizeObserver is unavailable — e.g. jsdom — so callers should treat 0
+ * as "unknown" and fall back to their richest layout).
+ */
+export function useElementSize<T extends HTMLElement>(): [React.RefObject<T | null>, ElementSize] {
+  const ref = useRef<T | null>(null)
+  const [size, setSize] = useState<ElementSize>({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const { width, height } = entry.contentRect
+      setSize((prev) => (prev.width === width && prev.height === height ? prev : { width, height }))
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return [ref, size]
+}

--- a/frontend/src/lib/engineAggregate.test.ts
+++ b/frontend/src/lib/engineAggregate.test.ts
@@ -39,6 +39,12 @@ function fullMetrics(overrides: Partial<EngineMetrics> = {}): EngineMetrics {
     tpot_percentiles: null,
     tpot_goodput_pct: null,
     tpot_buckets: null,
+    spec_decode_draft_tokens_total: null,
+    spec_decode_accepted_tokens_total: null,
+    spec_decode_drafts_total: null,
+    spec_decode_acceptance_rate: null,
+    spec_decode_acceptance_rate_live: null,
+    spec_decode_mean_acceptance_length: null,
     ...overrides,
   }
 }
@@ -120,6 +126,73 @@ describe('aggregateEngines', () => {
     ]
     const snap = aggregateEngines(engines)
     expect(snap.prefix_cache_queries_total).toBeNull()
+  })
+
+  it('sums spec-decode counters and recomputes TAR/mean-length from the sums', () => {
+    // Deliberately UNEQUAL draft volumes so the sum-weighted TAR cannot be
+    // confused with a naive per-engine average:
+    //   Engine A: 720 accepted / 800 draft / 200 draft-attempts (TAR 90%)
+    //   Engine B:  20 accepted / 200 draft / 100 draft-attempts (TAR 10%)
+    //   sum-derived TAR = 740/1000 = 74%   (naive mean of 90,10 would be 50%)
+    //   mean acceptance length = 740/300 = 2.4667
+    const engines = [
+      engine(
+        'Running',
+        fullMetrics({
+          spec_decode_accepted_tokens_total: 720,
+          spec_decode_draft_tokens_total: 800,
+          spec_decode_drafts_total: 200,
+          spec_decode_acceptance_rate: 90,
+        }),
+      ),
+      engine(
+        'Running',
+        fullMetrics({
+          spec_decode_accepted_tokens_total: 20,
+          spec_decode_draft_tokens_total: 200,
+          spec_decode_drafts_total: 100,
+          spec_decode_acceptance_rate: 10,
+        }),
+      ),
+    ]
+    const snap = aggregateEngines(engines)
+    expect(snap.spec_decode_accepted_tokens_total).toBe(740)
+    expect(snap.spec_decode_draft_tokens_total).toBe(1_000)
+    expect(snap.spec_decode_drafts_total).toBe(300)
+    // 74, NOT the naive average of 90 and 10 (= 50).
+    expect(snap.spec_decode_acceptance_rate).toBeCloseTo(74, 5)
+    expect(snap.spec_decode_mean_acceptance_length).toBeCloseTo(740 / 300, 5)
+  })
+
+  it('blends live TAR weighted by each engine draft-token volume', () => {
+    // Engine A: live 80%, 800 draft tokens; Engine B: live 20%, 200 draft.
+    // Weighted mean = (80*800 + 20*200) / 1000 = 68.
+    const engines = [
+      engine(
+        'Running',
+        fullMetrics({
+          spec_decode_acceptance_rate_live: 80,
+          spec_decode_draft_tokens_total: 800,
+        }),
+      ),
+      engine(
+        'Running',
+        fullMetrics({
+          spec_decode_acceptance_rate_live: 20,
+          spec_decode_draft_tokens_total: 200,
+        }),
+      ),
+    ]
+    const snap = aggregateEngines(engines)
+    expect(snap.spec_decode_acceptance_rate_live).toBeCloseTo(68, 5)
+  })
+
+  it('leaves spec-decode fields null when no running engine reports them', () => {
+    const snap = aggregateEngines([engine('Running', fullMetrics())])
+    expect(snap.spec_decode_draft_tokens_total).toBeNull()
+    expect(snap.spec_decode_acceptance_rate).toBeNull()
+    expect(snap.spec_decode_acceptance_rate_live).toBeNull()
+    expect(snap.spec_decode_mean_acceptance_length).toBeNull()
   })
 
   it('weighted mean for latencies uses total_requests as the weight', () => {

--- a/frontend/src/lib/engineAggregate.ts
+++ b/frontend/src/lib/engineAggregate.ts
@@ -28,6 +28,16 @@ export interface AggregateSnapshot {
   total_generation_tokens: number | null
   prefix_cache_queries_total: number | null
 
+  // Speculative decoding. Cumulative counters are summed; TAR and mean
+  // acceptance length are recomputed from the aggregated sums (not averaged
+  // per-engine) so they stay correctly volume-weighted across engines.
+  spec_decode_draft_tokens_total: number | null
+  spec_decode_accepted_tokens_total: number | null
+  spec_decode_drafts_total: number | null
+  spec_decode_acceptance_rate: number | null
+  spec_decode_acceptance_rate_live: number | null
+  spec_decode_mean_acceptance_length: number | null
+
   // Weighted mean by total_requests (simple mean fallback)
   ttft_ms: number | null
   e2e_latency_ms: number | null
@@ -118,6 +128,12 @@ function emptySnapshot(totalCount: number): AggregateSnapshot {
     total_prompt_tokens: null,
     total_generation_tokens: null,
     prefix_cache_queries_total: null,
+    spec_decode_draft_tokens_total: null,
+    spec_decode_accepted_tokens_total: null,
+    spec_decode_drafts_total: null,
+    spec_decode_acceptance_rate: null,
+    spec_decode_acceptance_rate_live: null,
+    spec_decode_mean_acceptance_length: null,
     ttft_ms: null,
     e2e_latency_ms: null,
     queue_time_ms: null,
@@ -242,6 +258,15 @@ export function aggregateEngines(engines: readonly EngineSnapshot[]): AggregateS
       get(key).map((value, i) => ({ value, weight: weights[i] })),
     )
 
+  // Speculative decoding: sum the cumulative counters, then recompute TAR and
+  // mean acceptance length from the aggregated sums so they are volume-weighted
+  // across engines rather than naively averaged. ratio() guards divide-by-zero.
+  const specDraftTokens = sumOrNull(get('spec_decode_draft_tokens_total'))
+  const specAcceptedTokens = sumOrNull(get('spec_decode_accepted_tokens_total'))
+  const specDrafts = sumOrNull(get('spec_decode_drafts_total'))
+  const ratio = (num: number | null, den: number | null, scale = 1): number | null =>
+    num !== null && den !== null && den > 0 ? (num / den) * scale : null
+
   return {
     running_count: running.length,
     total_count: engines.length,
@@ -259,6 +284,26 @@ export function aggregateEngines(engines: readonly EngineSnapshot[]): AggregateS
     total_prompt_tokens: sumOrNull(get('total_prompt_tokens')),
     total_generation_tokens: sumOrNull(get('total_generation_tokens')),
     prefix_cache_queries_total: sumOrNull(get('prefix_cache_queries_total')),
+
+    // Speculative decoding — additive counters + sum-derived ratios.
+    spec_decode_draft_tokens_total: specDraftTokens,
+    spec_decode_accepted_tokens_total: specAcceptedTokens,
+    spec_decode_drafts_total: specDrafts,
+    spec_decode_acceptance_rate: ratio(specAcceptedTokens, specDraftTokens, 100),
+    // Live TAR is a per-poll rolling value with no underlying delta exposed
+    // here to re-sum, so we weight each engine's live TAR by its lifetime
+    // draft-token volume. This is an approximation: vLLM exposes no windowed
+    // draft count, so a long-running high-traffic engine biases the blend even
+    // if its current draft rate matches a newer engine. Engines without
+    // spec-decode contribute {value: null, weight: null} and are dropped by
+    // weightedMeanOrNull, so a mixed fleet blends only the spec-decode engines.
+    spec_decode_acceptance_rate_live: weightedMeanOrNull(
+      get('spec_decode_acceptance_rate_live').map((value, i) => ({
+        value,
+        weight: get('spec_decode_draft_tokens_total')[i],
+      })),
+    ),
+    spec_decode_mean_acceptance_length: ratio(specAcceptedTokens, specDrafts),
 
     // Weighted mean
     ttft_ms: weightedBy('ttft_ms'),

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -128,6 +128,13 @@ export function formatCompactTokens(n: number | null): string {
   return `${text}${unit.suffix}`
 }
 
+/** Format mean acceptance length (accepted tokens per draft attempt): two
+ *  decimals, e.g. "3.42". Null/non-finite/negative -> '--'. */
+export function formatAcceptanceLength(n: number | null): string {
+  if (n === null || !Number.isFinite(n) || n < 0) return '--'
+  return n.toFixed(2)
+}
+
 /** Map EngineType enum to human-readable display name. */
 export function engineDisplayName(engineType: EngineType): string {
   const names: Record<EngineType, string> = {

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -167,6 +167,23 @@ export interface EngineMetrics {
   tpot_goodput_pct: number | null
   /** Raw TPOT histogram buckets (cumulative). */
   tpot_buckets: HistogramBucket[] | null
+
+  // --- Speculative decoding ---
+  // Populated only when the served model has speculative decoding configured
+  // (vLLM emits `vllm:spec_decode_*` only then). When all are null the UI hides
+  // the speculative-decoding section entirely.
+  /** Cumulative speculatively-generated (draft) tokens. Counts up over the engine's life. */
+  spec_decode_draft_tokens_total: number | null
+  /** Cumulative draft tokens that passed verification. Counts up. */
+  spec_decode_accepted_tokens_total: number | null
+  /** Cumulative number of speculative-decode draft attempts. */
+  spec_decode_drafts_total: number | null
+  /** Lifetime token acceptance rate (TAR), percentage: accepted/draft*100. */
+  spec_decode_acceptance_rate: number | null
+  /** Live (windowed) TAR from per-poll deltas, percentage. Fluctuates with recent traffic. */
+  spec_decode_acceptance_rate_live: number | null
+  /** Mean accepted tokens per draft attempt: accepted/drafts. */
+  spec_decode_mean_acceptance_length: number | null
 }
 
 export interface EngineSnapshot {

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -162,6 +162,25 @@ pub struct EngineMetrics {
     pub tpot_goodput_pct: Option<f64>,
     /// Raw TPOT histogram buckets (cumulative).
     pub tpot_buckets: Option<Vec<HistogramBucket>>,
+    // --- Speculative decoding ---
+    // These are populated only when the served model has speculative decoding
+    // configured (vLLM emits `vllm:spec_decode_*` only in that case). When the
+    // metrics are absent all six fields are `None`, which the frontend uses to
+    // hide the speculative-decoding section entirely.
+    /// Cumulative speculatively-generated (draft) tokens. Raw lifetime counter,
+    /// not warmup-adjusted, so it counts up continuously across the engine's life.
+    pub spec_decode_draft_tokens_total: Option<u64>,
+    /// Cumulative draft tokens that passed verification. Raw lifetime counter.
+    pub spec_decode_accepted_tokens_total: Option<u64>,
+    /// Cumulative number of speculative-decode draft attempts. Raw lifetime counter.
+    pub spec_decode_drafts_total: Option<u64>,
+    /// Lifetime token acceptance rate (TAR) as a percentage: accepted/draft*100.
+    pub spec_decode_acceptance_rate: Option<f64>,
+    /// Live (windowed) TAR from per-poll deltas: Δaccepted/Δdraft*100. Fluctuates
+    /// with recent traffic; `None` during warmup and on the first reading.
+    pub spec_decode_acceptance_rate_live: Option<f64>,
+    /// Mean accepted tokens per draft attempt: accepted/drafts (acceptance length).
+    pub spec_decode_mean_acceptance_length: Option<f64>,
     /// True while the engine is still in warmup — histogram-derived fields
     /// (averages, percentiles, goodput, rates) are intentionally `None` so the
     /// first slow inference does not pollute steady-state metrics. See

--- a/src/engines/vllm.rs
+++ b/src/engines/vllm.rs
@@ -83,6 +83,10 @@ pub struct VllmAdapter {
     prev_gen_tokens: Mutex<Option<(f64, Instant)>>,
     /// Previous prompt_tokens_total counter reading for rate computation.
     prev_prompt_tokens: Mutex<Option<(f64, Instant)>>,
+    /// Previous (accepted, draft) spec-decode counter readings, used to compute
+    /// the live (windowed) token acceptance rate from per-poll deltas. No
+    /// timestamp is stored because the live TAR is a unit-free ratio of deltas.
+    prev_spec_decode: Mutex<Option<(f64, f64)>>,
     /// Running average for generation: (sum_of_tps_readings, count_of_readings)
     avg_accum: Mutex<(f64, u64)>,
     /// Running average for prompt: (sum_of_tps_readings, count_of_readings)
@@ -115,6 +119,7 @@ impl VllmAdapter {
             served_model,
             prev_gen_tokens: Mutex::new(None),
             prev_prompt_tokens: Mutex::new(None),
+            prev_spec_decode: Mutex::new(None),
             avg_accum: Mutex::new((0.0, 0)),
             avg_prompt_accum: Mutex::new((0.0, 0)),
             warmup: Mutex::new(WarmupTracker::new(warmup_skip_from_env())),
@@ -432,6 +437,7 @@ impl EngineAdapter for VllmAdapter {
         if warmup_out.just_transitioned {
             *self.prev_gen_tokens.lock().await = None;
             *self.prev_prompt_tokens.lock().await = None;
+            *self.prev_spec_decode.lock().await = None;
             *self.avg_accum.lock().await = (0.0, 0);
             *self.avg_prompt_accum.lock().await = (0.0, 0);
             tracing::info!(
@@ -650,6 +656,61 @@ impl EngineAdapter for VllmAdapter {
             .get("vllm_num_preemptions_total")
             .map(|v| *v as u64);
 
+        // Speculative decoding. vLLM only emits these counters when the served
+        // model has speculative decoding configured, so their presence is the
+        // signal the frontend uses to show the section at all. The values are
+        // read from `raw` (absolute lifetime) so the cumulative token counters
+        // count up continuously and the lifetime acceptance ratios are stable.
+        // vLLM's prometheus_client appends `_total` to counter names, so try the
+        // `_total` key first and fall back to the bare logical name.
+        let spec_counter = |name: &str| -> Option<f64> {
+            raw.counters
+                .get(&format!("vllm_spec_decode_{name}_total"))
+                .or_else(|| raw.counters.get(&format!("vllm_spec_decode_{name}")))
+                .copied()
+        };
+        let spec_draft = spec_counter("num_draft_tokens");
+        let spec_accepted = spec_counter("num_accepted_tokens");
+        let spec_drafts = spec_counter("num_drafts");
+
+        // Prometheus counters are non-negative by spec; clamp before the lossy
+        // f64->u64 cast so a malformed/negative sample can never wrap to a huge
+        // value (same boundary as `preemptions_total` / `total_requests`).
+        let spec_decode_draft_tokens_total = spec_draft.map(|v| v.max(0.0) as u64);
+        let spec_decode_accepted_tokens_total = spec_accepted.map(|v| v.max(0.0) as u64);
+        let spec_decode_drafts_total = spec_drafts.map(|v| v.max(0.0) as u64);
+
+        // Lifetime token acceptance rate (TAR) = accepted / draft * 100.
+        let spec_decode_acceptance_rate = spec_acceptance_rate(spec_accepted, spec_draft);
+        // Mean acceptance length = accepted tokens / draft attempts.
+        let spec_decode_mean_acceptance_length =
+            spec_mean_acceptance_length(spec_accepted, spec_drafts);
+        // Live (windowed) TAR from per-poll deltas: Δaccepted / Δdraft * 100.
+        // The snapshot is discarded (`prev = None`) whenever a counter is
+        // missing this poll or appears to have gone backwards (engine restart
+        // resets its counters). Both cases would otherwise diff against a stale
+        // snapshot and silently inflate or negate the live rate.
+        let spec_decode_acceptance_rate_live = {
+            let mut prev_lock = self.prev_spec_decode.lock().await;
+            match (spec_accepted, spec_draft) {
+                (Some(acc), Some(draft)) => {
+                    let live = prev_lock.as_ref().and_then(|&(prev_acc, prev_draft)| {
+                        if acc >= prev_acc && draft >= prev_draft {
+                            spec_acceptance_rate(Some(acc - prev_acc), Some(draft - prev_draft))
+                        } else {
+                            None
+                        }
+                    });
+                    *prev_lock = Some((acc, draft));
+                    live
+                }
+                _ => {
+                    *prev_lock = None;
+                    None
+                }
+            }
+        };
+
         // Average batch size (tokens per iteration step)
         let avg_batch_size = {
             let sum = parsed.counters.get("vllm_iteration_tokens_total_sum");
@@ -825,8 +886,46 @@ impl EngineAdapter for VllmAdapter {
             tpot_percentiles: if blank { None } else { tpot_percentiles },
             tpot_goodput_pct: if blank { None } else { tpot_goodput_pct },
             tpot_buckets: if blank { None } else { tpot_buckets },
+            // Cumulative counters and lifetime ratios are pass-through (ungated
+            // by warmup) so they count up / stay stable continuously. Live TAR
+            // is a delta-derived rate, so it is blanked during warmup like the
+            // other per-poll rates.
+            spec_decode_draft_tokens_total,
+            spec_decode_accepted_tokens_total,
+            spec_decode_drafts_total,
+            spec_decode_acceptance_rate,
+            spec_decode_acceptance_rate_live: if blank {
+                None
+            } else {
+                spec_decode_acceptance_rate_live
+            },
+            spec_decode_mean_acceptance_length,
             warming_up,
         })
+    }
+}
+
+/// Token acceptance rate (TAR) as a percentage: `accepted / draft * 100`.
+///
+/// Returns `None` unless both counts are present, `draft > 0`, and `accepted`
+/// is non-negative, so the tile stays blank until at least one token has been
+/// drafted and never surfaces a negative rate from a malformed/reset counter.
+/// Used for both the lifetime TAR (absolute counters) and the live TAR
+/// (per-poll deltas).
+fn spec_acceptance_rate(accepted: Option<f64>, draft: Option<f64>) -> Option<f64> {
+    match (accepted, draft) {
+        (Some(a), Some(d)) if d > 0.0 && a >= 0.0 => Some((a / d) * 100.0),
+        _ => None,
+    }
+}
+
+/// Mean acceptance length: accepted tokens per draft attempt (`accepted / drafts`).
+///
+/// Returns `None` unless both counts are present and `drafts > 0`.
+fn spec_mean_acceptance_length(accepted: Option<f64>, drafts: Option<f64>) -> Option<f64> {
+    match (accepted, drafts) {
+        (Some(a), Some(n)) if n > 0.0 => Some(a / n),
+        _ => None,
     }
 }
 
@@ -1216,5 +1315,83 @@ vllm:prefix_cache_hits_total 123456.0
             .copied()
             .map(|v| v as u64);
         assert_eq!(queries, Some(654_321));
+    }
+
+    #[test]
+    fn spec_acceptance_rate_computes_percentage_and_guards_zero() {
+        assert_eq!(spec_acceptance_rate(Some(75.0), Some(100.0)), Some(75.0));
+        // Zero or missing draft tokens => blank, no divide-by-zero.
+        assert_eq!(spec_acceptance_rate(Some(10.0), Some(0.0)), None);
+        assert_eq!(spec_acceptance_rate(Some(10.0), None), None);
+        assert_eq!(spec_acceptance_rate(None, Some(10.0)), None);
+        // A negative numerator (e.g. a counter-reset delta) must not surface a
+        // negative rate.
+        assert_eq!(spec_acceptance_rate(Some(-5.0), Some(100.0)), None);
+    }
+
+    #[test]
+    fn spec_mean_acceptance_length_divides_accepted_by_drafts() {
+        assert_eq!(
+            spec_mean_acceptance_length(Some(300.0), Some(100.0)),
+            Some(3.0)
+        );
+        assert_eq!(spec_mean_acceptance_length(Some(5.0), Some(0.0)), None);
+        assert_eq!(spec_mean_acceptance_length(None, Some(2.0)), None);
+    }
+
+    /// vLLM's prometheus_client appends `_total` to the speculative-decoding
+    /// counters. Assert the parser captures them under the normalized
+    /// `vllm_spec_decode_*_total` keys the adapter reads.
+    #[test]
+    fn spec_decode_counters_roundtrip_from_metrics_body() {
+        let body = "\
+# HELP vllm:spec_decode_num_draft_tokens Cumulative drafted tokens.
+# TYPE vllm:spec_decode_num_draft_tokens counter
+vllm:spec_decode_num_draft_tokens_total 1000.0
+# HELP vllm:spec_decode_num_accepted_tokens Cumulative accepted tokens.
+# TYPE vllm:spec_decode_num_accepted_tokens counter
+vllm:spec_decode_num_accepted_tokens_total 720.0
+# HELP vllm:spec_decode_num_drafts Cumulative draft attempts.
+# TYPE vllm:spec_decode_num_drafts counter
+vllm:spec_decode_num_drafts_total 240.0
+";
+        let parsed = parse_prometheus_text(body).expect("parse");
+        let draft = parsed
+            .counters
+            .get("vllm_spec_decode_num_draft_tokens_total")
+            .copied();
+        let accepted = parsed
+            .counters
+            .get("vllm_spec_decode_num_accepted_tokens_total")
+            .copied();
+        let drafts = parsed
+            .counters
+            .get("vllm_spec_decode_num_drafts_total")
+            .copied();
+        assert_eq!(draft, Some(1000.0));
+        assert_eq!(accepted, Some(720.0));
+        assert_eq!(drafts, Some(240.0));
+        // Derived signals computed from the parsed counters.
+        assert_eq!(spec_acceptance_rate(accepted, draft), Some(72.0));
+        assert_eq!(spec_mean_acceptance_length(accepted, drafts), Some(3.0));
+    }
+
+    /// A metrics body without any speculative-decoding lines must leave every
+    /// spec-decode counter absent, so the adapter reports `None` and the
+    /// frontend hides the section.
+    #[test]
+    fn spec_decode_counters_absent_when_not_configured() {
+        let body = "\
+# HELP vllm:generation_tokens Generated tokens.
+# TYPE vllm:generation_tokens counter
+vllm:generation_tokens_total 42.0
+";
+        let parsed = parse_prometheus_text(body).expect("parse");
+        assert!(!parsed
+            .counters
+            .contains_key("vllm_spec_decode_num_draft_tokens_total"));
+        assert!(!parsed
+            .counters
+            .contains_key("vllm_spec_decode_num_draft_tokens"));
     }
 }


### PR DESCRIPTION
## Summary

Adds vLLM speculative-decoding metrics end-to-end (Rust parse → TS types → UI), and reworks the hardware cards so the dashboard stays a one-pager across viewport sizes.

## Changes

- **`feat(engines)`** — parse vLLM speculative-decoding metrics in `src/engines/vllm.rs` (+ `mod.rs`), with unit tests.
- **`feat(frontend)`** — surface the spec-decode metrics in the cache card; new TS types (`types/metrics.ts`), formatters (`lib/format.ts`), and aggregation (`lib/engineAggregate.ts`).
- **`style(frontend)`** — declutter the spec-decode card and tighten the responsive grid.
- **`feat(frontend)`** — adapt hardware cards to vertical space: new `HBar` gauge and `useElementSize` hook; cards swap square gauges for compact horizontal bars and drop line charts when vertical space is tight.

## Metrics contract

`EngineSnapshot` metrics gain spec-decode fields, propagated through Rust tests, `types/metrics.ts`, `lib/format.ts`, Vitest specs (`EngineCardSpecDecode`, `engineAggregate`, `format`, `HBar`), and the engine components.

## Test plan

- [x] `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked`
- [x] `cd frontend && npm run build && npm test -- --run`
- [x] End-to-end against a live vLLM engine on the DGX Spark (`deploy.sh`)

> Companion PR #35 (GPU power gauge fix) is stacked on this branch; merge this first, then retarget #35 to `main`.