### PR TITLE
chore(deps): bump Docker builder image to rust:1.97-slim

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN npm run build
 # (gcr.io/distroless/cc-debian13 → Debian trixie) track Debian 13 / glibc 2.41 —
 # keep them on matching Debian releases (e.g. both -debian13 or both -debian12),
 # or the binary fails with a "GLIBC_x.yz not found" error at startup.
-FROM rust:1.96-slim AS chef
+FROM rust:1.97-slim AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 


### PR DESCRIPTION
## What

`rust:1.96-slim` → `rust:1.97-slim` (latest stable Rust, 1.97.1). Single-line change.

## Verified against the registries (2026-07-22)

- `rust:1.97-slim` is **digest-identical** to `1.97-slim-trixie` — the Debian 13/glibc pairing with the `gcr.io/distroless/cc-debian13` runtime stage holds (per the Dockerfile's own warning comment)
- `node:24-alpine` **stays**: Node 24 is the latest LTS line until Node 26 enters LTS in Oct 2026 (Node 25 is EOL) — per the agreed Node-stays-on-LTS policy
- `cc-debian13` confirmed still distroless's newest Debian variant (README lists only debian12/debian13)

## Verification

- ✅ `./dev/docker-dev.sh --build-local` — full multi-stage buildx build passes (15 MB image)
- ✅ **Runtime smoke on the DGX Spark** via `--deploy-remote`: container healthy, NVML initialized on the GB10, `/healthz` ok — no `GLIBC_x.yz not found` at startup, confirming the builder/runtime glibc match