### PR TITLE
feat(config): support explicit engine env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,16 +238,19 @@ spark-dashboard service status
       --poll-interval <MS>    Polling interval ms [default: 1000] [env: SPARK_DASHBOARD_POLL_INTERVAL]
       --gpu-index <IDX>       Optional NVML GPU index to monitor [env: SPARK_DASHBOARD_GPU_INDEX]
       --simulate-gpus <N>     Append N fictive GPUs with simulated data (dev aid) [env: SPARK_DASHBOARD_SIMULATE_GPUS]
-      --engine <TYPE>         Manual engine type (e.g. vllm)
-      --engine-url <URL>      Manual engine endpoint (requires --engine)
-      --engine-api-key <KEY>  API key for an endpoint, paired by index with --engine-url
+      --engine <TYPE>         Manual engine type (e.g. vllm) [env: SPARK_DASHBOARD_ENGINE]
+      --engine-url <URL>      Manual engine endpoint (requires --engine) [env: SPARK_DASHBOARD_ENGINE_URL]
+      --engine-api-key <KEY>  API key for an endpoint, paired by index with --engine-url [env: SPARK_DASHBOARD_ENGINE_API_KEY]
       --provider-api-key <KEY> Fallback API key for any endpoint [env: SPARK_DASHBOARD_PROVIDER_API_KEY]
 ```
 
 On multi-GPU hosts, Spark Dashboard monitors all available NVIDIA GPUs by
 default. Use `--gpu-index` to focus on one device. Engines are auto-detected via
 process scan and Docker API. Use `--engine` and `--engine-url` to override when
-auto-detection doesn't work.
+auto-detection doesn't work. For a host-systemd installation, put the same
+values in `/etc/spark-dashboard/config.env` as `SPARK_DASHBOARD_ENGINE` and
+`SPARK_DASHBOARD_ENGINE_URL`; comma-separated engine and URL values are paired
+by position.
 
 For auth-gated deployments (e.g. vLLM started with `--api-key`), pass
 `--engine-api-key` (index-paired with `--engine-url`) or set

--- a/deploy/host/config.env.example
+++ b/deploy/host/config.env.example
@@ -14,5 +14,15 @@
 # Metrics polling interval in milliseconds (default: 1000)
 # SPARK_DASHBOARD_POLL_INTERVAL=1000
 
+# Explicit engine endpoint (optional). Use this when process or Docker discovery
+# cannot see an engine, for example when vLLM runs as a different systemd user.
+# Comma-separated engine and URL lists are paired by position.
+# SPARK_DASHBOARD_ENGINE=vllm
+# SPARK_DASHBOARD_ENGINE_URL=http://127.0.0.1:8000
+
+# Optional per-engine bearer token, paired by position with the endpoint URLs.
+# Do not commit a real token to this file.
+# SPARK_DASHBOARD_ENGINE_API_KEY=
+
 # Log level: error, warn, info, debug, trace (default: info)
 # RUST_LOG=info

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,17 +87,32 @@ struct RunArgs {
     simulate_gpus: u32,
 
     /// Manually specify engine type (use with --engine-url)
-    #[arg(long, value_name = "TYPE")]
+    #[arg(
+        long,
+        value_name = "TYPE",
+        env = "SPARK_DASHBOARD_ENGINE",
+        value_delimiter = ','
+    )]
     engine: Vec<String>,
 
     /// Manually specify engine endpoint URL (use with --engine)
-    #[arg(long, value_name = "URL")]
+    #[arg(
+        long,
+        value_name = "URL",
+        env = "SPARK_DASHBOARD_ENGINE_URL",
+        value_delimiter = ','
+    )]
     engine_url: Vec<String>,
 
     /// API key for an engine endpoint, paired by index with --engine-url.
     /// For auth-gated deployments (e.g. vLLM started with --api-key) this
     /// lets the initial /v1/models lookup succeed instead of 401-spamming.
-    #[arg(long, value_name = "KEY")]
+    #[arg(
+        long,
+        value_name = "KEY",
+        env = "SPARK_DASHBOARD_ENGINE_API_KEY",
+        value_delimiter = ','
+    )]
     engine_api_key: Vec<String>,
 
     /// Fallback API key applied to any engine endpoint without an explicit
@@ -231,4 +246,121 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
     axum::serve(listener, app).await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Clap reads the environment on every parse, so any test in this module
+    /// could observe the SPARK_DASHBOARD_ENGINE* variables another test set.
+    /// Every test takes this lock; env-setting tests clean up before releasing.
+    static ENGINE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn parse(args: &[&str]) -> RunArgs {
+        Cli::try_parse_from(std::iter::once("spark-dashboard").chain(args.iter().copied()))
+            .expect("args should parse")
+            .run
+    }
+
+    fn with_env_vars(vars: &[(&str, &str)], f: impl FnOnce()) {
+        let _guard = ENGINE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved: Vec<_> = vars
+            .iter()
+            .map(|(key, value)| {
+                let prior = std::env::var_os(key);
+                std::env::set_var(key, value);
+                (*key, prior)
+            })
+            .collect();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        for (key, prior) in saved {
+            match prior {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        if let Err(panic) = result {
+            std::panic::resume_unwind(panic);
+        }
+    }
+
+    #[test]
+    fn engine_flags_split_on_commas_and_pair_by_position() {
+        let _guard = ENGINE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let args = parse(&[
+            "--engine",
+            "vllm,vllm",
+            "--engine-url",
+            "http://127.0.0.1:8000,http://127.0.0.1:8001",
+            "--engine-api-key",
+            "key-a,key-b",
+        ]);
+        assert_eq!(args.engine, vec!["vllm", "vllm"]);
+        assert_eq!(
+            args.engine_url,
+            vec!["http://127.0.0.1:8000", "http://127.0.0.1:8001"]
+        );
+        assert_eq!(args.engine_api_key, vec!["key-a", "key-b"]);
+    }
+
+    #[test]
+    fn repeated_engine_flags_accumulate_in_order() {
+        let _guard = ENGINE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let args = parse(&[
+            "--engine",
+            "vllm",
+            "--engine-url",
+            "http://127.0.0.1:8000",
+            "--engine",
+            "vllm",
+            "--engine-url",
+            "http://127.0.0.1:8001",
+        ]);
+        assert_eq!(args.engine, vec!["vllm", "vllm"]);
+        assert_eq!(
+            args.engine_url,
+            vec!["http://127.0.0.1:8000", "http://127.0.0.1:8001"]
+        );
+        assert!(args.engine_api_key.is_empty());
+    }
+
+    #[test]
+    fn engine_env_vars_split_on_commas_and_pair_by_position() {
+        with_env_vars(
+            &[
+                ("SPARK_DASHBOARD_ENGINE", "vllm,vllm"),
+                (
+                    "SPARK_DASHBOARD_ENGINE_URL",
+                    "http://127.0.0.1:8000,http://127.0.0.1:8001",
+                ),
+                ("SPARK_DASHBOARD_ENGINE_API_KEY", "key-a,key-b"),
+            ],
+            || {
+                let args = parse(&[]);
+                assert_eq!(args.engine, vec!["vllm", "vllm"]);
+                assert_eq!(
+                    args.engine_url,
+                    vec!["http://127.0.0.1:8000", "http://127.0.0.1:8001"]
+                );
+                assert_eq!(args.engine_api_key, vec!["key-a", "key-b"]);
+            },
+        );
+    }
+
+    #[test]
+    fn engine_flags_take_precedence_over_env_vars() {
+        with_env_vars(
+            &[
+                ("SPARK_DASHBOARD_ENGINE", "vllm"),
+                ("SPARK_DASHBOARD_ENGINE_URL", "http://127.0.0.1:8000"),
+            ],
+            || {
+                let args = parse(&["--engine-url", "http://127.0.0.1:9000"]);
+                assert_eq!(args.engine, vec!["vllm"]);
+                assert_eq!(args.engine_url, vec!["http://127.0.0.1:9000"]);
+            },
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- expose manual engine type, endpoint, and API-key options through host systemd environment variables
- document the configuration in the host config template and README
- support comma-separated paired engine values for multi-engine deployments

## Why
Native vLLM can run under a different systemd user, where automatic process discovery may not see it. Explicit endpoint configuration keeps dashboard collection reliable.

## Validation
- cargo fmt --check
- cargo test --locked (127 passed)
- ran the binary with SPARK_DASHBOARD_ENGINE and SPARK_DASHBOARD_ENGINE_URL against a live vLLM endpoint