### PR TITLE
feat(dashboard): sync GPU selection with active engine

### DIFF
--- a/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
+++ b/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { Dashboard } from '../components/views/Dashboard'
-import type { GpuMetrics, MetricsSnapshot } from '../types/metrics'
+import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '../types/metrics'
 import type { GpuEvent } from '../types/events'
 
 // Stub out recharts so event overlays are assertable: the real chart renders
@@ -48,7 +48,7 @@ const gpu1 = makeGpu(1, {
   clock_graphics_mhz: 2100,
 })
 
-function makeSnapshot(gpus: GpuMetrics[] | undefined): MetricsSnapshot {
+function makeSnapshot(gpus: GpuMetrics[] | undefined, engines: EngineSnapshot[] = []): MetricsSnapshot {
   return {
     timestamp_ms: 1000,
     gpu: gpus?.[0] ?? gpu0,
@@ -67,11 +67,31 @@ function makeSnapshot(gpus: GpuMetrics[] | undefined): MetricsSnapshot {
     },
     disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
     network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
-    engines: [],
+    engines,
     gpu_events: [],
   }
 }
 
+function makeEngine(gpuIndexes?: number[]): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint: 'http://localhost:8000',
+    status: { type: 'Running' },
+    model: {
+      name: 'test-model',
+      parameter_size: null,
+      precision: null,
+      quantization: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: null,
+    recent_requests: [],
+    deployment_mode: 'Native',
+    gpu_indexes: gpuIndexes,
+  }
+}
 function stubHistory() {
   const calls: string[] = []
   return {
@@ -134,10 +154,10 @@ describe('Dashboard multi-GPU selection', () => {
     expect(details).not.toContain('gpu0 thermal')
   })
 
-  it('survives the metrics null → first-snapshot transition (initial WebSocket connect)', () => {
+  it('survives the metrics null â†’ first-snapshot transition (initial WebSocket connect)', () => {
     // Regression: with hooks split across the `if (!metrics) return null` early
     // return, the first snapshot changed the hook count mid-life and React threw
-    // "Rendered more hooks than during the previous render" — a white screen.
+    // "Rendered more hooks than during the previous render" â€” a white screen.
     const history = stubHistory()
     const { rerender } = render(<Dashboard metrics={null} history={history} events={[]} requests={[]} />)
 
@@ -180,6 +200,46 @@ describe('Dashboard multi-GPU selection', () => {
   })
 })
 
+describe('Dashboard engine GPU binding', () => {
+  it('automatically follows the selected engine GPU', () => {
+    const history = stubHistory()
+    const engine0 = makeEngine([0])
+    const engine1 = { ...makeEngine([1]), endpoint: 'http://localhost:8001', model: { ...makeEngine([1]).model!, name: 'second-model' } }
+    render(
+      <Dashboard
+        metrics={makeSnapshot([gpu0, gpu1], [engine0, engine1])}
+        history={history}
+        events={[]}
+        requests={[]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: /second-model/ }))
+
+    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByText('77')).toBeTruthy()
+  })
+
+  it('keeps the manual GPU when the selected engine spans it', () => {
+    const history = stubHistory()
+    const engine0 = makeEngine([0])
+    const engineBoth = { ...makeEngine([0, 1]), endpoint: 'http://localhost:8001', model: { ...makeEngine([0, 1]).model!, name: 'parallel-model' } }
+    render(
+      <Dashboard
+        metrics={makeSnapshot([gpu0, gpu1], [engine0, engineBoth])}
+        history={history}
+        events={[]}
+        requests={[]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+    fireEvent.click(screen.getByRole('tab', { name: /parallel-model/ }))
+
+    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
+  })
+})
+
 describe('Dashboard single-GPU regression', () => {
   it.each<[string, MetricsSnapshot]>([
     ['single-entry gpus array', makeSnapshot([gpu0])],
@@ -195,9 +255,9 @@ describe('Dashboard single-GPU regression', () => {
     expect(screen.queryByText('GPU 0')).toBeNull()
     expect(container.querySelector('[aria-pressed]')).toBeNull()
 
-    // Card subtitles carry the plain GPU name, not the multi-GPU "GPU n · name" form
+    // Card subtitles carry the plain GPU name, not the multi-GPU "GPU n Â· name" form
     expect(screen.getAllByText('NVIDIA Alpha 0').length).toBeGreaterThan(0)
-    expect(screen.queryByText(/GPU 0 · /)).toBeNull()
+    expect(screen.queryByText(/GPU 0 Â· /)).toBeNull()
 
     // Charts read the legacy un-prefixed history keys
     for (const key of ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics']) {

--- a/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
+++ b/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
@@ -154,10 +154,10 @@ describe('Dashboard multi-GPU selection', () => {
     expect(details).not.toContain('gpu0 thermal')
   })
 
-  it('survives the metrics null â†’ first-snapshot transition (initial WebSocket connect)', () => {
+  it('survives the metrics null → first-snapshot transition (initial WebSocket connect)', () => {
     // Regression: with hooks split across the `if (!metrics) return null` early
     // return, the first snapshot changed the hook count mid-life and React threw
-    // "Rendered more hooks than during the previous render" â€” a white screen.
+    // "Rendered more hooks than during the previous render" — a white screen.
     const history = stubHistory()
     const { rerender } = render(<Dashboard metrics={null} history={history} events={[]} requests={[]} />)
 
@@ -255,9 +255,9 @@ describe('Dashboard single-GPU regression', () => {
     expect(screen.queryByText('GPU 0')).toBeNull()
     expect(container.querySelector('[aria-pressed]')).toBeNull()
 
-    // Card subtitles carry the plain GPU name, not the multi-GPU "GPU n Â· name" form
+    // Card subtitles carry the plain GPU name, not the multi-GPU "GPU n · name" form
     expect(screen.getAllByText('NVIDIA Alpha 0').length).toBeGreaterThan(0)
-    expect(screen.queryByText(/GPU 0 Â· /)).toBeNull()
+    expect(screen.queryByText(/GPU 0 · /)).toBeNull()
 
     // Charts read the legacy un-prefixed history keys
     for (const key of ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics']) {

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -124,6 +124,8 @@ interface EngineSectionProps {
   /** Number of GPUs in the host snapshot. The per-engine GPU badge renders
    *  only when there are 2+ — on single-GPU hosts the placement is trivial. */
   gpuCount?: number
+  /** Notify the hardware dashboard when the selected engine has known GPU placement. */
+  onActiveEngineGpuChange?: (gpuIndexes?: number[]) => void
 }
 
 export function EngineSection({
@@ -132,6 +134,7 @@ export function EngineSection({
   getChartData,
   requests,
   gpuCount = 0,
+  onActiveEngineGpuChange,
 }: EngineSectionProps) {
   const [activeTab, setActiveTab] = useState<string>(() => {
     if (typeof window === 'undefined') return GLOBAL_TAB_VALUE
@@ -233,6 +236,19 @@ export function EngineSection({
 
   const showGlobalControls = aggregate.running_count > 1
 
+  const isGlobal = activeTab === GLOBAL_TAB_VALUE
+  const activeEngine = engines.find(
+    (e) => `${e.engine_type}-${e.endpoint}` === activeTab,
+  )
+  const activeEngineGpuIndexesKey = activeEngine?.gpu_indexes?.join(',') ?? ''
+
+  useEffect(() => {
+    if (isGlobal || !onActiveEngineGpuChange) return
+    const gpuIndexes = activeEngineGpuIndexesKey
+      ? activeEngineGpuIndexesKey.split(',').map(Number)
+      : undefined
+    onActiveEngineGpuChange(gpuIndexes)
+  }, [activeEngineGpuIndexesKey, isGlobal, onActiveEngineGpuChange])
   useEffect(() => {
     if (showGlobalControls || engines.length === 0) return
     const onlyEngineKey = `${engines[0].engine_type}-${engines[0].endpoint}`
@@ -290,11 +306,6 @@ export function EngineSection({
     )
   }
 
-  const activeEngine = engines.find(
-    (e) => `${e.engine_type}-${e.endpoint}` === activeTab,
-  )
-
-  const isGlobal = activeTab === GLOBAL_TAB_VALUE
   const headerTitle = isGlobal
     ? 'All Engines'
     : activeEngine?.model?.name ?? 'No Model Loaded'

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { ArcGauge, type GaugeSegment } from '@/components/gauges/ArcGauge'
 import { HBar } from '@/components/gauges/HBar'
 import { CoreHeatmap } from '@/components/charts/CoreHeatmap'
@@ -65,6 +65,10 @@ export function Dashboard({
   // Which GPU the hardware chart panels show on multi-GPU hosts. Held above
   // the early return so incoming snapshots cannot reset it.
   const [selectedGpuIndex, setSelectedGpuIndex] = useState(0)
+  const handleActiveEngineGpuChange = useCallback((gpuIndexes?: number[]) => {
+    if (!gpuIndexes || gpuIndexes.length === 0) return
+    setSelectedGpuIndex((current) => gpuIndexes.includes(current) ? current : gpuIndexes[0])
+  }, [])
 
   // Measure the hardware grid to adapt to available *vertical* space. The grid
   // uses auto-rows-fr, so per-card height depends only on the container height
@@ -171,6 +175,7 @@ export function Dashboard({
           getChartData={history.getChartData}
           requests={requests}
           gpuCount={gpus.length}
+          onActiveEngineGpuChange={handleActiveEngineGpuChange}
         />
       </div>
 


### PR DESCRIPTION
## Summary

Automatically sync the selected GPU in the Dashboard with the GPU used by the active inference engine.

When switching between engines/models running on different GPUs, the Dashboard now selects the corresponding GPU from `engine.gpu_indexes`.

For multi-GPU engines, the current manual GPU selection is preserved if that GPU is used by the engine. If the engine's GPU placement is unknown, the current selection is left unchanged.

# Changes

- Automatically select the GPU associated with the active engine
- Preserve the current GPU selection for multi-GPU engines when applicable
- Leave the selection unchanged when GPU placement is unknown
- Add regression tests for:
  - switching to an engine running on GPU 1
  - selecting an engine that uses multiple GPUs

# Scrreenshot

<img width="1918" height="1041" alt="spark-dashboard" src="https://github.com/user-attachments/assets/09ac0c08-4851-4761-b25c-03e6f2a67219" />

# Testing

- Tested manually with models running on different GPUs in a multi-GPU setup
- `git diff --check` passes
- Frontend tests added for the new behavior