### PR TITLE
feat: associate detected inference engines with the GPU they run on

### DIFF
--- a/frontend/src/__tests__/EngineSection.gpuBadge.test.tsx
+++ b/frontend/src/__tests__/EngineSection.gpuBadge.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EngineSection } from '../components/engines/EngineSection'
+import type { EngineSnapshot } from '../types/metrics'
+
+/** Minimal engine snapshot; header chips render even while metrics are null. */
+function engine(gpuIndexes: number[] | undefined): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint: 'http://localhost:8000',
+    status: { type: 'Running' },
+    model: {
+      name: 'test/model',
+      parameter_size: null,
+      quantization: null,
+      precision: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: null,
+    recent_requests: [],
+    deployment_mode: 'Docker',
+    gpu_indexes: gpuIndexes,
+  }
+}
+
+describe('EngineSection GPU badge', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('shows the GPU badge on a multi-GPU host when the engine is placed', () => {
+    render(<EngineSection engines={[engine([1])]} gpuCount={2} />)
+    expect(screen.getByText('GPU 1')).toBeTruthy()
+  })
+
+  it('joins indexes for an engine spanning multiple GPUs', () => {
+    render(<EngineSection engines={[engine([0, 1])]} gpuCount={2} />)
+    expect(screen.getByText('GPU 0+1')).toBeTruthy()
+  })
+
+  it('hides the badge on a single-GPU host even when placement is known', () => {
+    render(<EngineSection engines={[engine([0])]} gpuCount={1} />)
+    expect(screen.queryByText('GPU 0')).toBeNull()
+  })
+
+  it('hides the badge when placement is unknown (empty or absent indexes)', () => {
+    const { unmount } = render(<EngineSection engines={[engine([])]} gpuCount={2} />)
+    expect(screen.queryByText(/^GPU /)).toBeNull()
+    unmount()
+
+    render(<EngineSection engines={[engine(undefined)]} gpuCount={2} />)
+    expect(screen.queryByText(/^GPU /)).toBeNull()
+  })
+})

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { formatBytes, formatGiB, formatCompactTokens, formatAcceptanceLength } from '../lib/format'
+import {
+  formatBytes,
+  formatGiB,
+  formatCompactTokens,
+  formatAcceptanceLength,
+  formatGpuIndexes,
+} from '../lib/format'
 
 const GIB = 1_073_741_824
 const MIB = 1_048_576
@@ -66,5 +72,20 @@ describe('formatAcceptanceLength', () => {
     expect(formatAcceptanceLength(3)).toBe('3.00')
     expect(formatAcceptanceLength(3.4167)).toBe('3.42')
     expect(formatAcceptanceLength(0)).toBe('0.00')
+  })
+})
+
+describe('formatGpuIndexes', () => {
+  it('renders a single index as "GPU N"', () => {
+    expect(formatGpuIndexes([0])).toBe('GPU 0')
+    expect(formatGpuIndexes([3])).toBe('GPU 3')
+  })
+
+  it('joins multiple indexes with "+" (tensor parallel)', () => {
+    expect(formatGpuIndexes([0, 1])).toBe('GPU 0+1')
+  })
+
+  it('renders an empty string when no indexes are known', () => {
+    expect(formatGpuIndexes([])).toBe('')
   })
 })

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -18,7 +18,7 @@ import {
   type LatencyMode,
 } from './LatencyModeControl'
 import { aggregateEngines, groupRunningByProvider } from '@/lib/engineAggregate'
-import { engineDisplayName } from '@/lib/format'
+import { engineDisplayName, formatGpuIndexes } from '@/lib/format'
 import { getProviderLogo } from '@/lib/providerLogo'
 import { useTabRotation } from '@/hooks/useTabRotation'
 import type { EngineSnapshot, EngineType, DeploymentMode } from '@/types/metrics'
@@ -121,6 +121,9 @@ interface EngineSectionProps {
   showCharts?: boolean
   getChartData?: (metric: string) => ChartDataPoint[]
   requests?: InferenceRequest[]
+  /** Number of GPUs in the host snapshot. The per-engine GPU badge renders
+   *  only when there are 2+ — on single-GPU hosts the placement is trivial. */
+  gpuCount?: number
 }
 
 export function EngineSection({
@@ -128,6 +131,7 @@ export function EngineSection({
   showCharts = false,
   getChartData,
   requests,
+  gpuCount = 0,
 }: EngineSectionProps) {
   const [activeTab, setActiveTab] = useState<string>(() => {
     if (typeof window === 'undefined') return GLOBAL_TAB_VALUE
@@ -341,6 +345,11 @@ export function EngineSection({
                     iconSrc={ENGINE_ICON[activeEngine.engine_type]}
                   />
                   <DeploymentChip mode={activeEngine.deployment_mode} />
+                  {gpuCount >= 2 &&
+                    activeEngine.gpu_indexes &&
+                    activeEngine.gpu_indexes.length > 0 && (
+                      <EngineChip label={formatGpuIndexes(activeEngine.gpu_indexes)} />
+                    )}
                   {activeEngine.model?.parameter_size && (
                     <EngineChip label={activeEngine.model.parameter_size} />
                   )}

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -170,6 +170,7 @@ export function Dashboard({
           showCharts={showEngineCharts}
           getChartData={history.getChartData}
           requests={requests}
+          gpuCount={gpus.length}
         />
       </div>
 

--- a/frontend/src/components/views/DetailedView.tsx
+++ b/frontend/src/components/views/DetailedView.tsx
@@ -107,6 +107,7 @@ export function DetailedView({
         showCharts={true}
         getChartData={history.getChartData}
         requests={requests}
+        gpuCount={gpus.length}
       />
     </div>
   )

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -135,6 +135,14 @@ export function formatAcceptanceLength(n: number | null): string {
   return n.toFixed(2)
 }
 
+/** Label for an engine's GPU badge: "GPU 0", or "GPU 0+1" when the engine
+ *  spans multiple GPUs (tensor parallel). Empty string when no indexes are
+ *  known — callers hide the badge entirely in that case. */
+export function formatGpuIndexes(indexes: number[]): string {
+  if (indexes.length === 0) return ''
+  return `GPU ${indexes.join('+')}`
+}
+
 /** Map EngineType enum to human-readable display name. */
 export function engineDisplayName(engineType: EngineType): string {
   const names: Record<EngineType, string> = {

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -200,7 +200,8 @@ export interface EngineSnapshot {
   recent_requests: InferenceRequestData[]
   deployment_mode: DeploymentMode
   /** Indexes of the GPU(s) the engine was observed running on (NVML
-   *  compute-process match on the backend). Empty or absent = unknown;
-   *  the UI shows the badge only on multi-GPU hosts. */
+   *  compute-process match on the backend). Empty = unknown; the UI shows
+   *  the badge only on multi-GPU hosts. The backend always serializes the
+   *  field — optional only so snapshots from older backends still parse. */
   gpu_indexes?: number[]
 }

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -199,4 +199,8 @@ export interface EngineSnapshot {
   metrics: EngineMetrics | null
   recent_requests: InferenceRequestData[]
   deployment_mode: DeploymentMode
+  /** Indexes of the GPU(s) the engine was observed running on (NVML
+   *  compute-process match on the backend). Empty or absent = unknown;
+   *  the UI shows the badge only on multi-GPU hosts. */
+  gpu_indexes?: number[]
 }

--- a/src/engines/detector.rs
+++ b/src/engines/detector.rs
@@ -41,12 +41,30 @@ pub async fn detect_engines(
 
     // Layer 2: Docker scan (Linux-only)
     let docker_candidates = detect_docker_engines().await;
+    merge_docker_candidates(&mut candidates, docker_candidates);
 
-    // Merge Docker results. Key by (engine_type, endpoint) so multiple
-    // instances of the same engine on different ports are preserved as
-    // distinct entries. When a Docker candidate matches an existing
-    // process-scan entry by exact endpoint, upgrade its deployment_mode to
-    // Docker (Docker detection is authoritative for container metadata).
+    // Layer 3: API health probe -- verify each candidate is actually reachable
+    let mut verified = Vec::new();
+    for candidate in candidates {
+        if probe_engine(client, &candidate).await {
+            verified.push(candidate);
+        }
+    }
+
+    verified
+}
+
+/// Merge Docker results into the process-scan candidates. Key by
+/// (engine_type, endpoint) so multiple instances of the same engine on
+/// different ports are preserved as distinct entries. When a Docker candidate
+/// matches an existing process-scan entry by exact endpoint, upgrade its
+/// deployment_mode to Docker (Docker detection is authoritative for container
+/// metadata) and union the PID sets — `docker top` and the host process scan
+/// may each see processes the other missed.
+fn merge_docker_candidates(
+    candidates: &mut Vec<DetectedEngine>,
+    docker_candidates: Vec<DetectedEngine>,
+) {
     let mut seen: HashSet<(EngineType, String)> = candidates
         .iter()
         .map(|c| (c.engine_type.clone(), c.endpoint.clone()))
@@ -67,8 +85,6 @@ pub async fn detect_engines(
                 if existing.served_model.is_none() && dc.served_model.is_some() {
                     existing.served_model = dc.served_model.clone();
                 }
-                // Union the PID sets: `docker top` and the host process scan
-                // may each see processes the other missed.
                 for pid in &dc.pids {
                     if !existing.pids.contains(pid) {
                         existing.pids.push(*pid);
@@ -81,16 +97,6 @@ pub async fn detect_engines(
             candidates.push(dc);
         }
     }
-
-    // Layer 3: API health probe -- verify each candidate is actually reachable
-    let mut verified = Vec::new();
-    for candidate in candidates {
-        if probe_engine(client, &candidate).await {
-            verified.push(candidate);
-        }
-    }
-
-    verified
 }
 
 // ---------------------------------------------------------------------------
@@ -98,7 +104,7 @@ pub async fn detect_engines(
 // ---------------------------------------------------------------------------
 
 fn detect_by_process(sys: &sysinfo::System) -> Vec<DetectedEngine> {
-    let mut detected = Vec::new();
+    let mut detected: Vec<DetectedEngine> = Vec::new();
 
     for &(binary, ref engine_type, default_endpoint) in ENGINE_BINARIES {
         // Direct binary match (e.g. process named "vllm")
@@ -700,5 +706,46 @@ mod tests {
         // Degenerate parent data forming a cycle must not loop forever.
         let processes = vec![(100, Some(101)), (101, Some(100))];
         assert_eq!(expand_pid_tree(&[100], &processes), vec![100, 101]);
+    }
+
+    fn candidate(endpoint: &str, mode: DeploymentMode, pids: &[u32]) -> DetectedEngine {
+        DetectedEngine {
+            engine_type: EngineType::Vllm,
+            endpoint: endpoint.to_string(),
+            deployment_mode: mode,
+            served_model: None,
+            pids: pids.to_vec(),
+        }
+    }
+
+    #[test]
+    fn docker_merge_unions_pids_and_upgrades_mode() {
+        let mut candidates = vec![candidate(
+            "http://localhost:8000",
+            DeploymentMode::Native,
+            &[100, 101],
+        )];
+        let docker = vec![candidate(
+            "http://localhost:8000",
+            DeploymentMode::Docker,
+            &[101, 102],
+        )];
+        merge_docker_candidates(&mut candidates, docker);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].deployment_mode, DeploymentMode::Docker);
+        assert_eq!(candidates[0].pids, vec![100, 101, 102]);
+    }
+
+    #[test]
+    fn docker_merge_keeps_distinct_endpoints_separate() {
+        let mut candidates =
+            vec![candidate("http://localhost:8000", DeploymentMode::Native, &[100])];
+        let docker = vec![candidate("http://localhost:8001", DeploymentMode::Docker, &[200])];
+        merge_docker_candidates(&mut candidates, docker);
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].pids, vec![100]);
+        assert_eq!(candidates[1].pids, vec![200]);
     }
 }

--- a/src/engines/detector.rs
+++ b/src/engines/detector.rs
@@ -1,5 +1,5 @@
 use super::{DeploymentMode, EngineType};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::time::Duration;
 
@@ -14,6 +14,11 @@ pub struct DetectedEngine {
     /// fallback when `/v1/models` returns a bare slug without the HF-style
     /// `Provider/` prefix that the operator actually started the server with.
     pub served_model: Option<String>,
+    /// Host-namespace PIDs belonging to this engine: the detected process and
+    /// its descendants (native scan), or every process `docker top` reports
+    /// for the container. Matched against NVML's per-device compute-process
+    /// lists to attribute the engine to the GPU(s) it runs on.
+    pub pids: Vec<u32>,
 }
 
 /// Known engine binaries and their default ports.
@@ -62,6 +67,14 @@ pub async fn detect_engines(
                 if existing.served_model.is_none() && dc.served_model.is_some() {
                     existing.served_model = dc.served_model.clone();
                 }
+                // Union the PID sets: `docker top` and the host process scan
+                // may each see processes the other missed.
+                for pid in &dc.pids {
+                    if !existing.pids.contains(pid) {
+                        existing.pids.push(*pid);
+                    }
+                }
+                existing.pids.sort_unstable();
             }
         } else {
             seen.insert(key);
@@ -116,7 +129,7 @@ fn detect_by_process(sys: &sysinfo::System) -> Vec<DetectedEngine> {
         // Emit one DetectedEngine per distinct endpoint. Multi-instance native
         // setups (three `vllm serve --port 8000/8001/8002` processes) need each
         // port to surface as its own engine rather than collapsing to the first.
-        let mut seen_endpoints: HashSet<String> = HashSet::new();
+        let mut seen_endpoints: HashMap<String, usize> = HashMap::new();
         for p in &procs {
             if p.cmd().is_empty() {
                 continue;
@@ -124,18 +137,65 @@ fn detect_by_process(sys: &sysinfo::System) -> Vec<DetectedEngine> {
             let endpoint = parse_endpoint_from_args(p.cmd(), default_endpoint)
                 .unwrap_or_else(|| default_endpoint.to_string());
             let served_model = parse_model_from_args(p.cmd());
-            if seen_endpoints.insert(endpoint.clone()) {
-                detected.push(DetectedEngine {
-                    engine_type: engine_type.clone(),
-                    endpoint,
-                    deployment_mode: DeploymentMode::Native,
-                    served_model,
-                });
+            let pid = p.pid().as_u32();
+            match seen_endpoints.get(&endpoint) {
+                Some(&slot) => detected[slot].pids.push(pid),
+                None => {
+                    seen_endpoints.insert(endpoint.clone(), detected.len());
+                    detected.push(DetectedEngine {
+                        engine_type: engine_type.clone(),
+                        endpoint,
+                        deployment_mode: DeploymentMode::Native,
+                        served_model,
+                        pids: vec![pid],
+                    });
+                }
             }
         }
     }
 
+    // vLLM's API-server process rarely holds the CUDA context itself — the
+    // engine-core / tensor-parallel worker child processes do — so NVML's
+    // compute-process list must be matched against the whole process tree,
+    // not just the detected root PID.
+    if !detected.is_empty() {
+        let processes: Vec<(u32, Option<u32>)> = sys
+            .processes()
+            .iter()
+            .map(|(pid, proc_)| (pid.as_u32(), proc_.parent().map(|pp| pp.as_u32())))
+            .collect();
+        for d in &mut detected {
+            d.pids = expand_pid_tree(&d.pids, &processes);
+        }
+    }
+
     detected
+}
+
+/// Expand root PIDs to the full set including every descendant process,
+/// given `(pid, parent_pid)` pairs for all processes on the host. Returned
+/// sorted and deduplicated; cycles in the parent data are tolerated.
+fn expand_pid_tree(roots: &[u32], processes: &[(u32, Option<u32>)]) -> Vec<u32> {
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for &(pid, parent) in processes {
+        if let Some(parent) = parent {
+            children.entry(parent).or_default().push(pid);
+        }
+    }
+
+    let mut seen: HashSet<u32> = HashSet::new();
+    let mut queue: Vec<u32> = roots.iter().copied().filter(|&p| seen.insert(p)).collect();
+    let mut result = queue.clone();
+    while let Some(pid) = queue.pop() {
+        for &child in children.get(&pid).map(Vec::as_slice).unwrap_or_default() {
+            if seen.insert(child) {
+                result.push(child);
+                queue.push(child);
+            }
+        }
+    }
+    result.sort_unstable();
+    result
 }
 
 /// Parse `--port` and `--host` from a process's command-line arguments.
@@ -372,16 +432,17 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
 
         let port = mapped_port.map(|p| p.to_string()).or(cmd_port);
 
-        // 3. If still no port (e.g. host networking + `sleep infinity` container),
-        //    inspect the actual processes running inside the container via `docker top`.
-        //    The same top output is also the best source for recovering the model
-        //    argument, since `container.command` is just the container's *entrypoint*
-        //    and often omits the child vllm-serve args.
+        // 3. Inspect the actual processes running inside the container via
+        //    `docker top`. Always queried when a container id is known: its rows
+        //    carry the *host-namespace* PIDs (the namespace NVML reports) used
+        //    for GPU association, and double as the fallback source for the port
+        //    (host networking + `sleep infinity` containers) and the model
+        //    argument, since `container.command` is just the container's
+        //    *entrypoint* and often omits the child vllm-serve args.
+        let mut pids: Vec<u32> = Vec::new();
         let (port, served_model) = {
             let container_id = container.id.as_deref().unwrap_or_default();
-            let need_port = port.is_none();
-            let need_model = cmd_model.is_none();
-            if container_id.is_empty() || (!need_port && !need_model) {
+            if container_id.is_empty() {
                 (port, cmd_model)
             } else {
                 let top_opts = TopOptionsBuilder::default().ps_args("-eo pid,args").build();
@@ -391,6 +452,9 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
                         let mut found_model = cmd_model;
                         if let Some(procs) = top.processes.as_ref() {
                             for row in procs {
+                                if let Some(pid) = parse_pid_from_top_row(row) {
+                                    pids.push(pid);
+                                }
                                 let line = row.join(" ");
                                 if found_port.is_none() {
                                     if let Some(p) = parse_port_from_command_str(&line) {
@@ -412,9 +476,6 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
                                         found_model = Some(m);
                                     }
                                 }
-                                if found_port.is_some() && found_model.is_some() {
-                                    break;
-                                }
                             }
                         }
                         (found_port, found_model)
@@ -426,6 +487,8 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
                 }
             }
         };
+        pids.sort_unstable();
+        pids.dedup();
 
         if let Some(p) = port {
             let endpoint = format!("http://localhost:{}", p);
@@ -441,6 +504,7 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
                 endpoint,
                 deployment_mode: DeploymentMode::Docker,
                 served_model,
+                pids,
             });
         } else {
             tracing::debug!(
@@ -451,6 +515,17 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
     }
 
     detected
+}
+
+/// Parse the host-namespace PID from a `docker top` row produced with
+/// `ps_args("-eo pid,args")` — the PID is the first column. Returns `None`
+/// for the header row ("PID") or malformed rows.
+///
+/// Only reachable from the Linux Docker path in normal builds, but the unit
+/// tests exercise it on every platform — hence the `test` cfg.
+#[cfg(any(target_os = "linux", test))]
+fn parse_pid_from_top_row(row: &[String]) -> Option<u32> {
+    row.first().and_then(|cell| cell.trim().parse::<u32>().ok())
 }
 
 /// Parse `--port` value from a command string (space-separated).
@@ -581,5 +656,49 @@ mod tests {
     #[test]
     fn command_str_returns_none_for_unrelated_command() {
         assert_eq!(parse_model_from_command_str("sleep infinity"), None);
+    }
+
+    fn to_row(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn top_row_pid_is_parsed_from_first_column() {
+        assert_eq!(
+            parse_pid_from_top_row(&to_row(&["4242", "vllm serve --port 8000"])),
+            Some(4242),
+        );
+    }
+
+    #[test]
+    fn top_row_header_and_malformed_rows_yield_none() {
+        assert_eq!(parse_pid_from_top_row(&to_row(&["PID", "COMMAND"])), None);
+        assert_eq!(parse_pid_from_top_row(&[]), None);
+    }
+
+    #[test]
+    fn pid_tree_includes_children_and_grandchildren() {
+        // 100 (root) -> 101 -> 102, plus unrelated 200 -> 201.
+        let processes = vec![
+            (100, Some(1)),
+            (101, Some(100)),
+            (102, Some(101)),
+            (200, Some(1)),
+            (201, Some(200)),
+        ];
+        assert_eq!(expand_pid_tree(&[100], &processes), vec![100, 101, 102]);
+    }
+
+    #[test]
+    fn pid_tree_without_children_returns_only_roots() {
+        let processes = vec![(100, Some(1)), (200, Some(1))];
+        assert_eq!(expand_pid_tree(&[100], &processes), vec![100]);
+    }
+
+    #[test]
+    fn pid_tree_tolerates_parent_cycles() {
+        // Degenerate parent data forming a cycle must not loop forever.
+        let processes = vec![(100, Some(101)), (101, Some(100))];
+        assert_eq!(expand_pid_tree(&[100], &processes), vec![100, 101]);
     }
 }

--- a/src/engines/detector.rs
+++ b/src/engines/detector.rs
@@ -739,9 +739,16 @@ mod tests {
 
     #[test]
     fn docker_merge_keeps_distinct_endpoints_separate() {
-        let mut candidates =
-            vec![candidate("http://localhost:8000", DeploymentMode::Native, &[100])];
-        let docker = vec![candidate("http://localhost:8001", DeploymentMode::Docker, &[200])];
+        let mut candidates = vec![candidate(
+            "http://localhost:8000",
+            DeploymentMode::Native,
+            &[100],
+        )];
+        let docker = vec![candidate(
+            "http://localhost:8001",
+            DeploymentMode::Docker,
+            &[200],
+        )];
         merge_docker_candidates(&mut candidates, docker);
 
         assert_eq!(candidates.len(), 2);

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -352,6 +352,20 @@ impl EngineState {
     }
 }
 
+/// Clear the PID set of every engine the current detection pass did not see.
+/// Their snapshots keep being emitted through the grace period, but matching
+/// stale PIDs against NVML risks a wrong GPU badge once the OS recycles a PID.
+fn clear_stale_pids(
+    engine_map: &mut HashMap<(EngineType, String), EngineState>,
+    detected_keys: &std::collections::HashSet<(EngineType, String)>,
+) {
+    for (key, state) in engine_map.iter_mut() {
+        if !detected_keys.contains(key) {
+            state.pids.clear();
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Manual override (D-11, D-12)
 // ---------------------------------------------------------------------------
@@ -515,6 +529,17 @@ pub async fn engine_collector_loop(
                     // restart and fork workers over their lifetime.
                     state.pids = d.pids.clone();
                 }
+
+                // Engines absent from this pass (stopped, restarting, probe
+                // blip) keep emitting snapshots through the grace period, but
+                // their PIDs are stale — the OS may recycle one onto an
+                // unrelated GPU process, turning the badge into a confident
+                // wrong guess. Clear them: empty = unknown = no badge.
+                let detected_keys: std::collections::HashSet<_> = detected
+                    .iter()
+                    .map(|d| (d.engine_type.clone(), d.endpoint.clone()))
+                    .collect();
+                clear_stale_pids(&mut engine_map, &detected_keys);
             }
 
             _ = poll_interval.tick() => {
@@ -715,6 +740,25 @@ mod tests {
         let r =
             ApiKeyResolver::from_pairs(&["http://a:8000".into()], &["".into()], Some("".into()));
         assert_eq!(r.resolve("http://a:8000"), None);
+    }
+
+    #[test]
+    fn stale_pids_cleared_for_engines_absent_from_detection() {
+        let mut map: HashMap<(EngineType, String), EngineState> = HashMap::new();
+        let seen_key = (EngineType::Vllm, "http://a:8000".to_string());
+        let stale_key = (EngineType::Vllm, "http://b:8001".to_string());
+        let mut seen = state();
+        seen.pids = vec![100];
+        let mut stale = state();
+        stale.pids = vec![200];
+        map.insert(seen_key.clone(), seen);
+        map.insert(stale_key.clone(), stale);
+
+        let detected_keys = std::collections::HashSet::from([seen_key.clone()]);
+        clear_stale_pids(&mut map, &detected_keys);
+
+        assert_eq!(map[&seen_key].pids, vec![100], "detected engine keeps PIDs");
+        assert!(map[&stale_key].pids.is_empty(), "undetected engine cleared");
     }
 
     #[test]

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -207,6 +207,18 @@ pub struct EngineSnapshot {
     pub metrics: Option<EngineMetrics>,
     pub recent_requests: Vec<RecentRequest>,
     pub deployment_mode: DeploymentMode,
+    /// Indexes of the GPU(s) this engine was observed running on, derived by
+    /// matching `pids` against NVML's per-device compute-process lists.
+    /// Empty = unknown (NVML unavailable, empty process lists, engine not on
+    /// a GPU yet) — the UI shows nothing rather than a wrong guess. Filled in
+    /// by the metrics collector at snapshot-assembly time (it owns the NVML
+    /// device handles), so the copy in the shared engine state is always empty.
+    pub gpu_indexes: Vec<u32>,
+    /// Host-namespace PIDs belonging to the engine, used to compute
+    /// `gpu_indexes`. Internal plumbing between the collector loops — not
+    /// part of the wire format.
+    #[serde(skip_serializing)]
+    pub pids: Vec<u32>,
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +263,9 @@ pub struct EngineState {
     /// When a fetch was last attempted (success or unresolved) — drives the
     /// unresolved-retry cooldown.
     pub model_attempted_at: Option<Instant>,
+    /// Host-namespace PIDs from the most recent detection tick. Empty for
+    /// manual overrides until process/Docker detection also finds the engine.
+    pub pids: Vec<u32>,
 }
 
 impl EngineState {
@@ -265,6 +280,7 @@ impl EngineState {
             cached_model: None,
             model_fetched_at: None,
             model_attempted_at: None,
+            pids: Vec::new(),
         }
     }
 
@@ -479,7 +495,7 @@ pub async fn engine_collector_loop(
                 // Add newly detected engines
                 for d in &detected {
                     let key = (d.engine_type.clone(), d.endpoint.clone());
-                    engine_map.entry(key).or_insert_with(|| {
+                    let state = engine_map.entry(key).or_insert_with(|| {
                         let adapter = create_adapter(
                             d.engine_type.clone(),
                             d.endpoint.clone(),
@@ -495,6 +511,9 @@ pub async fn engine_collector_loop(
                         );
                         EngineState::new(adapter, d.deployment_mode.clone())
                     });
+                    // Refresh the PID set every detection tick — engines
+                    // restart and fork workers over their lifetime.
+                    state.pids = d.pids.clone();
                 }
             }
 
@@ -543,6 +562,8 @@ pub async fn engine_collector_loop(
                             metrics,
                             recent_requests: Vec::new(),
                             deployment_mode: state.deployment_mode.clone(),
+                            gpu_indexes: Vec::new(),
+                            pids: state.pids.clone(),
                         });
                     }
                 }

--- a/src/metrics/gpu.rs
+++ b/src/metrics/gpu.rs
@@ -64,6 +64,41 @@ pub fn empty_gpu_metrics() -> GpuMetrics {
     }
 }
 
+/// Per-device compute-process PID lists from NVML — the source of truth for
+/// engine→GPU association. Devices whose process list is unsupported or
+/// unavailable (e.g. unified-memory systems) contribute an empty list.
+#[cfg(target_os = "linux")]
+pub fn collect_device_pids(devices: &[(u32, nvml_wrapper::Device)]) -> Vec<(u32, Vec<u32>)> {
+    devices
+        .iter()
+        .map(|(index, device)| {
+            let pids = nvml_optional(device.running_compute_processes())
+                .map(|procs| procs.iter().map(|p| p.pid).collect())
+                .unwrap_or_default();
+            (*index, pids)
+        })
+        .collect()
+}
+
+/// Map an engine's process IDs to the GPU indexes those processes are
+/// observed running on.
+///
+/// `device_pids` holds, per monitored device, the PIDs from NVML's
+/// compute-process list. A PID appearing on several devices (tensor
+/// parallel) yields every matching index, sorted and deduplicated. No match
+/// — NVML unavailable, empty process lists, engine not yet on a GPU —
+/// yields an empty vec so the UI shows nothing rather than a wrong guess.
+pub fn gpu_indexes_for_pids(pids: &[u32], device_pids: &[(u32, Vec<u32>)]) -> Vec<u32> {
+    let mut indexes: Vec<u32> = device_pids
+        .iter()
+        .filter(|(_, dev_pids)| dev_pids.iter().any(|p| pids.contains(p)))
+        .map(|(index, _)| *index)
+        .collect();
+    indexes.sort_unstable();
+    indexes.dedup();
+    indexes
+}
+
 /// Collect GPU metrics from all opened NVML devices.
 #[cfg(target_os = "linux")]
 pub fn collect_gpu_metrics(devices: &[(u32, nvml_wrapper::Device)]) -> Vec<GpuMetrics> {
@@ -253,6 +288,46 @@ mod tests {
         fn detect_gpu_events_stub_returns_empty() {
             let events = detect_gpu_events(1000);
             assert!(events.is_empty());
+        }
+    }
+
+    mod gpu_association_tests {
+        use super::*;
+
+        #[test]
+        fn engine_pinned_to_one_gpu_yields_that_index() {
+            let device_pids = vec![(0, vec![999]), (1, vec![4242, 4243])];
+            assert_eq!(gpu_indexes_for_pids(&[4242], &device_pids), vec![1]);
+        }
+
+        #[test]
+        fn pid_on_two_devices_yields_both_indexes() {
+            let device_pids = vec![(0, vec![4242]), (1, vec![4242]), (2, vec![999])];
+            assert_eq!(gpu_indexes_for_pids(&[4242], &device_pids), vec![0, 1]);
+        }
+
+        #[test]
+        fn unknown_pids_yield_empty() {
+            let device_pids = vec![(0, vec![999]), (1, vec![998])];
+            assert!(gpu_indexes_for_pids(&[4242], &device_pids).is_empty());
+        }
+
+        #[test]
+        fn empty_device_process_lists_yield_empty() {
+            let device_pids = vec![(0, vec![]), (1, vec![])];
+            assert!(gpu_indexes_for_pids(&[4242], &device_pids).is_empty());
+        }
+
+        #[test]
+        fn no_engine_pids_yield_empty() {
+            let device_pids = vec![(0, vec![999])];
+            assert!(gpu_indexes_for_pids(&[], &device_pids).is_empty());
+        }
+
+        #[test]
+        fn multiple_engine_pids_on_one_device_dedup_to_one_index() {
+            let device_pids = vec![(0, vec![10, 11])];
+            assert_eq!(gpu_indexes_for_pids(&[10, 11], &device_pids), vec![0]);
         }
     }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -121,7 +121,14 @@ pub async fn metrics_collector(
             .as_millis() as u64;
 
         // Read latest engine snapshots (non-blocking read from shared state)
-        let engines = engine_state.read().await.clone();
+        // and stamp each with the GPU(s) its PIDs are observed on. Computed
+        // here rather than in the engine collector because this loop owns the
+        // NVML device handles.
+        let mut engines = engine_state.read().await.clone();
+        let device_pids = gpu::collect_device_pids(&devices);
+        for engine in &mut engines {
+            engine.gpu_indexes = gpu::gpu_indexes_for_pids(&engine.pids, &device_pids);
+        }
 
         let mut gpu_events = gpu::detect_gpu_events(&devices, timestamp_ms);
         gpu_events.extend(gpu_sim::simulated_gpu_events(


### PR DESCRIPTION
Implements #45: each detected inference engine snapshot now carries the GPU index(es) it is observed running on, and the dashboard shows a "GPU N" badge on multi-GPU hosts.

## How it works

- **PID → GPU truth**: NVML `running_compute_processes()` per device, collected by the metrics collector (which owns the NVML device handles) and matched at snapshot-assembly time via a pure, unit-tested `gpu_indexes_for_pids` function.
- **Native engines**: the process-scan detector records the detected PID and expands it to the full process tree — vLLM's API-server process rarely holds the CUDA context itself; the engine-core / tensor-parallel worker children do.
- **Docker engines**: the existing `docker top` call (which reports host-namespace PIDs, the same namespace NVML uses) now always runs and its PID column is parsed; PID sets are unioned when both detectors see the same engine.
- **Frontend**: `gpu_indexes` mirrored in the TS types; the engine header renders an `EngineChip` ("GPU 1", "GPU 0+1" for tensor parallel) only when the snapshot's `gpus` array has 2+ entries and placement is known. Single-GPU hosts are unchanged; no match renders nothing — never a wrong guess.

## Acceptance criteria

- [x] Engine pinned to GPU 1 yields `gpu_indexes: [1]` (unit-tested with injected PID→GPU mapping, no hardware needed)
- [x] A PID appearing on two devices yields both indexes
- [x] No match yields an empty list and no badge
- [x] Badge renders only with 2+ GPUs — Vitest specs cover 1-GPU, 2-GPU, and unknown-placement cases
- [x] Rust unit tests for PID matching, process-tree expansion, and top-row parsing
- [x] TS types updated alongside the Rust shape (metrics-contract rule: formatter in `format.ts`, spec in `__tests__`, component updated; `src/metrics` shape itself unchanged)

Out of scope (per the brief): reading Docker `--gpus` config, switching GPU charts on engine selection, per-engine memory attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)