### PR TITLE
feat(gpu): make main Dashboard hardware panels switch between GPUs

### DIFF
--- a/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
+++ b/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
@@ -180,6 +180,10 @@ describe('Dashboard single-GPU regression', () => {
     expect(screen.queryByText('GPU 0')).toBeNull()
     expect(container.querySelector('[aria-pressed]')).toBeNull()
 
+    // Card subtitles carry the plain GPU name, not the multi-GPU "GPU n · name" form
+    expect(screen.getAllByText('NVIDIA Alpha 0').length).toBeGreaterThan(0)
+    expect(screen.queryByText(/GPU 0 · /)).toBeNull()
+
     // Charts read the legacy un-prefixed history keys
     for (const key of ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics']) {
       expect(history.calls).toContain(key)

--- a/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
+++ b/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
@@ -134,6 +134,21 @@ describe('Dashboard multi-GPU selection', () => {
     expect(details).not.toContain('gpu0 thermal')
   })
 
+  it('survives the metrics null → first-snapshot transition (initial WebSocket connect)', () => {
+    // Regression: with hooks split across the `if (!metrics) return null` early
+    // return, the first snapshot changed the hook count mid-life and React threw
+    // "Rendered more hooks than during the previous render" — a white screen.
+    const history = stubHistory()
+    const { rerender } = render(<Dashboard metrics={null} history={history} events={[]} requests={[]} />)
+
+    expect(() =>
+      rerender(
+        <Dashboard metrics={makeSnapshot([gpu0, gpu1])} history={history} events={[]} requests={[]} />,
+      ),
+    ).not.toThrow()
+    expect(gpuSelector()).not.toBeNull()
+  })
+
   it('keeps the selected GPU when a new snapshot arrives', () => {
     const history = stubHistory()
     const snapshot = makeSnapshot([gpu0, gpu1])

--- a/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
+++ b/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Dashboard } from '../components/views/Dashboard'
+import type { GpuMetrics, MetricsSnapshot } from '../types/metrics'
+import type { GpuEvent } from '../types/events'
+
+// Stub out recharts so event overlays are assertable: the real chart renders
+// event markers as SVG reference lines whose text is just the event type's
+// first letter, which cannot distinguish events from different GPUs.
+vi.mock('@/components/charts/TimeSeriesChart', () => ({
+  TimeSeriesChart: ({ events }: { events?: Array<{ detail: string }> }) => (
+    <div data-testid="time-series-chart">
+      {events?.map((e, i) => (
+        <span key={i} data-testid="chart-event">
+          {e.detail}
+        </span>
+      ))}
+    </div>
+  ),
+}))
+
+const GIB = 1_073_741_824
+
+function makeGpu(index: number, overrides: Partial<GpuMetrics> = {}): GpuMetrics {
+  return {
+    index,
+    name: `NVIDIA Alpha ${index}`,
+    utilization_percent: 11,
+    memory_total_bytes: 48 * GIB,
+    memory_used_bytes: 24 * GIB,
+    temperature_celsius: 40,
+    power_watts: 100,
+    power_limit_watts: 300,
+    clock_graphics_mhz: 1800,
+    clock_sm_mhz: 1800,
+    clock_memory_mhz: 9000,
+    fan_speed_percent: 30,
+    ...overrides,
+  }
+}
+
+const gpu0 = makeGpu(0)
+const gpu1 = makeGpu(1, {
+  name: 'NVIDIA Beta 1',
+  utilization_percent: 77,
+  temperature_celsius: 61,
+  power_watts: 220,
+  clock_graphics_mhz: 2100,
+})
+
+function makeSnapshot(gpus: GpuMetrics[] | undefined): MetricsSnapshot {
+  return {
+    timestamp_ms: 1000,
+    gpu: gpus?.[0] ?? gpu0,
+    ...(gpus ? { gpus } : {}),
+    cpu: { name: 'CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128 * GIB,
+      display_total_bytes: 128 * GIB,
+      used_bytes: 64 * GIB,
+      available_bytes: 64 * GIB,
+      cached_bytes: 8 * GIB,
+      gpu_estimated_bytes: null,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: false,
+    },
+    disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
+    network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
+    engines: [],
+    gpu_events: [],
+  }
+}
+
+function stubHistory() {
+  const calls: string[] = []
+  return {
+    calls,
+    getChartData: (metric: string) => {
+      calls.push(metric)
+      return []
+    },
+    getSparklineData: () => [],
+  }
+}
+
+function gpuSelector() {
+  return screen.queryByRole('group', { name: 'GPU selector' })
+}
+
+describe('Dashboard multi-GPU selection', () => {
+  it('switches all GPU chart panels and gauges to the clicked GPU', () => {
+    const history = stubHistory()
+    render(<Dashboard metrics={makeSnapshot([gpu0, gpu1])} history={history} events={[]} requests={[]} />)
+
+    expect(gpuSelector()).not.toBeNull()
+    // Primary GPU selected by default: per-GPU keys for GPU 0, gauge shows its util
+    expect(history.calls).toContain('gpu:0:gpuUtil')
+    expect(screen.getByText('11')).toBeTruthy()
+
+    history.calls.length = 0
+    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+
+    for (const key of ['gpu:1:gpuUtil', 'gpu:1:gpuTemp', 'gpu:1:gpuPower', 'gpu:1:gpuClockGraphics']) {
+      expect(history.calls).toContain(key)
+    }
+    expect(history.calls.filter((c) => c.startsWith('gpu:0:'))).toEqual([])
+    // Gauges now show GPU 1's utilization / temperature / power
+    expect(screen.getByText('77')).toBeTruthy()
+    expect(screen.getByText('61')).toBeTruthy()
+    expect(screen.getByText('220')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: /GPU 0/ }).getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('chart event markers follow the selected GPU', () => {
+    const events: GpuEvent[] = [
+      { timestamp_ms: 900, gpu_index: 0, event_type: 'thermal', detail: 'gpu0 thermal' },
+      { timestamp_ms: 950, gpu_index: 1, event_type: 'throttle', detail: 'gpu1 throttle' },
+      { timestamp_ms: 980, gpu_index: null, event_type: 'xid', detail: 'global xid' },
+    ]
+    render(<Dashboard metrics={makeSnapshot([gpu0, gpu1])} history={stubHistory()} events={events} requests={[]} />)
+
+    let details = screen.getAllByTestId('chart-event').map((e) => e.textContent)
+    expect(details).toContain('gpu0 thermal')
+    expect(details).toContain('global xid')
+    expect(details).not.toContain('gpu1 throttle')
+
+    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+
+    details = screen.getAllByTestId('chart-event').map((e) => e.textContent)
+    expect(details).toContain('gpu1 throttle')
+    expect(details).toContain('global xid')
+    expect(details).not.toContain('gpu0 thermal')
+  })
+
+  it('keeps the selected GPU when a new snapshot arrives', () => {
+    const history = stubHistory()
+    const snapshot = makeSnapshot([gpu0, gpu1])
+    const { rerender } = render(<Dashboard metrics={snapshot} history={history} events={[]} requests={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+    history.calls.length = 0
+
+    rerender(
+      <Dashboard metrics={{ ...snapshot, timestamp_ms: 2000 }} history={history} events={[]} requests={[]} />,
+    )
+
+    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
+    expect(history.calls).toContain('gpu:1:gpuUtil')
+    expect(history.calls.filter((c) => c.startsWith('gpu:0:'))).toEqual([])
+  })
+
+  it('falls back to the primary GPU when the selected GPU disappears', () => {
+    const history = stubHistory()
+    const { rerender } = render(
+      <Dashboard metrics={makeSnapshot([gpu0, gpu1])} history={history} events={[]} requests={[]} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+
+    rerender(<Dashboard metrics={makeSnapshot([gpu0])} history={history} events={[]} requests={[]} />)
+
+    expect(gpuSelector()).toBeNull()
+    expect(screen.getByText('11')).toBeTruthy()
+  })
+})
+
+describe('Dashboard single-GPU regression', () => {
+  it.each<[string, MetricsSnapshot]>([
+    ['single-entry gpus array', makeSnapshot([gpu0])],
+    ['legacy gpu-only payload', makeSnapshot(undefined)],
+  ])('renders the pre-multi-GPU UI for a %s', (_label, snapshot) => {
+    const history = stubHistory()
+    const { container } = render(
+      <Dashboard metrics={snapshot} history={history} events={[]} requests={[]} />,
+    )
+
+    // No selector strip, no per-GPU chrome
+    expect(gpuSelector()).toBeNull()
+    expect(screen.queryByText('GPU 0')).toBeNull()
+    expect(container.querySelector('[aria-pressed]')).toBeNull()
+
+    // Charts read the legacy un-prefixed history keys
+    for (const key of ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics']) {
+      expect(history.calls).toContain(key)
+    }
+    expect(history.calls.filter((c) => c.startsWith('gpu:'))).toEqual([])
+  })
+})

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -66,6 +66,26 @@ export function Dashboard({
   // the early return so incoming snapshots cannot reset it.
   const [selectedGpuIndex, setSelectedGpuIndex] = useState(0)
 
+  // Measure the hardware grid to adapt to available *vertical* space. The grid
+  // uses auto-rows-fr, so per-card height depends only on the container height
+  // and the column count (2 below the `sm` breakpoint, 4 at/above it) — not on
+  // card content, which keeps this free of layout feedback loops. `compact`
+  // stays false until measured (height 0) so the full layout renders first.
+  const [hwGridRef, hwGridSize] = useElementSize<HTMLDivElement>()
+  const hwCols = hwGridSize.width >= 640 ? 4 : 2
+  const hwRows = Math.ceil(HW_CARD_COUNT / hwCols)
+  const perCardHeight =
+    hwGridSize.height > 0 ? (hwGridSize.height - (hwRows - 1) * 6) / hwRows : 0
+  const compact = perCardHeight > 0 && perCardHeight < HW_COMPACT_HEIGHT_PX
+
+  // Engine trend charts collapse on short viewports (see constant). Default to
+  // showing them until the root is measured (height 0).
+  // All hooks sit above this early return: the hook count must not change when
+  // the first snapshot flips `metrics` from null, or React unmounts the tree
+  // ("Rendered more hooks than during the previous render").
+  const [rootRef, rootSize] = useElementSize<HTMLDivElement>()
+  const showEngineCharts = rootSize.height === 0 || rootSize.height >= ENGINE_CHARTS_MIN_HEIGHT_PX
+
   if (!metrics) return null
 
   const gpus = metrics.gpus && metrics.gpus.length > 0 ? metrics.gpus : [metrics.gpu]
@@ -140,23 +160,6 @@ export function Dashboard({
   const TOTAL_COLOR = '#A1A1AA'
   const NET_RX_COLOR = '#3B82F6'
   const NET_TX_COLOR = '#A855F7'
-
-  // Measure the hardware grid to adapt to available *vertical* space. The grid
-  // uses auto-rows-fr, so per-card height depends only on the container height
-  // and the column count (2 below the `sm` breakpoint, 4 at/above it) — not on
-  // card content, which keeps this free of layout feedback loops. `compact`
-  // stays false until measured (height 0) so the full layout renders first.
-  const [hwGridRef, hwGridSize] = useElementSize<HTMLDivElement>()
-  const hwCols = hwGridSize.width >= 640 ? 4 : 2
-  const hwRows = Math.ceil(HW_CARD_COUNT / hwCols)
-  const perCardHeight =
-    hwGridSize.height > 0 ? (hwGridSize.height - (hwRows - 1) * 6) / hwRows : 0
-  const compact = perCardHeight > 0 && perCardHeight < HW_COMPACT_HEIGHT_PX
-
-  // Engine trend charts collapse on short viewports (see constant). Default to
-  // showing them until the root is measured (height 0).
-  const [rootRef, rootSize] = useElementSize<HTMLDivElement>()
-  const showEngineCharts = rootSize.height === 0 || rootSize.height >= ENGINE_CHARTS_MIN_HEIGHT_PX
 
   return (
     <div ref={rootRef} className="flex flex-col flex-1 min-h-0 gap-2">

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -70,9 +70,10 @@ export function Dashboard({
 
   const gpus = metrics.gpus && metrics.gpus.length > 0 ? metrics.gpus : [metrics.gpu]
   const multiGpu = gpus.length > 1
+  const gpuIndexOf = (gpu: MetricsSnapshot['gpu']) => gpu.index ?? 0
   // Fall back to the primary GPU if the selected index vanishes from the feed.
-  const activeGpu = gpus.find((g) => (g.index ?? 0) === selectedGpuIndex) ?? gpus[0]
-  const activeGpuIndex = activeGpu.index ?? 0
+  const activeGpu = gpus.find((g) => gpuIndexOf(g) === selectedGpuIndex) ?? gpus[0]
+  const activeGpuIndex = gpuIndexOf(activeGpu)
   // Single-GPU hosts keep the legacy un-prefixed history keys so the
   // pre-multi-GPU rendering stays identical; multi-GPU hosts read the
   // `gpu:<index>:<metric>` series (same scheme as DetailedView).
@@ -107,10 +108,9 @@ export function Dashboard({
   ]
 
   // Un-indexed events apply to all GPUs; indexed events only to their GPU.
-  const activeGpuEvents = events.filter(e => e.gpu_index === undefined || e.gpu_index === null || e.gpu_index === activeGpuIndex)
-  const allEvents = activeGpuEvents.map(e => ({
-    timestamp: e.timestamp_ms, type: e.event_type, detail: e.detail,
-  }))
+  const activeGpuChartEvents = events
+    .filter(e => e.gpu_index === undefined || e.gpu_index === null || e.gpu_index === activeGpuIndex)
+    .map(e => ({ timestamp: e.timestamp_ms, type: e.event_type, detail: e.detail }))
   const requestSpans = requests.map(r => ({
     start: r.start_ms, end: r.end_ms, tps: r.tps, ttft: r.ttft_ms,
   }))
@@ -175,12 +175,12 @@ export function Dashboard({
         {multiGpu && (
           <div role="group" aria-label="GPU selector" className="shrink-0 grid grid-cols-2 lg:grid-cols-4 gap-1 lg:gap-1.5 mb-1 lg:mb-1.5">
             {gpus.map((gpu) => {
-              const isActive = (gpu.index ?? 0) === activeGpuIndex
+              const isActive = gpuIndexOf(gpu) === activeGpuIndex
               return (
                 <button
                   key={gpu.index ?? 'primary'}
                   type="button"
-                  onClick={() => setSelectedGpuIndex(gpu.index ?? 0)}
+                  onClick={() => setSelectedGpuIndex(gpuIndexOf(gpu))}
                   aria-pressed={isActive}
                   className={`min-w-0 rounded-md border px-2 py-1 text-left cursor-pointer transition-colors duration-150 ${
                     isActive
@@ -215,7 +215,7 @@ export function Dashboard({
               <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
                 <ArcGauge value={activeGpu.utilization_percent ?? 0} label="GPU Util" unit="%" size={HW_GAUGE_PX} />
                 <div className="flex-1 min-w-0">
-                  <TimeSeriesChart data={history.getChartData(gpuMetricKey('gpuUtil'))} yDomain={[0, 100]} unit="%" events={allEvents} requests={requestSpans} height={HW_CHART_HEIGHT} />
+                  <TimeSeriesChart data={history.getChartData(gpuMetricKey('gpuUtil'))} yDomain={[0, 100]} unit="%" events={activeGpuChartEvents} requests={requestSpans} height={HW_CHART_HEIGHT} />
                 </div>
               </div>
             )}

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { ArcGauge, type GaugeSegment } from '@/components/gauges/ArcGauge'
 import { HBar } from '@/components/gauges/HBar'
 import { CoreHeatmap } from '@/components/charts/CoreHeatmap'
@@ -61,16 +62,31 @@ export function Dashboard({
   events,
   requests,
 }: DashboardProps) {
+  // Which GPU the hardware chart panels show on multi-GPU hosts. Held above
+  // the early return so incoming snapshots cannot reset it.
+  const [selectedGpuIndex, setSelectedGpuIndex] = useState(0)
+
   if (!metrics) return null
+
+  const gpus = metrics.gpus && metrics.gpus.length > 0 ? metrics.gpus : [metrics.gpu]
+  const multiGpu = gpus.length > 1
+  // Fall back to the primary GPU if the selected index vanishes from the feed.
+  const activeGpu = gpus.find((g) => (g.index ?? 0) === selectedGpuIndex) ?? gpus[0]
+  const activeGpuIndex = activeGpu.index ?? 0
+  // Single-GPU hosts keep the legacy un-prefixed history keys so the
+  // pre-multi-GPU rendering stays identical; multi-GPU hosts read the
+  // `gpu:<index>:<metric>` series (same scheme as DetailedView).
+  const gpuMetricKey = (metric: string) => (multiGpu ? `gpu:${activeGpuIndex}:${metric}` : metric)
+  const gpuName = activeGpu.name ?? undefined
+  const gpuSubtitle = multiGpu ? `GPU ${activeGpuIndex}${gpuName ? ` · ${gpuName}` : ''}` : gpuName
 
   // No hardware power cap is exposed on the GB10 (unified-memory SoC), so scale
   // the gauge against the observed peak draw when the limit is absent.
-  const gpus = metrics.gpus && metrics.gpus.length > 0 ? metrics.gpus : [metrics.gpu]
-  const powerHistory = history.getChartData('gpuPower')
+  const powerHistory = history.getChartData(gpuMetricKey('gpuPower'))
   const powerPercent = computePowerScale(
-    metrics.gpu.power_watts,
-    metrics.gpu.power_limit_watts,
-    powerPeak(powerHistory, metrics.gpu.power_watts),
+    activeGpu.power_watts,
+    activeGpu.power_limit_watts,
+    powerPeak(powerHistory, activeGpu.power_watts),
   ).percent
 
   const memUsedPercent = metrics.memory.total_bytes > 0
@@ -90,9 +106,9 @@ export function Dashboard({
     { value: free, total: metrics.memory.total_bytes, color: '#27272A', label: `Free: ${formatBytes(free)}` },
   ]
 
-  const primaryGpuIndex = metrics.gpu.index ?? 0
-  const primaryGpuEvents = events.filter(e => e.gpu_index === undefined || e.gpu_index === null || e.gpu_index === primaryGpuIndex)
-  const allEvents = primaryGpuEvents.map(e => ({
+  // Un-indexed events apply to all GPUs; indexed events only to their GPU.
+  const activeGpuEvents = events.filter(e => e.gpu_index === undefined || e.gpu_index === null || e.gpu_index === activeGpuIndex)
+  const allEvents = activeGpuEvents.map(e => ({
     timestamp: e.timestamp_ms, type: e.event_type, detail: e.detail,
   }))
   const requestSpans = requests.map(r => ({
@@ -156,65 +172,78 @@ export function Dashboard({
 
       {/* ── Hardware Overview — fills the rest of the viewport ── */}
       <div className="flex-1 min-h-0 bg-[#0a0a0d]/80 rounded-xl border border-white/[0.03] p-1 lg:p-1.5 2xl:p-2 flex flex-col">
-        {gpus.length > 1 && (
-          <div className="shrink-0 grid grid-cols-2 lg:grid-cols-4 gap-1 lg:gap-1.5 mb-1 lg:mb-1.5">
-            {gpus.map((gpu) => (
-              <div key={gpu.index ?? 'primary'} className="min-w-0 rounded-md border border-white/[0.04] bg-[#151519] px-2 py-1">
-                <div className="flex items-baseline justify-between gap-2 min-w-0">
-                  <span className="text-[10px] lg:text-[11px] font-semibold text-zinc-200 truncate">
-                    {gpu.index !== null && gpu.index !== undefined ? `GPU ${gpu.index}` : 'GPU'}
-                  </span>
-                  <span className="text-[10px] text-zinc-500 truncate">{gpu.name}</span>
-                </div>
-                <div className="mt-0.5 grid grid-cols-3 gap-2 text-[10px] lg:text-[11px] font-mono tabular-nums text-zinc-300">
-                  <span>{gpu.utilization_percent ?? 0}%</span>
-                  <span>{gpu.temperature_celsius ?? 0}C</span>
-                  <span>{gpu.power_watts !== null ? `${Math.round(gpu.power_watts)}W` : '--'}</span>
-                </div>
-              </div>
-            ))}
+        {multiGpu && (
+          <div role="group" aria-label="GPU selector" className="shrink-0 grid grid-cols-2 lg:grid-cols-4 gap-1 lg:gap-1.5 mb-1 lg:mb-1.5">
+            {gpus.map((gpu) => {
+              const isActive = (gpu.index ?? 0) === activeGpuIndex
+              return (
+                <button
+                  key={gpu.index ?? 'primary'}
+                  type="button"
+                  onClick={() => setSelectedGpuIndex(gpu.index ?? 0)}
+                  aria-pressed={isActive}
+                  className={`min-w-0 rounded-md border px-2 py-1 text-left cursor-pointer transition-colors duration-150 ${
+                    isActive
+                      ? 'border-[#76B900]/50 bg-[#76B900]/[0.06]'
+                      : 'border-white/[0.04] bg-[#151519] hover:border-white/[0.12]'
+                  }`}
+                >
+                  <div className="flex items-baseline justify-between gap-2 min-w-0">
+                    <span className="text-[10px] lg:text-[11px] font-semibold text-zinc-200 truncate">
+                      {gpu.index !== null && gpu.index !== undefined ? `GPU ${gpu.index}` : 'GPU'}
+                    </span>
+                    <span className="text-[10px] text-zinc-500 truncate">{gpu.name}</span>
+                  </div>
+                  <div className="mt-0.5 grid grid-cols-3 gap-2 text-[10px] lg:text-[11px] font-mono tabular-nums text-zinc-300">
+                    <span>{gpu.utilization_percent ?? 0}%</span>
+                    <span>{gpu.temperature_celsius ?? 0}C</span>
+                    <span>{gpu.power_watts !== null ? `${Math.round(gpu.power_watts)}W` : '--'}</span>
+                  </div>
+                </button>
+              )
+            })}
           </div>
         )}
 
         <div ref={hwGridRef} className="flex-1 min-h-0 grid grid-cols-2 sm:grid-cols-4 gap-1 lg:gap-1.5 auto-rows-fr">
 
           {/* GPU Utilization */}
-          <HwCard title="GPU Utilization" subtitle={metrics.gpu.name ?? undefined}>
+          <HwCard title="GPU Utilization" subtitle={gpuSubtitle}>
             {compact ? (
-              <HBar value={metrics.gpu.utilization_percent ?? 0} label="GPU Util" unit="%" />
+              <HBar value={activeGpu.utilization_percent ?? 0} label="GPU Util" unit="%" />
             ) : (
               <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-                <ArcGauge value={metrics.gpu.utilization_percent ?? 0} label="GPU Util" unit="%" size={HW_GAUGE_PX} />
+                <ArcGauge value={activeGpu.utilization_percent ?? 0} label="GPU Util" unit="%" size={HW_GAUGE_PX} />
                 <div className="flex-1 min-w-0">
-                  <TimeSeriesChart data={history.getChartData('gpuUtil')} yDomain={[0, 100]} unit="%" events={allEvents} requests={requestSpans} height={HW_CHART_HEIGHT} />
+                  <TimeSeriesChart data={history.getChartData(gpuMetricKey('gpuUtil'))} yDomain={[0, 100]} unit="%" events={allEvents} requests={requestSpans} height={HW_CHART_HEIGHT} />
                 </div>
               </div>
             )}
           </HwCard>
 
           {/* GPU Temperature */}
-          <HwCard title="GPU Temp" subtitle={metrics.gpu.name ?? undefined}>
+          <HwCard title="GPU Temp" subtitle={gpuSubtitle}>
             {compact ? (
-              <HBar value={metrics.gpu.temperature_celsius ?? 0} label="GPU Temp" unit="°C" thresholds={THRESHOLDS.gpuTemp} />
+              <HBar value={activeGpu.temperature_celsius ?? 0} label="GPU Temp" unit="°C" thresholds={THRESHOLDS.gpuTemp} />
             ) : (
               <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
-                <ArcGauge value={metrics.gpu.temperature_celsius ?? 0} label="GPU Temp" unit="°C" thresholds={THRESHOLDS.gpuTemp} size={HW_GAUGE_PX} />
+                <ArcGauge value={activeGpu.temperature_celsius ?? 0} label="GPU Temp" unit="°C" thresholds={THRESHOLDS.gpuTemp} size={HW_GAUGE_PX} />
                 <div className="flex-1 min-w-0">
-                  <TimeSeriesChart data={history.getChartData('gpuTemp')} yDomain={[0, 100]} unit="°C" height={HW_CHART_HEIGHT} />
+                  <TimeSeriesChart data={history.getChartData(gpuMetricKey('gpuTemp'))} yDomain={[0, 100]} unit="°C" height={HW_CHART_HEIGHT} />
                 </div>
               </div>
             )}
           </HwCard>
 
           {/* GPU Power */}
-          <HwCard title="GPU Power" subtitle={metrics.gpu.name ?? undefined}>
+          <HwCard title="GPU Power" subtitle={gpuSubtitle}>
             {compact ? (
               <HBar
                 value={powerPercent}
                 label="GPU Power"
                 unit="W"
                 thresholds={THRESHOLDS.gpuPower}
-                displayValue={metrics.gpu.power_watts !== null ? Math.round(metrics.gpu.power_watts) : 0}
+                displayValue={activeGpu.power_watts !== null ? Math.round(activeGpu.power_watts) : 0}
               />
             ) : (
               <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
@@ -223,30 +252,30 @@ export function Dashboard({
                   label="GPU Power"
                   unit="W"
                   thresholds={THRESHOLDS.gpuPower}
-                  displayValue={metrics.gpu.power_watts !== null ? Math.round(metrics.gpu.power_watts) : 0}
+                  displayValue={activeGpu.power_watts !== null ? Math.round(activeGpu.power_watts) : 0}
                   size={HW_GAUGE_PX}
                 />
                 <div className="flex-1 min-w-0">
-                  <TimeSeriesChart data={history.getChartData('gpuPower')} unit="W" height={HW_CHART_HEIGHT} />
+                  <TimeSeriesChart data={powerHistory} unit="W" height={HW_CHART_HEIGHT} />
                 </div>
               </div>
             )}
           </HwCard>
 
           {/* GPU Clock */}
-          <HwCard title="GPU Clock" subtitle={metrics.gpu.name ?? undefined}>
+          <HwCard title="GPU Clock" subtitle={gpuSubtitle}>
             {compact ? (
               <div className="flex items-baseline justify-between gap-2 min-w-0">
                 <span className="text-[9px] lg:text-[10px] text-zinc-400 uppercase tracking-wider truncate">Graphics</span>
-                <span className="ml-auto shrink-0 text-xs lg:text-sm 2xl:text-base font-bold text-zinc-100 font-mono tabular-nums">{formatMhz(metrics.gpu.clock_graphics_mhz)}</span>
+                <span className="ml-auto shrink-0 text-xs lg:text-sm 2xl:text-base font-bold text-zinc-100 font-mono tabular-nums">{formatMhz(activeGpu.clock_graphics_mhz)}</span>
               </div>
             ) : (
               <div className="flex items-center gap-2 min-w-0 min-h-0 flex-1 overflow-hidden">
                 <div className="flex flex-col items-center justify-center shrink-0" style={{ width: HW_GAUGE_PX, height: HW_GAUGE_PX }}>
-                  <span className="text-sm 2xl:text-base min-[1920px]:text-lg font-bold text-zinc-100 font-mono">{formatMhz(metrics.gpu.clock_graphics_mhz)}</span>
+                  <span className="text-sm 2xl:text-base min-[1920px]:text-lg font-bold text-zinc-100 font-mono">{formatMhz(activeGpu.clock_graphics_mhz)}</span>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <TimeSeriesChart data={history.getChartData('gpuClockGraphics')} unit="MHz" height={HW_CHART_HEIGHT} />
+                  <TimeSeriesChart data={history.getChartData(gpuMetricKey('gpuClockGraphics'))} unit="MHz" height={HW_CHART_HEIGHT} />
                 </div>
               </div>
             )}


### PR DESCRIPTION
Closes #44. Follow-up to #40/#41.

## What

The main Dashboard's per-GPU summary strip (shown only on multi-GPU hosts) now acts as a **GPU selector**: clicking an entry switches all four GPU hardware panels (utilization, temperature, power, clocks) to that GPU — gauges, history charts, and chart event overlays together.

## Design choices (per the issue brief)

- **Selector over overlay/facet** — the issue recommended the selector as the safer fit for the dense one-pager layout; all panels switch together.
- **Reuses the existing `gpu:<index>:<metric>` history keys** from `useMetricsHistory` (same scheme DetailedView uses); no new buffering mechanism.
- **Event overlays follow the selection**: events with a null/undefined `gpu_index` apply to every GPU, indexed events only to theirs.
- **Selection survives snapshots**: it is component state held above the early return; a fresh `MetricsSnapshot` render cannot reset it. If the selected index disappears from the feed, the panels fall back to the primary GPU.
- **Single-GPU / legacy payload unchanged**: with one GPU (or the pre-#41 `gpu`-only payload) there is no selector chrome and the charts read the legacy un-prefixed keys, so the UI renders exactly as before.
- **No Rust changes** — frontend only, as required.

## Tests (Vitest, `Dashboard.multiGpu.test.tsx`)

- clicking GPU 1 switches gauges and all four chart series keys to `gpu:1:*`
- event markers follow the selected GPU (events on two different `gpu_index` values + a global one)
- selection persists across a new snapshot
- fallback when the selected GPU disappears
- regression: single-entry `gpus` array and legacy `gpu`-only payload render the pre-change UI (no selector, un-prefixed keys)

Verification runs in CI (`frontend` job: `npm run build && npm test -- --run`) — this machine has no local node toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)