### PR TITLE
ci: bump actions/checkout and actions/setup-node to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       installer: ${{ steps.filter.outputs.installer }}
       docker: ${{ steps.filter.outputs.docker }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: filter
         uses: dorny/paths-filter@v4
         with:
@@ -54,14 +54,14 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
 
       # rust-embed needs frontend/dist/ present at build time.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm
@@ -90,8 +90,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm
@@ -106,7 +106,7 @@ jobs:
     if: needs.changes.outputs.installer == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: shellcheck install.sh
         run: shellcheck deploy/host/install.sh
       - name: systemd-analyze verify
@@ -133,7 +133,7 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
       # Native per-arch build (no QEMU): confirms the multi-stage Dockerfile
       # compiles for both targets. Publishes nothing — that's docker-publish.yml.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,7 +32,7 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,11 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag_name }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm


### PR DESCRIPTION
## What

`actions/checkout` v6 → **v7.0.1** and `actions/setup-node` v6 → **v7.0.0** across `ci.yml`, `publish.yml`, `docker-publish.yml` (9 pins total).

## Release-notes review

- **checkout v7**: ESM migration + blocks fork-PR checkout under `pull_request_target`/`workflow_run` triggers — not used by these workflows, so no behavioral impact
- **setup-node v7**: ESM migration + new `cache-primary-key`/`cache-matched-key` outputs; no input changes

## Already at latest (verified against GitHub releases 2026-07-22)

`dorny/paths-filter` v4 · `Swatinem/rust-cache` v2 · `docker/setup-buildx-action` v4 · `docker/build-push-action` v7 · `aquasecurity/trivy-action` v0.36.0 (exact pin = latest) · `docker/login-action` v4 · `actions/upload-artifact` v7 · `actions/download-artifact` v8 · `docker/metadata-action` v6 · `googleapis/release-please-action` v5 · `dtolnay/rust-toolchain@stable` (floating)

## Verification

The CI runs on this PR exercise the bumped actions directly (checkout + setup-node run in every job).