### PR TITLE
feat(frontend): collapsible log viewer with WebSocket streaming

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,14 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useMetrics } from './hooks/useMetrics'
 import { useMetricsHistory } from './hooks/useMetricsHistory'
 import { ConnectionBadge } from './components/ConnectionBadge'
 import { Dashboard } from './components/views/Dashboard'
+import { LogViewer } from './components/LogViewer'
 import type { GpuEvent, InferenceRequest } from './types/events'
 
 function App() {
   const { metrics, connectionStatus, isStale } = useMetrics()
+  const [consoleExpanded, setConsoleExpanded] = useState(false)
 
   const history = useMetricsHistory(metrics)
 
@@ -59,7 +61,10 @@ function App() {
           history={history}
           events={events}
           requests={requests}
+          collapseCharts={consoleExpanded}
         />
+
+        <LogViewer onExpandChange={setConsoleExpanded} />
       </main>
     </div>
   )

--- a/frontend/src/__tests__/LogViewer.test.tsx
+++ b/frontend/src/__tests__/LogViewer.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { LogViewer } from '../components/LogViewer'
+
+// Mock WebSocket
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  readyState = 0
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  close() {
+    this.readyState = 3
+    if (this.onclose) this.onclose(new CloseEvent('close'))
+  }
+
+  send(_data: string) {}
+
+  // Helper to simulate server messages
+  receive(data: string) {
+    if (this.onmessage) this.onmessage(new MessageEvent('message', { data }))
+  }
+
+  // Helper to simulate connection
+  connect() {
+    this.readyState = 1
+    if (this.onopen) this.onopen(new Event('open'))
+  }
+}
+
+// Restore original WebSocket type for the mock
+(globalThis as any).WebSocket = MockWebSocket as unknown as typeof WebSocket
+
+describe('LogViewer', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders collapsed by default', () => {
+    render(<LogViewer />)
+    expect(screen.getByText('Console Logs')).toBeDefined()
+    // Should not show the expanded log panel
+    expect(screen.queryByText('▼ Console Logs')).toBeNull()
+  })
+
+  it('shows disconnected state when collapsed', () => {
+    render(<LogViewer />)
+    expect(screen.getByText('○ Disconnected')).toBeDefined()
+  })
+
+  it('expands when clicked', () => {
+    render(<LogViewer />)
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('▼ Console Logs')).toBeDefined()
+  })
+
+  it('collapses when expanded and collapse button clicked', () => {
+    render(<LogViewer />)
+    // Expand
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('▼ Console Logs')).toBeDefined()
+    // Collapse
+    fireEvent.click(screen.getByText('▼ Console Logs'))
+    expect(screen.queryByText('▼ Console Logs')).toBeNull()
+    expect(screen.getByText('Console Logs')).toBeDefined()
+  })
+
+  it('connects to WebSocket on mount', () => {
+    render(<LogViewer />)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.instances[0].url).toContain('/ws/logs')
+  })
+
+  it('shows live indicator when connected', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    expect(screen.getByText('● Live')).toBeDefined()
+  })
+
+  it('displays log messages from WebSocket', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    // Expand
+    fireEvent.click(screen.getByText('Console Logs'))
+    // Receive a log line
+    act(() => ws.receive('INFO: Server started on port 3000'))
+    expect(screen.getByText('INFO: Server started on port 3000')).toBeDefined()
+  })
+
+  it('filters log lines by text', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    act(() => {
+      ws.receive('ERROR: something broke')
+      ws.receive('INFO: all good')
+    })
+    // Both should be visible initially
+    expect(screen.getByText('ERROR: something broke')).toBeDefined()
+    expect(screen.getByText('INFO: all good')).toBeDefined()
+    // Type filter
+    const input = screen.getByPlaceholderText('Filter lines containing...')
+    fireEvent.change(input, { target: { value: 'error' } })
+    expect(screen.getByText('ERROR: something broke')).toBeDefined()
+    expect(screen.queryByText('INFO: all good')).toBeNull()
+  })
+
+  it('shows paused state when pause button clicked', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    fireEvent.click(screen.getByText('⏵ Live'))
+    expect(screen.getByText('⏸ Paused')).toBeDefined()
+  })
+
+  it('shows waiting message when connected but no logs', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('Waiting for log output...')).toBeDefined()
+  })
+
+  it('shows connecting message when not connected', () => {
+    render(<LogViewer />)
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('Connecting...')).toBeDefined()
+  })
+
+  it('highlights error lines in red', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    act(() => ws.receive('ERROR: critical failure'))
+    const errorLine = screen.getByText('ERROR: critical failure')
+    expect(errorLine.className).toContain('text-red-400')
+  })
+
+  it('highlights warning lines in yellow', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    act(() => ws.receive('WARN: deprecated function used'))
+    const warnLine = screen.getByText('WARN: deprecated function used')
+    expect(warnLine.className).toContain('text-yellow-400')
+  })
+})

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,0 +1,245 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+
+/**
+ * Scrollable log viewer that connects to the backend's /ws/logs WebSocket
+ * endpoint and streams Docker container logs in real-time.
+ *
+ * Features:
+ * - Collapsible section at the bottom of the dashboard
+ * - Pause/Resume button — freeze the viewport to read, unpause to catch up
+ * - Text filter — type a keyword to only show lines containing it
+ * - Auto-scroll to newest lines (pauses when scrolled up manually)
+ * - Error/warning color highlighting
+ */
+export function LogViewer({ onExpandChange }: { onExpandChange?: (expanded: boolean) => void }) {
+  const [logs, setLogs] = useState<string[]>([])
+  const [connected, setConnected] = useState(false)
+  const [collapsed, setCollapsed] = useState(true)
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [paused, setPaused] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [excludeMode, setExcludeMode] = useState(false)
+  const filterRef = useRef<HTMLInputElement>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const wsUrl = `${protocol}//${window.location.host}/ws/logs`
+    const ws = new WebSocket(wsUrl)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setConnected(true)
+    }
+
+    ws.onmessage = (event) => {
+      const text = event.data as string
+      setLogs((prev) => {
+        const next = [...prev, text]
+        return next.length > 1000 ? next.slice(-1000) : next
+      })
+    }
+
+    ws.onclose = () => {
+      setConnected(false)
+      wsRef.current = null
+    }
+
+    ws.onerror = () => {
+      ws.close()
+    }
+
+    return () => {
+      ws.close()
+      wsRef.current = null
+    }
+  }, [])
+
+  // Auto-scroll when new logs arrive (only if not paused)
+  useEffect(() => {
+    if (autoScroll && !paused && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [logs, autoScroll, paused])
+
+  const handleScroll = () => {
+    if (!containerRef.current) return
+    const el = containerRef.current
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50
+    setAutoScroll(atBottom)
+  }
+
+  // Filtered log lines — computed from the full buffer
+  const filteredLogs = useMemo(() => {
+    if (!filter.trim()) return logs
+    const lower = filter.toLowerCase()
+    return excludeMode
+      ? logs.filter((line) => !line.toLowerCase().includes(lower))
+      : logs.filter((line) => line.toLowerCase().includes(lower))
+  }, [logs, filter, excludeMode])
+
+  // Toggle pause/resume
+  const togglePause = () => {
+    const next = !paused
+    setPaused(next)
+    if (!next) {
+      // Unpausing: jump to bottom
+      setAutoScroll(true)
+      if (containerRef.current) {
+        containerRef.current.scrollTop = containerRef.current.scrollHeight
+      }
+    }
+  }
+
+  // Keyboard shortcut: Ctrl+F / Cmd+F to focus the filter input
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+      e.preventDefault()
+      filterRef.current?.focus()
+    }
+  }
+
+  if (collapsed) {
+    return (
+      <div className="shrink-0 mt-2">
+        <button
+          onClick={() => { setCollapsed(false); onExpandChange?.(true) }}
+          className="w-full flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-zinc-400 
+                     bg-[#111115] rounded-md border border-white/[0.04] hover:border-zinc-700 
+                     transition-colors duration-200"
+        >
+          <span className={`inline-block w-1.5 h-1.5 rounded-full ${connected ? 'bg-[#76B900]' : 'bg-zinc-500'}`} />
+          Console Logs
+          <span className="text-zinc-600 ml-auto">
+            {connected ? '● Live' : '○ Disconnected'}
+          </span>
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="shrink-0 mt-2" onKeyDown={handleKeyDown}>
+      {/* Header bar */}
+      <div className="flex items-center gap-2 px-3 py-1.5 bg-[#111115] rounded-t-md border border-white/[0.04] border-b-0 flex-wrap">
+        <button
+          onClick={() => { setCollapsed(true); onExpandChange?.(false) }}
+          className="text-xs font-medium text-zinc-400 hover:text-zinc-200 transition-colors shrink-0"
+        >
+          ▼ Console Logs
+        </button>
+
+        {/* Connection indicator */}
+        <span className={`inline-block w-1.5 h-1.5 rounded-full ${connected ? 'bg-[#76B900]' : 'bg-zinc-500'}`} />
+
+        {/* Pause/Resume button */}
+        <button
+          onClick={togglePause}
+          className={`text-[11px] px-2 py-0.5 rounded font-medium transition-colors shrink-0 ${
+            paused
+              ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30'
+              : 'text-zinc-400 hover:text-zinc-200'
+          }`}
+          title={paused ? 'Resume — jump to latest' : 'Pause — freeze viewport'}
+        >
+          {paused ? '⏸ Paused' : '⏵ Live'}
+        </button>
+
+        {/* Line count */}
+        <span className="text-[10px] text-zinc-600 shrink-0">
+          {filteredLogs.length}/{logs.length}
+        </span>
+
+        {/* Scroll-to-bottom button (only when not auto-scrolling) */}
+        {!autoScroll && !paused && (
+          <button
+            onClick={() => {
+              setAutoScroll(true)
+              if (containerRef.current) {
+                containerRef.current.scrollTop = containerRef.current.scrollHeight
+              }
+            }}
+            className="text-[10px] text-yellow-400 hover:text-yellow-300 shrink-0"
+          >
+            ↓ Auto-scroll
+          </button>
+        )}
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-2 px-3 py-1 bg-[#0d0d11] border-x border-white/[0.04]">
+        <button
+          onClick={() => setExcludeMode(!excludeMode)}
+          className={`text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0 border transition-colors ${
+            excludeMode
+              ? 'bg-red-500/15 text-red-400 border-red-500/30'
+              : 'bg-blue-500/15 text-blue-400 border-blue-500/30'
+          }`}
+          title={excludeMode ? 'Exclude mode — hides matching lines' : 'Filter mode — shows only matching lines'}
+        >
+          {excludeMode ? 'Exclude' : 'Filter'}
+        </button>
+        <svg className="w-3 h-3 text-zinc-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+        </svg>
+        <input
+          ref={filterRef}
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={excludeMode ? 'Exclude lines containing...' : 'Filter lines containing...'}
+          className="flex-1 bg-transparent text-[11px] text-zinc-300 placeholder-zinc-600 outline-none border-none"
+        />
+        {filter && (
+          <button
+            onClick={() => setFilter('')}
+            className="text-[10px] text-zinc-500 hover:text-zinc-300 shrink-0"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Log content */}
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className={`h-48 overflow-y-auto bg-black/60 rounded-b-md border border-white/[0.04] 
+                   font-mono text-[11px] leading-[1.4] p-2 space-y-0.5 ${paused ? 'opacity-60' : ''}`}
+        style={{ scrollBehavior: 'smooth' }}
+      >
+        {logs.length === 0 && (
+          <div className="text-zinc-600 italic text-center pt-8">
+            {connected ? 'Waiting for log output...' : 'Connecting...'}
+          </div>
+        )}
+
+        {filteredLogs.length === 0 && logs.length > 0 && (
+          <div className="text-zinc-600 italic text-center pt-8">
+            No lines match &quot;{filter}&quot;
+          </div>
+        )}
+
+        {filteredLogs.map((line, i) => {
+          const isError = line.toLowerCase().includes('error') || line.toLowerCase().includes('traceback')
+          const isWarning = line.toLowerCase().includes('warn') || line.toLowerCase().includes('warning')
+          return (
+            <div
+              key={i}
+              className={`whitespace-pre-wrap break-all ${
+                isError
+                  ? 'text-red-400'
+                  : isWarning
+                    ? 'text-yellow-400'
+                    : 'text-zinc-300'
+              }`}
+            >
+              {line}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/engines/EngineCard.tsx
+++ b/frontend/src/components/engines/EngineCard.tsx
@@ -64,6 +64,7 @@ interface EngineCardProps {
   ttftHistory?: number[]
   kvHistory?: number[]
   showCharts?: boolean
+  collapseCharts?: boolean
   chartData?: {
     tps: ChartDataPoint[]
     avgTps: ChartDataPoint[]
@@ -102,6 +103,7 @@ interface EngineCardProps {
 export function EngineCard({
   engine,
   showCharts = false,
+  collapseCharts = false,
   chartData,
   requests,
   latencyMode = 'avg',
@@ -344,7 +346,7 @@ export function EngineCard({
           {/* Chart columns mirror metric-card columns:
            *   1 Prefill · 2 Decode · 3 Latency · 4 SLO Goodput · 5 Requests · 6 Cache
            * E2E sits under SLO Goodput (col 4); Requests under col 5; KV under Cache (col 6). */}
-          {showCharts && chartData && (
+          {showCharts && !collapseCharts && chartData && (
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 pt-1">
               <TimeSeriesChart
                 title="Prefill Throughput (tok/s)"

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -119,6 +119,7 @@ interface EngineChartData {
 interface EngineSectionProps {
   engines: EngineSnapshot[]
   showCharts?: boolean
+  collapseCharts?: boolean
   getChartData?: (metric: string) => ChartDataPoint[]
   requests?: InferenceRequest[]
   /** Number of GPUs in the host snapshot. The per-engine GPU badge renders
@@ -131,6 +132,7 @@ interface EngineSectionProps {
 export function EngineSection({
   engines,
   showCharts = false,
+  collapseCharts = false,
   getChartData,
   requests,
   gpuCount = 0,
@@ -497,6 +499,7 @@ export function EngineSection({
                 <EngineCard
                   engine={engine}
                   showCharts={showCharts}
+                  collapseCharts={collapseCharts}
                   chartData={chartDataForEngine}
                   requests={requests}
                   latencyMode={latencyMode}

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -19,6 +19,7 @@ interface DashboardProps {
   }
   events: GpuEvent[]
   requests: InferenceRequest[]
+  collapseCharts?: boolean
 }
 
 function HwCard({ title, subtitle, children }: { title?: string; subtitle?: string; children: React.ReactNode }) {
@@ -61,6 +62,7 @@ export function Dashboard({
   history,
   events,
   requests,
+  collapseCharts = false,
 }: DashboardProps) {
   // Which GPU the hardware chart panels show on multi-GPU hosts. Held above
   // the early return so incoming snapshots cannot reset it.
@@ -172,6 +174,7 @@ export function Dashboard({
         <EngineSection
           engines={metrics.engines}
           showCharts={showEngineCharts}
+          collapseCharts={collapseCharts}
           getChartData={history.getChartData}
           requests={requests}
           gpuCount={gpus.length}


### PR DESCRIPTION
## Collapsible log viewer with WebSocket streaming

Adds a `LogViewer` component — a collapsible console panel at the bottom of the dashboard that streams Docker container logs in real-time via the `/ws/logs` WebSocket endpoint.

**Depends on PR #48** for the backend log streaming API (`/ws/logs` WebSocket endpoint, `bollard` Docker integration). This PR adds the frontend UI only.

### Features

- **Collapsible** — collapsed by default, click "Console Logs" to expand
- **Pause/Resume** — freeze the viewport to read, unpause to jump to latest
- **Text filter** with include/exclude modes
- **Auto-scroll** — sticks to bottom; pauses when user scrolls up
- **Color highlighting** — error lines in red, warnings in yellow
- **Connection indicator** — green dot when connected, gray when disconnected
- **1000-line ring buffer**
- **Ctrl+F / Cmd+F** — focuses the filter input

### Layout behavior

When the console expands, the engine chart row collapses to make room. Hardware cards stay fully visible. `collapseCharts` prop threaded through `App -> Dashboard -> EngineSection -> EngineCard`.

### Files changed (frontend-only)

- `LogViewer.tsx` — new component (245 lines)
- `LogViewer.test.tsx` — 13 unit tests
- `App.tsx` — import, render, console expanded state
- `Dashboard.tsx` — `collapseCharts` prop passthrough
- `EngineSection.tsx` — `collapseCharts` prop passthrough
- `EngineCard.tsx` — `collapseCharts` hides chart row when true

### Testing

- 183/183 frontend tests pass (13 new)
- `npm run build` passes
- No backend/Rust changes
