### PR TITLE
feat(logs): container log streaming via bollard Docker API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "axum",
  "bollard",
  "clap",
+ "futures-util",
  "mime_guess",
  "nvml-wrapper",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ mime_guess = "2"
 reqwest = { version = "0.13", features = ["json"] }
 async-trait = "0.1"
 prometheus-parse = "0.2"
+futures-util = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nvml-wrapper = "0.12"

--- a/README.md
+++ b/README.md
@@ -256,6 +256,28 @@ engines too. Model info is resolved from `/v1/models` once and cached —
 re-resolved only on engine restart or every 10 minutes — so an auth-gated
 engine is no longer hit on every poll tick.
 
+### Log viewer (`--enable-log-viewer`, Linux only, opt-in)
+
+`--enable-log-viewer` (or the `SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1` env var)
+registers an extra `/ws/logs` WebSocket endpoint that streams the tracked
+engine container's Docker logs directly to the dashboard, using the bollard
+Docker API (no `docker` CLI or shell required — works in distroless images).
+
+- **Off by default.** Nothing is exposed unless the flag is passed.
+- **`/ws/logs` is unauthenticated.** The dashboard binds `0.0.0.0` by default
+  and the WebSocket has no auth layer, so anyone who can reach the port can
+  read the stream.
+- **Engine logs can contain sensitive data.** Inference-engine logs commonly
+  include prompts, request payloads, and API keys passed on the command line.
+  Treat the endpoint as equivalent to `docker logs` access.
+- **Recommendation: only enable on trusted networks.** Put the dashboard behind
+  a reverse proxy with auth, bind to `127.0.0.1`/`--bind 127.0.0.1`, or
+  restrict the port with a firewall. Do not enable on a public-facing host.
+
+The stream is shared: one background Docker log stream fans out to all
+connected clients (same pattern as metrics). stdout and stderr are line-buffered
+so split frames don't produce partial lines.
+
 ## Development
 
 ### Prerequisites

--- a/src/engines/detector.rs
+++ b/src/engines/detector.rs
@@ -19,6 +19,11 @@ pub struct DetectedEngine {
     /// for the container. Matched against NVML's per-device compute-process
     /// lists to attribute the engine to the GPU(s) it runs on.
     pub pids: Vec<u32>,
+    /// Docker container id (full) when discovered via the Docker scan layer;
+    /// `None` for natively-detected engines. Used by the log viewer to stream
+    /// the same container the dashboard is showing metrics for, rather than
+    /// re-scanning and potentially picking a different one.
+    pub container_id: Option<String>,
 }
 
 /// Known engine binaries and their default ports.
@@ -91,6 +96,10 @@ fn merge_docker_candidates(
                     }
                 }
                 existing.pids.sort_unstable();
+                // Docker discovery is authoritative for container identity.
+                if existing.container_id.is_none() && dc.container_id.is_some() {
+                    existing.container_id = dc.container_id.clone();
+                }
             }
         } else {
             seen.insert(key);
@@ -154,6 +163,7 @@ fn detect_by_process(sys: &sysinfo::System) -> Vec<DetectedEngine> {
                         deployment_mode: DeploymentMode::Native,
                         served_model,
                         pids: vec![pid],
+                        container_id: None,
                     });
                 }
             }
@@ -511,6 +521,7 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
                 deployment_mode: DeploymentMode::Docker,
                 served_model,
                 pids,
+                container_id: container.id.clone(),
             });
         } else {
             tracing::debug!(
@@ -715,6 +726,7 @@ mod tests {
             deployment_mode: mode,
             served_model: None,
             pids: pids.to_vec(),
+            container_id: None,
         }
     }
 

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -219,6 +219,12 @@ pub struct EngineSnapshot {
     /// part of the wire format.
     #[serde(skip_serializing)]
     pub pids: Vec<u32>,
+    /// Full Docker container id when the engine is running in a container
+    /// discovered via the Docker scan layer. Internal-only: not serialized to
+    /// the frontend (the dashboard has no use for it), but read by the log
+    /// viewer to stream the exact container the dashboard is showing.
+    #[serde(skip)]
+    pub container_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -266,6 +272,9 @@ pub struct EngineState {
     /// Host-namespace PIDs from the most recent detection tick. Empty for
     /// manual overrides until process/Docker detection also finds the engine.
     pub pids: Vec<u32>,
+    /// Docker container id captured at detection time (Linux Docker scan only).
+    /// Forwarded into each `EngineSnapshot` for the log viewer to consume.
+    pub container_id: Option<String>,
 }
 
 impl EngineState {
@@ -281,6 +290,7 @@ impl EngineState {
             model_fetched_at: None,
             model_attempted_at: None,
             pids: Vec::new(),
+            container_id: None,
         }
     }
 
@@ -523,7 +533,10 @@ pub async fn engine_collector_loop(
                             d.endpoint,
                             d.served_model,
                         );
-                        EngineState::new(adapter, d.deployment_mode.clone())
+                        let mut state =
+                            EngineState::new(adapter, d.deployment_mode.clone());
+                        state.container_id = d.container_id.clone();
+                        state
                     });
                     // Refresh the PID set every detection tick — engines
                     // restart and fork workers over their lifetime.
@@ -589,6 +602,7 @@ pub async fn engine_collector_loop(
                             deployment_mode: state.deployment_mode.clone(),
                             gpu_indexes: Vec::new(),
                             pids: state.pids.clone(),
+                            container_id: state.container_id.clone(),
                         });
                     }
                 }

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -1,0 +1,218 @@
+//! Docker container log streaming via the bollard API.
+//!
+//! Instead of shelling out to `docker logs -f` (which fails on distroless
+//! runtimes that have no shell or `docker` CLI), this module talks directly to
+//! the Docker daemon over its Unix socket via bollard.
+//!
+//! Stream characteristics:
+//! - stdout/stderr are multiplexed in real-time (not drained sequentially).
+//! - The WebSocket connects lazily -- the backend stream is only opened when a
+//!   client connects, not on page load.
+//! - Container discovery uses the Docker API directly rather than needing the
+//!   shared engine state wired into this handler.
+
+#![cfg(target_os = "linux")]
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use bollard::container::LogOutput;
+use bollard::query_parameters::{ListContainersOptionsBuilder, LogsOptionsBuilder};
+use bollard::Docker;
+use futures_util::StreamExt;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tracing::debug;
+
+/// Flag set at startup when `--enable-log-viewer` is passed.
+/// Read by `server.rs` to decide whether to register the `/ws/logs` route.
+static LOG_VIEWER_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable the log viewer feature. Called from `main.rs` when
+/// `--enable-log-viewer` is set.
+pub fn enable_log_viewer() {
+    LOG_VIEWER_ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Returns whether the log viewer was enabled at startup.
+pub fn is_log_viewer_enabled() -> bool {
+    LOG_VIEWER_ENABLED.load(Ordering::Relaxed)
+}
+
+/// WebSocket upgrade handler for `/ws/logs`.
+///
+/// The Docker log stream is started only when a client actually connects
+/// (lazy connect -- no background resource consumption while collapsed).
+pub async fn ws_logs_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_logs_socket)
+}
+
+async fn handle_logs_socket(mut socket: WebSocket) {
+    debug!("Logs WebSocket client connected");
+
+    // Connect to the Docker daemon over the local Unix socket.
+    let docker = match Docker::connect_with_local_defaults() {
+        Ok(d) => d,
+        Err(e) => {
+            let msg = format!("ERR:Could not connect to Docker daemon: {e}");
+            let _ = socket.send(Message::Text(msg.into())).await;
+            return;
+        }
+    };
+
+    // Find the first vLLM container via the Docker API.
+    let container_id = match find_container_via_docker(&docker).await {
+        Some(id) => id,
+        None => {
+            let msg = "ERR:No engine container found".to_string();
+            let _ = socket.send(Message::Text(msg.into())).await;
+            return;
+        }
+    };
+
+    debug!("Streaming logs for container: {container_id}");
+
+    let options = LogsOptionsBuilder::new()
+        .follow(true)
+        .stdout(true)
+        .stderr(true)
+        .tail("100")
+        .build();
+
+    let mut stream = docker.logs(&container_id, Some(options));
+    let mut recv_buffer = String::with_capacity(1024);
+
+    loop {
+        tokio::select! {
+            frame = stream.next() => {
+                match frame {
+                    Some(Ok(LogOutput::StdOut { message })) => {
+                        recv_buffer.push_str(&String::from_utf8_lossy(&message));
+                        while let Some(pos) = recv_buffer.find('\n') {
+                            let line = recv_buffer[..pos].to_string();
+                            recv_buffer.drain(..=pos);
+                            if socket.send(Message::Text(line.into())).await.is_err() {
+                                debug!("Logs client disconnected");
+                                return;
+                            }
+                        }
+                    }
+                    Some(Ok(LogOutput::StdErr { message })) => {
+                        let text = String::from_utf8_lossy(&message).to_string();
+                        for line in text.split('\n') {
+                            if line.is_empty() { continue; }
+                            let tagged = format!("[stderr] {}", line);
+                            if socket.send(Message::Text(tagged.into())).await.is_err() {
+                                debug!("Logs client disconnected");
+                                return;
+                            }
+                        }
+                    }
+                    Some(Ok(LogOutput::Console { message })) => {
+                        let text = String::from_utf8_lossy(&message).to_string();
+                        if socket.send(Message::Text(text.into())).await.is_err() {
+                            debug!("Logs client disconnected");
+                            return;
+                        }
+                    }
+                    Some(Ok(LogOutput::StdIn { .. })) => {
+                        // We don't write to stdin, so ignore
+                    }
+                    Some(Err(e)) => {
+                        let msg = format!("ERR:Log stream error: {e}");
+                        let _ = socket.send(Message::Text(msg.into())).await;
+                        return;
+                    }
+                    None => {
+                        let _ = socket.send(Message::Text("LOG:Stream ended - container stopped".into())).await;
+                        return;
+                    }
+                }
+            }
+            ws_msg = socket.recv() => {
+                match ws_msg {
+                    Some(Ok(Message::Close(_))) | None => {
+                        debug!("Logs client disconnected via close frame");
+                        return;
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => {
+                        debug!("Logs WebSocket error: {e}");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Find a running Docker container whose name or image contains a known engine
+/// identifier (e.g. vllm, deepseek).
+pub async fn find_container_via_docker(docker: &Docker) -> Option<String> {
+    let mut filters = HashMap::new();
+    filters.insert("status".to_string(), vec!["running".to_string()]);
+
+    let options = ListContainersOptionsBuilder::new()
+        .all(false)
+        .filters(&filters)
+        .build();
+
+    let containers = docker.list_containers(Some(options)).await.ok()?;
+
+    for container in &containers {
+        let image = container.image.as_deref().unwrap_or("");
+        let image_lower = image.to_lowercase();
+        let names: Vec<&str> = container
+            .names
+            .as_ref()
+            .map(|n| n.iter().map(|s| s.as_str()).collect())
+            .unwrap_or_default();
+
+        let name_match = names
+            .iter()
+            .any(|n| n.to_lowercase().contains("vllm") || n.to_lowercase().contains("deepseek"));
+
+        let image_match = image_lower.contains("vllm") || image_lower.contains("deepseek");
+
+        if name_match || image_match {
+            return container
+                .id
+                .as_ref()
+                .map(|id| id.chars().take(12).collect());
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn container_id_is_truncated_to_12_chars() {
+        let long_id = "abc123def4567890";
+        let short: String = long_id.chars().take(12).collect();
+        assert_eq!(short.len(), 12);
+        assert_eq!(short, "abc123def456");
+    }
+
+    #[test]
+    fn short_id_under_12_chars_is_unchanged() {
+        let id = "abc123";
+        let short: String = id.chars().take(12).collect();
+        assert_eq!(short, "abc123");
+    }
+
+    #[test]
+    fn stderr_prefix_is_formatted_correctly() {
+        let line = "[stderr] Error: connection refused";
+        assert!(line.starts_with("[stderr]"));
+        assert!(line.contains("connection refused"));
+    }
+
+    #[test]
+    fn log_stream_ended_message_format() {
+        let msg = "LOG:Stream ended - container stopped";
+        assert!(msg.starts_with("LOG:"));
+        assert!(msg.contains("container stopped"));
+    }
+}

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -6,30 +6,62 @@
 //!
 //! Stream characteristics:
 //! - stdout/stderr are multiplexed in real-time (not drained sequentially).
-//! - The WebSocket connects lazily -- the backend stream is only opened when a
-//!   client connects, not on page load.
-//! - Container discovery uses the Docker API directly rather than needing the
-//!   shared engine state wired into this handler.
+//! - One Docker log stream is shared across all connected WebSocket clients
+//!   (same fan-out pattern as the metrics broadcast in `ws.rs`): a single
+//!   background task owns the Docker stream and publishes line-buffered log
+//!   lines over a `broadcast` channel; each WS handler subscribes to it.
+//! - Both stdout and stderr are buffered by lines — bollard frames can split a
+//!   log line mid-way, so partial frames are accumulated until a newline arrives
+//!   before being forwarded. The trailing partial line is flushed when the
+//!   Docker stream ends.
+//! - The container to stream is read from the shared engine state populated by
+//!   `engine_collector_loop`, so the dashboard streams the exact container it is
+//!   showing metrics for rather than re-scanning and potentially picking a
+//!   different one.
 
 #![cfg(target_os = "linux")]
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use bollard::container::LogOutput;
-use bollard::query_parameters::{ListContainersOptionsBuilder, LogsOptionsBuilder};
+use bollard::query_parameters::LogsOptionsBuilder;
 use bollard::Docker;
 use futures_util::StreamExt;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tracing::debug;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::{broadcast, RwLock};
+use tracing::{debug, warn};
+
+use crate::engines::EngineSnapshot;
 
 /// Flag set at startup when `--enable-log-viewer` is passed.
 /// Read by `server.rs` to decide whether to register the `/ws/logs` route.
 static LOG_VIEWER_ENABLED: AtomicBool = AtomicBool::new(false);
 
+/// Broadcast channel carrying line-buffered log lines to all connected WS
+/// clients. Lazily initialized by [`start_log_stream`] the first time a client
+/// connects. Mirrors the `broadcast::Sender<String>` used for metrics in
+/// [`crate::metrics`] / [`crate::ws`]: one producer (the background stream
+/// task) fans out to N subscribers (the WS handlers).
+static LOG_TX: OnceLock<broadcast::Sender<String>> = OnceLock::new();
+
+/// Shared engine state, set at startup when the log viewer is enabled.
+/// The background stream task reads the tracked container id from here so it
+/// streams the same container the dashboard is reporting metrics for.
+static ENGINE_STATE: OnceLock<Arc<RwLock<Vec<EngineSnapshot>>>> = OnceLock::new();
+
+/// Capacity of the log broadcast channel. Sized so a slow WS client can fall a
+/// few seconds behind (log lines are small) without being dropped; lagged
+/// clients simply skip missed lines (see [`handle_logs_socket`]).
+const LOG_CHANNEL_CAPACITY: usize = 256;
+
 /// Enable the log viewer feature. Called from `main.rs` when
-/// `--enable-log-viewer` is set.
-pub fn enable_log_viewer() {
+/// `--enable-log-viewer` is set. Captures the shared engine state so the
+/// background stream can resolve the tracked container id.
+pub fn enable_log_viewer(engine_state: Arc<RwLock<Vec<EngineSnapshot>>>) {
+    // Setting the engine state first avoids a race where a client connects and
+    // the stream task starts before the state pointer is available.
+    let _ = ENGINE_STATE.set(engine_state);
     LOG_VIEWER_ENABLED.store(true, Ordering::Relaxed);
 }
 
@@ -40,8 +72,9 @@ pub fn is_log_viewer_enabled() -> bool {
 
 /// WebSocket upgrade handler for `/ws/logs`.
 ///
-/// The Docker log stream is started only when a client actually connects
-/// (lazy connect -- no background resource consumption while collapsed).
+/// The Docker log stream is started only when the first client actually
+/// connects (lazy connect -- no background resource consumption while
+/// collapsed). Subsequent clients subscribe to the same broadcast.
 pub async fn ws_logs_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
     ws.on_upgrade(handle_logs_socket)
 }
@@ -49,81 +82,35 @@ pub async fn ws_logs_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
 async fn handle_logs_socket(mut socket: WebSocket) {
     debug!("Logs WebSocket client connected");
 
-    // Connect to the Docker daemon over the local Unix socket.
-    let docker = match Docker::connect_with_local_defaults() {
-        Ok(d) => d,
-        Err(e) => {
-            let msg = format!("ERR:Could not connect to Docker daemon: {e}");
-            let _ = socket.send(Message::Text(msg.into())).await;
-            return;
-        }
-    };
+    let tx = start_log_stream().await;
+    let mut rx = tx.subscribe();
 
-    // Find the first vLLM container via the Docker API.
-    let container_id = match find_container_via_docker(&docker).await {
-        Some(id) => id,
-        None => {
-            let msg = "ERR:No engine container found".to_string();
-            let _ = socket.send(Message::Text(msg.into())).await;
-            return;
-        }
-    };
-
-    debug!("Streaming logs for container: {container_id}");
-
-    let options = LogsOptionsBuilder::new()
-        .follow(true)
-        .stdout(true)
-        .stderr(true)
-        .tail("100")
-        .build();
-
-    let mut stream = docker.logs(&container_id, Some(options));
-    let mut recv_buffer = String::with_capacity(1024);
+    // Replay a marker so the client knows streaming has begun.
+    if socket
+        .send(Message::Text("LOG:stream attached".into()))
+        .await
+        .is_err()
+    {
+        debug!("Logs client disconnected before first message");
+        return;
+    }
 
     loop {
         tokio::select! {
-            frame = stream.next() => {
-                match frame {
-                    Some(Ok(LogOutput::StdOut { message })) => {
-                        recv_buffer.push_str(&String::from_utf8_lossy(&message));
-                        while let Some(pos) = recv_buffer.find('\n') {
-                            let line = recv_buffer[..pos].to_string();
-                            recv_buffer.drain(..=pos);
-                            if socket.send(Message::Text(line.into())).await.is_err() {
-                                debug!("Logs client disconnected");
-                                return;
-                            }
-                        }
-                    }
-                    Some(Ok(LogOutput::StdErr { message })) => {
-                        let text = String::from_utf8_lossy(&message).to_string();
-                        for line in text.split('\n') {
-                            if line.is_empty() { continue; }
-                            let tagged = format!("[stderr] {}", line);
-                            if socket.send(Message::Text(tagged.into())).await.is_err() {
-                                debug!("Logs client disconnected");
-                                return;
-                            }
-                        }
-                    }
-                    Some(Ok(LogOutput::Console { message })) => {
-                        let text = String::from_utf8_lossy(&message).to_string();
-                        if socket.send(Message::Text(text.into())).await.is_err() {
+            line = rx.recv() => {
+                match line {
+                    Ok(msg) => {
+                        if socket.send(Message::Text(msg.into())).await.is_err() {
                             debug!("Logs client disconnected");
                             return;
                         }
                     }
-                    Some(Ok(LogOutput::StdIn { .. })) => {
-                        // We don't write to stdin, so ignore
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        debug!("Logs client lagged, skipped {} lines", n);
+                        continue;
                     }
-                    Some(Err(e)) => {
-                        let msg = format!("ERR:Log stream error: {e}");
-                        let _ = socket.send(Message::Text(msg.into())).await;
-                        return;
-                    }
-                    None => {
-                        let _ = socket.send(Message::Text("LOG:Stream ended - container stopped".into())).await;
+                    Err(broadcast::error::RecvError::Closed) => {
+                        debug!("Logs broadcast channel closed");
                         return;
                     }
                 }
@@ -145,74 +132,274 @@ async fn handle_logs_socket(mut socket: WebSocket) {
     }
 }
 
-/// Find a running Docker container whose name or image contains a known engine
-/// identifier (e.g. vllm, deepseek).
-pub async fn find_container_via_docker(docker: &Docker) -> Option<String> {
-    let mut filters = HashMap::new();
-    filters.insert("status".to_string(), vec!["running".to_string()]);
+/// Lazily start the shared Docker log stream (if not already running) and
+/// return a clone of the broadcast sender. Idempotent: the first caller to
+/// populate `LOG_TX` wins; `STREAM_TASK_STARTED` then ensures the background
+/// task is spawned exactly once. Later callers just subscribe.
+async fn start_log_stream() -> broadcast::Sender<String> {
+    let tx = LOG_TX
+        .get_or_init(|| broadcast::channel::<String>(LOG_CHANNEL_CAPACITY).0)
+        .clone();
 
-    let options = ListContainersOptionsBuilder::new()
-        .all(false)
-        .filters(&filters)
-        .build();
-
-    let containers = docker.list_containers(Some(options)).await.ok()?;
-
-    for container in &containers {
-        let image = container.image.as_deref().unwrap_or("");
-        let image_lower = image.to_lowercase();
-        let names: Vec<&str> = container
-            .names
-            .as_ref()
-            .map(|n| n.iter().map(|s| s.as_str()).collect())
-            .unwrap_or_default();
-
-        let name_match = names
-            .iter()
-            .any(|n| n.to_lowercase().contains("vllm") || n.to_lowercase().contains("deepseek"));
-
-        let image_match = image_lower.contains("vllm") || image_lower.contains("deepseek");
-
-        if name_match || image_match {
-            return container
-                .id
-                .as_ref()
-                .map(|id| id.chars().take(12).collect());
-        }
+    // Only one caller wins this CAS; it spawns the single stream task.
+    if STREAM_TASK_STARTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        tokio::spawn(log_stream_task(tx.clone()));
     }
 
+    tx
+}
+
+/// Guarantees the background Docker-stream task is spawned exactly once.
+static STREAM_TASK_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Background task that owns the single Docker log stream and publishes
+/// line-buffered log lines to all WS clients via the broadcast channel.
+async fn log_stream_task(tx: broadcast::Sender<String>) {
+    let docker = match Docker::connect_with_local_defaults() {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = tx.send(format!("ERR:Could not connect to Docker daemon: {e}"));
+            return;
+        }
+    };
+
+    // Resolve the tracked container id from shared engine state. Poll briefly
+    // in case detection hasn't completed yet at first connect.
+    let container_id = match resolve_container_id().await {
+        Some(id) => id,
+        None => {
+            let _ = tx.send("ERR:No engine container found".to_string());
+            return;
+        }
+    };
+
+    debug!("Streaming logs for container: {container_id}");
+
+    let options = LogsOptionsBuilder::new()
+        .follow(true)
+        .stdout(true)
+        .stderr(true)
+        .tail("100")
+        .build();
+
+    let mut stream = docker.logs(&container_id, Some(options));
+    let mut stdout_buf = String::with_capacity(1024);
+    let mut stderr_buf = String::with_capacity(1024);
+
+    loop {
+        match stream.next().await {
+            Some(Ok(LogOutput::StdOut { message })) => {
+                for line in buffer_lines(&mut stdout_buf, &message, None) {
+                    // No subscribers is fine — a client may reconnect; keep streaming.
+                    let _ = tx.send(line);
+                }
+            }
+            Some(Ok(LogOutput::StdErr { message })) => {
+                // Stderr is buffered by lines the same way stdout is: frames
+                // can split a line mid-way, so accumulate until a newline.
+                for line in buffer_lines(&mut stderr_buf, &message, Some("[stderr] ")) {
+                    let _ = tx.send(line);
+                }
+            }
+            Some(Ok(LogOutput::Console { message })) => {
+                // Console frames are whole lines from the Docker daemon itself.
+                let text = String::from_utf8_lossy(&message).to_string();
+                let _ = tx.send(text);
+            }
+            Some(Ok(LogOutput::StdIn { .. })) => {
+                // We don't write to stdin, so ignore.
+            }
+            Some(Err(e)) => {
+                let _ = tx.send(format!("ERR:Log stream error: {e}"));
+                return;
+            }
+            None => {
+                // Stream ended (container stopped). Flush any trailing partial
+                // lines that never received a newline.
+                flush_trailing(&mut stdout_buf, None, &tx);
+                flush_trailing(&mut stderr_buf, Some("[stderr] "), &tx);
+                let _ = tx.send("LOG:Stream ended - container stopped".to_string());
+                return;
+            }
+        }
+    }
+}
+
+/// Read the tracked container id from shared engine state. Waits up to ~10s for
+/// detection to populate a container id, since the log viewer may be connected
+/// before the first detection sweep completes.
+async fn resolve_container_id() -> Option<String> {
+    let state = ENGINE_STATE.get()?;
+    for _ in 0..100 {
+        {
+            let lock = state.read().await;
+            for snap in lock.iter() {
+                if let Some(id) = &snap.container_id {
+                    return Some(id.clone());
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    warn!("Log viewer could not resolve a container id from engine state after 10s");
     None
+}
+
+// ---------------------------------------------------------------------------
+// Line buffering helpers (pure -- exercised by unit tests)
+// ---------------------------------------------------------------------------
+
+/// Accumulate `chunk` into `buffer`, then emit and drain every complete line
+/// (text up to and including a `\n`). Any trailing partial line (no newline
+/// yet) remains in `buffer` for the next chunk. `prefix` is prepended to each
+/// emitted line (used to tag stderr lines with `[stderr] `).
+///
+/// This is the core line-buffering behavior shared by stdout and stderr: a
+/// single log line may arrive split across several bollard frames, so we only
+/// forward text once we have a complete line.
+fn buffer_lines(buffer: &mut String, chunk: &[u8], prefix: Option<&str>) -> Vec<String> {
+    buffer.push_str(&String::from_utf8_lossy(chunk));
+    let mut out = Vec::new();
+    while let Some(pos) = buffer.find('\n') {
+        let line: String = buffer.drain(..=pos).collect();
+        // Strip the trailing newline (already drained) and emit the line
+        // body, with the optional prefix.
+        let body = line.trim_end_matches('\n');
+        let prefixed = match prefix {
+            Some(p) => format!("{p}{body}"),
+            None => body.to_string(),
+        };
+        out.push(prefixed);
+    }
+    out
+}
+
+/// Emit whatever remains in `buffer` as a single final line (no trailing
+/// newline was ever received), then clear it. Called when the Docker stream
+/// ends so a partial last line isn't silently dropped.
+fn flush_trailing(buffer: &mut String, prefix: Option<&str>, tx: &broadcast::Sender<String>) {
+    if buffer.is_empty() {
+        return;
+    }
+    let body = std::mem::take(buffer);
+    let prefixed = match prefix {
+        Some(p) => format!("{p}{body}"),
+        None => body,
+    };
+    let _ = tx.send(prefixed);
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
+    /// A complete line arriving in one frame is emitted immediately, and the
+    /// buffer is left empty (no partial line retained).
     #[test]
-    fn container_id_is_truncated_to_12_chars() {
-        let long_id = "abc123def4567890";
-        let short: String = long_id.chars().take(12).collect();
-        assert_eq!(short.len(), 12);
-        assert_eq!(short, "abc123def456");
+    fn stdout_single_complete_line_is_emitted() {
+        let mut buf = String::new();
+        let lines = buffer_lines(&mut buf, b"hello world\n", None);
+        assert_eq!(lines, vec!["hello world".to_string()]);
+        assert!(buf.is_empty(), "no partial line should remain");
     }
 
+    /// A line split across two frames is only emitted once the newline arrives.
+    /// The first frame leaves a partial line buffered; the second completes it.
     #[test]
-    fn short_id_under_12_chars_is_unchanged() {
-        let id = "abc123";
-        let short: String = id.chars().take(12).collect();
-        assert_eq!(short, "abc123");
+    fn stdout_split_line_is_buffered_until_newline() {
+        let mut buf = String::new();
+
+        // First frame: no newline yet -- nothing emitted, partial buffered.
+        let lines = buffer_lines(&mut buf, b"partial", None);
+        assert!(lines.is_empty(), "no complete line yet");
+        assert_eq!(buf, "partial");
+
+        // Second frame: completes the line.
+        let lines = buffer_lines(&mut buf, b" line\n", None);
+        assert_eq!(lines, vec!["partial line".to_string()]);
+        assert!(buf.is_empty());
     }
 
+    /// Multiple complete lines in a single frame are all emitted, in order.
     #[test]
-    fn stderr_prefix_is_formatted_correctly() {
-        let line = "[stderr] Error: connection refused";
-        assert!(line.starts_with("[stderr]"));
-        assert!(line.contains("connection refused"));
+    fn stdout_multiple_lines_in_one_frame() {
+        let mut buf = String::new();
+        let lines = buffer_lines(&mut buf, b"a\nb\nc\n", None);
+        assert_eq!(
+            lines,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        assert!(buf.is_empty());
     }
 
+    /// Stderr is buffered by lines the same way stdout is: a frame without a
+    /// newline is retained, and each emitted line is tagged with the prefix.
     #[test]
-    fn log_stream_ended_message_format() {
-        let msg = "LOG:Stream ended - container stopped";
-        assert!(msg.starts_with("LOG:"));
-        assert!(msg.contains("container stopped"));
+    fn stderr_is_line_buffered_and_prefixed() {
+        let mut buf = String::new();
+
+        // Split stderr frame: no newline in the first chunk.
+        let lines = buffer_lines(&mut buf, b"err ", Some("[stderr] "));
+        assert!(lines.is_empty());
+        assert_eq!(buf, "err ");
+
+        // Completing chunk emits the tagged line.
+        let lines = buffer_lines(&mut buf, b"half\n", Some("[stderr] "));
+        assert_eq!(lines, vec!["[stderr] err half".to_string()]);
+        assert!(buf.is_empty());
+    }
+
+    /// A partial stdout line that never receives a trailing newline is flushed
+    /// when the stream ends, so it is not silently lost.
+    #[tokio::test]
+    async fn trailing_partial_stdout_line_is_flushed_on_stream_end() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let mut buf = String::new();
+
+        // Buffer a partial line with no newline.
+        let lines = buffer_lines(&mut buf, b"trailing partial", None);
+        assert!(lines.is_empty());
+
+        // Stream ends -> flush the leftover.
+        flush_trailing(&mut buf, None, &tx);
+        assert!(buf.is_empty());
+        assert_eq!(rx.recv().await.unwrap(), "trailing partial");
+    }
+
+    /// A trailing partial stderr line is flushed with its prefix on stream end.
+    #[tokio::test]
+    async fn trailing_partial_stderr_line_is_flushed_with_prefix() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let mut buf = String::new();
+
+        let _ = buffer_lines(&mut buf, b"leftover stderr", Some("[stderr] "));
+        flush_trailing(&mut buf, Some("[stderr] "), &tx);
+        assert_eq!(rx.recv().await.unwrap(), "[stderr] leftover stderr");
+    }
+
+    /// `flush_trailing` on an empty buffer is a no-op (no spurious empty line).
+    #[test]
+    fn flush_trailing_empty_buffer_emits_nothing() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let mut buf = String::new();
+        flush_trailing(&mut buf, None, &tx);
+        // No message should be available.
+        assert!(
+            rx.try_recv().is_err(),
+            "flush of empty buffer must not emit a line"
+        );
+    }
+
+    /// Mixed complete-and-partial frame: the complete line is emitted, the
+    /// trailing partial is retained for the next chunk.
+    #[test]
+    fn stdout_complete_line_then_partial_in_same_frame() {
+        let mut buf = String::new();
+        let lines = buffer_lines(&mut buf, b"done\nstart of next", None);
+        assert_eq!(lines, vec!["done".to_string()]);
+        assert_eq!(buf, "start of next");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,8 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
     // Shared engine state: engine collector writes, metrics collector reads
     let engine_state: Arc<RwLock<Vec<engines::EngineSnapshot>>> = Arc::new(RwLock::new(Vec::new()));
 
-    // Spawn engine collector loop as separate tokio task
+    // Spawn engine collector loop as separate tokio task (Research Pitfall 7:
+    // separate task so slow engine API calls don't block hardware metrics)
     tokio::spawn(engines::engine_collector_loop(
         engine_state.clone(),
         overrides,
@@ -210,7 +211,7 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
     // This registers /ws/logs in the router; nothing is exposed by default.
     #[cfg(target_os = "linux")]
     if args.enable_log_viewer {
-        logs::enable_log_viewer();
+        logs::enable_log_viewer(engine_state.clone());
         tracing::info!(
             "Log viewer enabled at /ws/logs - unauthenticated, container logs are exposed"
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ mod metrics;
 mod server;
 mod ws;
 
+#[cfg(target_os = "linux")]
+mod logs;
+
 use clap::{Args, Parser, Subcommand};
 use cli::service::ServiceCommand;
 use engines::{ApiKeyResolver, EngineOverride, EngineType};
@@ -101,6 +104,20 @@ struct RunArgs {
     /// --engine-api-key (also covers auto-detected engines).
     #[arg(long, env = "SPARK_DASHBOARD_PROVIDER_API_KEY")]
     provider_api_key: Option<String>,
+
+    /// Enable the experimental log viewer at /ws/logs (Linux only).
+    ///
+    /// When set, the dashboard streams container logs from the Docker daemon
+    /// using the bollard API. This is opt-in because engine logs can contain
+    /// prompts and request payloads; the dashboard binds 0.0.0.0 by default
+    /// and /ws/logs is unauthenticated.
+    #[cfg(target_os = "linux")]
+    #[arg(
+        long,
+        env = "SPARK_DASHBOARD_ENABLE_LOG_VIEWER",
+        default_value_t = false
+    )]
+    enable_log_viewer: bool,
 }
 
 fn main() -> ExitCode {
@@ -173,8 +190,7 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
     // Shared engine state: engine collector writes, metrics collector reads
     let engine_state: Arc<RwLock<Vec<engines::EngineSnapshot>>> = Arc::new(RwLock::new(Vec::new()));
 
-    // Spawn engine collector loop as separate tokio task (Research Pitfall 7:
-    // separate task so slow engine API calls don't block hardware metrics)
+    // Spawn engine collector loop as separate tokio task
     tokio::spawn(engines::engine_collector_loop(
         engine_state.clone(),
         overrides,
@@ -189,6 +205,16 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
         args.simulate_gpus,
         engine_state.clone(),
     ));
+
+    // Enable the log viewer if the opt-in flag was passed (Linux only).
+    // This registers /ws/logs in the router; nothing is exposed by default.
+    #[cfg(target_os = "linux")]
+    if args.enable_log_viewer {
+        logs::enable_log_viewer();
+        tracing::info!(
+            "Log viewer enabled at /ws/logs - unauthenticated, container logs are exposed"
+        );
+    }
 
     let app = server::create_router(tx);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,9 @@ struct FrontendAssets;
 pub fn create_router(tx: broadcast::Sender<String>) -> Router {
     let mut router = Router::new()
         .route("/ws", get(crate::ws::ws_handler))
+        // Liveness probe for container HEALTHCHECK / orchestrators. Intentionally
+        // dependency-free: it reports that the HTTP server is up, not that any
+        // engine/GPU is healthy (that's surfaced over /ws).
         .route("/healthz", get(healthz))
         .fallback(static_handler)
         .with_state(tx)
@@ -37,6 +40,7 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
         path = "index.html";
     }
 
+    // Try exact file match first
     if let Some(file) = FrontendAssets::get(path) {
         let mime = mime_guess::from_path(path).first_or_octet_stream();
         return (
@@ -47,6 +51,7 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
             .into_response();
     }
 
+    // SPA fallback: serve index.html for any unmatched route
     if let Some(index) = FrontendAssets::get("index.html") {
         return (
             axum::http::StatusCode::OK,

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,15 +9,22 @@ use tower_http::cors::CorsLayer;
 struct FrontendAssets;
 
 pub fn create_router(tx: broadcast::Sender<String>) -> Router {
-    Router::new()
+    let mut router = Router::new()
         .route("/ws", get(crate::ws::ws_handler))
-        // Liveness probe for container HEALTHCHECK / orchestrators. Intentionally
-        // dependency-free: it reports that the HTTP server is up, not that any
-        // engine/GPU is healthy (that's surfaced over /ws).
         .route("/healthz", get(healthz))
         .fallback(static_handler)
         .with_state(tx)
-        .layer(CorsLayer::permissive())
+        .layer(CorsLayer::permissive());
+
+    // Conditionally register the experimental log viewer endpoint.
+    // Gated behind --enable-log-viewer so deployments can opt out of
+    // exposing unauthenticated container logs.
+    #[cfg(target_os = "linux")]
+    if crate::logs::is_log_viewer_enabled() {
+        router = router.route("/ws/logs", get(crate::logs::ws_logs_handler));
+    }
+
+    router
 }
 
 async fn healthz() -> &'static str {
@@ -30,7 +37,6 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
         path = "index.html";
     }
 
-    // Try exact file match first
     if let Some(file) = FrontendAssets::get(path) {
         let mime = mime_guess::from_path(path).first_or_octet_stream();
         return (
@@ -41,7 +47,6 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
             .into_response();
     }
 
-    // SPA fallback: serve index.html for any unmatched route
     if let Some(index) = FrontendAssets::get("index.html") {
         return (
             axum::http::StatusCode::OK,


### PR DESCRIPTION
NOTE: MERGE 2nd
NOTE 2: PR for historical dashboard should be merged last to prevent rebase requirement.
NOTE 3: This branch stays on the simple create_router(tx) pattern from origin/main and PR for history updates it.

Replace shell-based `docker logs -f` with direct Docker daemon communication via the bollard crate. This eliminates the dependency on a shell or docker CLI in the container image.

Stream characteristics:
- Stdout/stderr multiplexed in real-time
- Lazy WebSocket connect -- back-end stream opens only on client connection
- Container discovery via Docker API scanning for vLLM/DeepSeek images
- Opt-in via --enable-log-viewer (default off) since logs can contain prompts and are served over an unauthenticated WebSocket

Includes:
- New src/logs.rs module (Linux-only, behind #[cfg])
- --enable-log-viewer CLI flag and SPARK_DASHBOARD_ENABLE_LOG_VIEWER env
- Conditional /ws/logs route registration in create_router()
- futures-util dependency for StreamExt
