### PR TITLE
feat(logs): engine-synced container log viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "axum",
  "bollard",
  "clap",
+ "futures-util",
  "mime_guess",
  "nvml-wrapper",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ mime_guess = "2"
 reqwest = { version = "0.13", features = ["json"] }
 async-trait = "0.1"
 prometheus-parse = "0.2"
+futures-util = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nvml-wrapper = "0.12"

--- a/README.md
+++ b/README.md
@@ -256,6 +256,28 @@ engines too. Model info is resolved from `/v1/models` once and cached —
 re-resolved only on engine restart or every 10 minutes — so an auth-gated
 engine is no longer hit on every poll tick.
 
+### Log viewer (`--enable-log-viewer`, Linux only, opt-in)
+
+`--enable-log-viewer` (or the `SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1` env var)
+registers an extra `/ws/logs` WebSocket endpoint that streams the tracked
+engine container's Docker logs directly to the dashboard, using the bollard
+Docker API (no `docker` CLI or shell required — works in distroless images).
+
+- **Off by default.** Nothing is exposed unless the flag is passed.
+- **`/ws/logs` is unauthenticated.** The dashboard binds `0.0.0.0` by default
+  and the WebSocket has no auth layer, so anyone who can reach the port can
+  read the stream.
+- **Engine logs can contain sensitive data.** Inference-engine logs commonly
+  include prompts, request payloads, and API keys passed on the command line.
+  Treat the endpoint as equivalent to `docker logs` access.
+- **Recommendation: only enable on trusted networks.** Put the dashboard behind
+  a reverse proxy with auth, bind to `127.0.0.1`/`--bind 127.0.0.1`, or
+  restrict the port with a firewall. Do not enable on a public-facing host.
+
+The stream is shared: one background Docker log stream fans out to all
+connected clients (same pattern as metrics). stdout and stderr are line-buffered
+so split frames don't produce partial lines.
+
 ## Development
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -274,9 +274,13 @@ Docker API (no `docker` CLI or shell required — works in distroless images).
   a reverse proxy with auth, bind to `127.0.0.1`/`--bind 127.0.0.1`, or
   restrict the port with a firewall. Do not enable on a public-facing host.
 
-The stream is shared: one background Docker log stream fans out to all
-connected clients (same pattern as metrics). stdout and stderr are line-buffered
-so split frames don't produce partial lines.
+The stream follows the engine selected in the dashboard: the frontend passes
+the engine's endpoint as `/ws/logs?engine=<endpoint>`, which is validated
+against the tracked engine state — only containers the dashboard knows as
+engines can be streamed. Per container, one background Docker log stream fans
+out to all clients watching it (same pattern as metrics) and stops when the
+last viewer disconnects. stdout and stderr are line-buffered so split frames
+don't produce partial lines.
 
 ## Development
 

--- a/deploy/docker/.env.docker.example
+++ b/deploy/docker/.env.docker.example
@@ -25,6 +25,10 @@ SPARK_DASHBOARD_GPU_INDEX=0
 # SPARK_DASHBOARD_SIMULATE_GPUS=1
 # Fallback API key applied to engine endpoints without an explicit key.
 # SPARK_DASHBOARD_PROVIDER_API_KEY=
+# Opt-in log viewer: streams the selected engine's container logs at /ws/logs.
+# Off by default — the endpoint is unauthenticated and engine logs can contain
+# prompts/keys; read the README's "Log viewer" section before enabling.
+# SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1
 
 # --- Logging ------------------------------------------------------------------
 # error | warn | info | debug | trace (or per-module, e.g. spark_dashboard=debug)

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -55,6 +55,10 @@ services:
       - SPARK_DASHBOARD_GPU_INDEX
       - SPARK_DASHBOARD_SIMULATE_GPUS=${SPARK_DASHBOARD_SIMULATE_GPUS:-0}
       - SPARK_DASHBOARD_PROVIDER_API_KEY=${SPARK_DASHBOARD_PROVIDER_API_KEY:-}
+      # Opt-in log viewer (/ws/logs). Off by default: the endpoint is
+      # unauthenticated and engine logs can contain prompts — see the README's
+      # "Log viewer" section before enabling.
+      - SPARK_DASHBOARD_ENABLE_LOG_VIEWER=${SPARK_DASHBOARD_ENABLE_LOG_VIEWER:-0}
       - RUST_LOG=${RUST_LOG:-info}
 
     restart: unless-stopped

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,14 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useMetrics } from './hooks/useMetrics'
 import { useMetricsHistory } from './hooks/useMetricsHistory'
 import { ConnectionBadge } from './components/ConnectionBadge'
 import { Dashboard } from './components/views/Dashboard'
+import { LogViewer } from './components/LogViewer'
 import type { GpuEvent, InferenceRequest } from './types/events'
 
 function App() {
   const { metrics, connectionStatus, isStale } = useMetrics()
+  const [consoleExpanded, setConsoleExpanded] = useState(false)
 
   const history = useMetricsHistory(metrics)
 
@@ -59,7 +61,10 @@ function App() {
           history={history}
           events={events}
           requests={requests}
+          collapseCharts={consoleExpanded}
         />
+
+        <LogViewer onExpandChange={setConsoleExpanded} />
       </main>
     </div>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useMetrics } from './hooks/useMetrics'
 import { useMetricsHistory } from './hooks/useMetricsHistory'
 import { ConnectionBadge } from './components/ConnectionBadge'
@@ -9,6 +9,12 @@ import type { GpuEvent, InferenceRequest } from './types/events'
 function App() {
   const { metrics, connectionStatus, isStale } = useMetrics()
   const [consoleExpanded, setConsoleExpanded] = useState(false)
+  // Endpoint of the engine tab selected in the engine section (null = Global
+  // tab). The log viewer follows it so logs stay in sync with the selection.
+  const [selectedEngineEndpoint, setSelectedEngineEndpoint] = useState<string | null>(null)
+  const handleActiveEngineChange = useCallback((endpoint: string | undefined) => {
+    setSelectedEngineEndpoint(endpoint ?? null)
+  }, [])
 
   const history = useMetricsHistory(metrics)
 
@@ -62,9 +68,14 @@ function App() {
           events={events}
           requests={requests}
           collapseCharts={consoleExpanded}
+          onActiveEngineChange={handleActiveEngineChange}
         />
 
-        <LogViewer onExpandChange={setConsoleExpanded} />
+        <LogViewer
+          engines={metrics?.engines ?? []}
+          selectedEndpoint={selectedEngineEndpoint}
+          onExpandChange={setConsoleExpanded}
+        />
       </main>
     </div>
   )

--- a/frontend/src/__tests__/LogViewer.test.tsx
+++ b/frontend/src/__tests__/LogViewer.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { LogViewer } from '../components/LogViewer'
+
+// Mock WebSocket
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  readyState = 0
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  close() {
+    this.readyState = 3
+    if (this.onclose) this.onclose(new CloseEvent('close'))
+  }
+
+  send(_data: string) {}
+
+  // Helper to simulate server messages
+  receive(data: string) {
+    if (this.onmessage) this.onmessage(new MessageEvent('message', { data }))
+  }
+
+  // Helper to simulate connection
+  connect() {
+    this.readyState = 1
+    if (this.onopen) this.onopen(new Event('open'))
+  }
+}
+
+// Restore original WebSocket type for the mock
+(globalThis as any).WebSocket = MockWebSocket as unknown as typeof WebSocket
+
+describe('LogViewer', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders collapsed by default', () => {
+    render(<LogViewer />)
+    expect(screen.getByText('Console Logs')).toBeDefined()
+    // Should not show the expanded log panel
+    expect(screen.queryByText('▼ Console Logs')).toBeNull()
+  })
+
+  it('shows disconnected state when collapsed', () => {
+    render(<LogViewer />)
+    expect(screen.getByText('○ Disconnected')).toBeDefined()
+  })
+
+  it('expands when clicked', () => {
+    render(<LogViewer />)
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('▼ Console Logs')).toBeDefined()
+  })
+
+  it('collapses when expanded and collapse button clicked', () => {
+    render(<LogViewer />)
+    // Expand
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('▼ Console Logs')).toBeDefined()
+    // Collapse
+    fireEvent.click(screen.getByText('▼ Console Logs'))
+    expect(screen.queryByText('▼ Console Logs')).toBeNull()
+    expect(screen.getByText('Console Logs')).toBeDefined()
+  })
+
+  it('connects to WebSocket on mount', () => {
+    render(<LogViewer />)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.instances[0].url).toContain('/ws/logs')
+  })
+
+  it('shows live indicator when connected', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    expect(screen.getByText('● Live')).toBeDefined()
+  })
+
+  it('displays log messages from WebSocket', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    // Expand
+    fireEvent.click(screen.getByText('Console Logs'))
+    // Receive a log line
+    act(() => ws.receive('INFO: Server started on port 3000'))
+    expect(screen.getByText('INFO: Server started on port 3000')).toBeDefined()
+  })
+
+  it('filters log lines by text', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    act(() => {
+      ws.receive('ERROR: something broke')
+      ws.receive('INFO: all good')
+    })
+    // Both should be visible initially
+    expect(screen.getByText('ERROR: something broke')).toBeDefined()
+    expect(screen.getByText('INFO: all good')).toBeDefined()
+    // Type filter
+    const input = screen.getByPlaceholderText('Filter lines containing...')
+    fireEvent.change(input, { target: { value: 'error' } })
+    expect(screen.getByText('ERROR: something broke')).toBeDefined()
+    expect(screen.queryByText('INFO: all good')).toBeNull()
+  })
+
+  it('shows paused state when pause button clicked', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    fireEvent.click(screen.getByText('⏵ Live'))
+    expect(screen.getByText('⏸ Paused')).toBeDefined()
+  })
+
+  it('shows waiting message when connected but no logs', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('Waiting for log output...')).toBeDefined()
+  })
+
+  it('shows connecting message when not connected', () => {
+    render(<LogViewer />)
+    fireEvent.click(screen.getByText('Console Logs'))
+    expect(screen.getByText('Connecting...')).toBeDefined()
+  })
+
+  it('highlights error lines in red', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    act(() => ws.receive('ERROR: critical failure'))
+    const errorLine = screen.getByText('ERROR: critical failure')
+    expect(errorLine.className).toContain('text-red-400')
+  })
+
+  it('highlights warning lines in yellow', () => {
+    render(<LogViewer />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.connect())
+    fireEvent.click(screen.getByText('Console Logs'))
+    act(() => ws.receive('WARN: deprecated function used'))
+    const warnLine = screen.getByText('WARN: deprecated function used')
+    expect(warnLine.className).toContain('text-yellow-400')
+  })
+})

--- a/frontend/src/__tests__/LogViewer.test.tsx
+++ b/frontend/src/__tests__/LogViewer.test.tsx
@@ -1,6 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { LogViewer } from '../components/LogViewer'
+import type { EngineSnapshot } from '../types/metrics'
+
+const engine = (
+  endpoint: string,
+  mode: 'Docker' | 'Native' = 'Docker',
+): EngineSnapshot => ({
+  engine_type: 'Vllm',
+  endpoint,
+  status: { type: 'Running' },
+  model: null,
+  metrics: null,
+  recent_requests: [],
+  deployment_mode: mode,
+  gpu_indexes: [],
+})
 
 // Mock WebSocket
 class MockWebSocket {
@@ -39,6 +54,13 @@ class MockWebSocket {
 // Restore original WebSocket type for the mock
 (globalThis as any).WebSocket = MockWebSocket as unknown as typeof WebSocket
 
+/** Expand the console (which lazily opens the socket) and return the socket. */
+function expand(): MockWebSocket {
+  fireEvent.click(screen.getByText('▶ Console Logs'))
+  expect(MockWebSocket.instances.length).toBeGreaterThan(0)
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1]
+}
+
 describe('LogViewer', () => {
   beforeEach(() => {
     MockWebSocket.instances = []
@@ -51,62 +73,52 @@ describe('LogViewer', () => {
 
   it('renders collapsed by default', () => {
     render(<LogViewer />)
-    expect(screen.getByText('Console Logs')).toBeDefined()
+    expect(screen.getByText('▶ Console Logs')).toBeDefined()
     // Should not show the expanded log panel
     expect(screen.queryByText('▼ Console Logs')).toBeNull()
   })
 
-  it('shows disconnected state when collapsed', () => {
+  it('does not open a socket while collapsed (lazy connect)', () => {
     render(<LogViewer />)
-    expect(screen.getByText('○ Disconnected')).toBeDefined()
+    expect(MockWebSocket.instances).toHaveLength(0)
+    expect(screen.getByText('click to stream')).toBeDefined()
   })
 
-  it('expands when clicked', () => {
+  it('connects on first expand', () => {
     render(<LogViewer />)
-    fireEvent.click(screen.getByText('Console Logs'))
-    expect(screen.getByText('▼ Console Logs')).toBeDefined()
-  })
-
-  it('collapses when expanded and collapse button clicked', () => {
-    render(<LogViewer />)
-    // Expand
-    fireEvent.click(screen.getByText('Console Logs'))
-    expect(screen.getByText('▼ Console Logs')).toBeDefined()
-    // Collapse
-    fireEvent.click(screen.getByText('▼ Console Logs'))
-    expect(screen.queryByText('▼ Console Logs')).toBeNull()
-    expect(screen.getByText('Console Logs')).toBeDefined()
-  })
-
-  it('connects to WebSocket on mount', () => {
-    render(<LogViewer />)
+    const ws = expand()
     expect(MockWebSocket.instances).toHaveLength(1)
-    expect(MockWebSocket.instances[0].url).toContain('/ws/logs')
+    expect(ws.url).toContain('/ws/logs')
   })
 
-  it('shows live indicator when connected', () => {
+  it('closes the socket when collapsed again', () => {
     render(<LogViewer />)
-    const ws = MockWebSocket.instances[0]
+    const ws = expand()
     act(() => ws.connect())
-    expect(screen.getByText('● Live')).toBeDefined()
+    fireEvent.click(screen.getByText('▼ Console Logs'))
+    expect(ws.readyState).toBe(3)
+    expect(screen.getByText('▶ Console Logs')).toBeDefined()
+  })
+
+  it('shows live state when connected', () => {
+    render(<LogViewer />)
+    const ws = expand()
+    act(() => ws.connect())
+    expect(screen.getByText('⏵ Live')).toBeDefined()
   })
 
   it('displays log messages from WebSocket', () => {
     render(<LogViewer />)
-    const ws = MockWebSocket.instances[0]
+    const ws = expand()
     act(() => ws.connect())
-    // Expand
-    fireEvent.click(screen.getByText('Console Logs'))
-    // Receive a log line
     act(() => ws.receive('INFO: Server started on port 3000'))
     expect(screen.getByText('INFO: Server started on port 3000')).toBeDefined()
   })
 
   it('filters log lines by text', () => {
     render(<LogViewer />)
-    const ws = MockWebSocket.instances[0]
+    const ws = expand()
     act(() => ws.connect())
-    fireEvent.click(screen.getByText('Console Logs'))
     act(() => {
       ws.receive('ERROR: something broke')
       ws.receive('INFO: all good')
@@ -123,32 +135,52 @@ describe('LogViewer', () => {
 
   it('shows paused state when pause button clicked', () => {
     render(<LogViewer />)
-    const ws = MockWebSocket.instances[0]
+    const ws = expand()
     act(() => ws.connect())
-    fireEvent.click(screen.getByText('Console Logs'))
     fireEvent.click(screen.getByText('⏵ Live'))
     expect(screen.getByText('⏸ Paused')).toBeDefined()
   })
 
   it('shows waiting message when connected but no logs', () => {
     render(<LogViewer />)
-    const ws = MockWebSocket.instances[0]
+    const ws = expand()
     act(() => ws.connect())
-    fireEvent.click(screen.getByText('Console Logs'))
     expect(screen.getByText('Waiting for log output...')).toBeDefined()
   })
 
-  it('shows connecting message when not connected', () => {
+  it('shows connecting message before the socket opens', () => {
     render(<LogViewer />)
-    fireEvent.click(screen.getByText('Console Logs'))
+    expand()
     expect(screen.getByText('Connecting...')).toBeDefined()
+  })
+
+  it('shows the not-enabled hint when the handshake never succeeds', () => {
+    render(<LogViewer />)
+    const ws = expand()
+    // Close without ever opening: /ws/logs is not registered on the backend.
+    act(() => ws.close())
+    expect(
+      screen.getByText(/Log viewer not enabled on this server/),
+    ).toBeDefined()
+    // No retry loop against a doomed endpoint.
+    act(() => vi.advanceTimersByTime(10000))
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('reconnects after a dropped live connection', () => {
+    render(<LogViewer />)
+    const ws = expand()
+    act(() => ws.connect())
+    act(() => ws.close())
+    expect(screen.getByText(/reconnecting/)).toBeDefined()
+    act(() => vi.advanceTimersByTime(2000))
+    expect(MockWebSocket.instances).toHaveLength(2)
   })
 
   it('highlights error lines in red', () => {
     render(<LogViewer />)
-    const ws = MockWebSocket.instances[0]
+    const ws = expand()
     act(() => ws.connect())
-    fireEvent.click(screen.getByText('Console Logs'))
     act(() => ws.receive('ERROR: critical failure'))
     const errorLine = screen.getByText('ERROR: critical failure')
     expect(errorLine.className).toContain('text-red-400')
@@ -156,11 +188,64 @@ describe('LogViewer', () => {
 
   it('highlights warning lines in yellow', () => {
     render(<LogViewer />)
-    const ws = MockWebSocket.instances[0]
+    const ws = expand()
     act(() => ws.connect())
-    fireEvent.click(screen.getByText('Console Logs'))
     act(() => ws.receive('WARN: deprecated function used'))
     const warnLine = screen.getByText('WARN: deprecated function used')
     expect(warnLine.className).toContain('text-yellow-400')
+  })
+
+  it('passes the selected engine endpoint as ?engine=', () => {
+    render(
+      <LogViewer
+        engines={[engine('http://localhost:8000'), engine('http://localhost:8100')]}
+        selectedEndpoint="http://localhost:8100"
+      />,
+    )
+    const ws = expand()
+    expect(ws.url).toContain(
+      `/ws/logs?engine=${encodeURIComponent('http://localhost:8100')}`,
+    )
+  })
+
+  it('falls back to the first Docker engine when no engine is selected', () => {
+    render(
+      <LogViewer
+        engines={[engine('http://localhost:8000', 'Native'), engine('http://localhost:8100')]}
+        selectedEndpoint={null}
+      />,
+    )
+    const ws = expand()
+    expect(ws.url).toContain(
+      `/ws/logs?engine=${encodeURIComponent('http://localhost:8100')}`,
+    )
+  })
+
+  it('reconnects and clears the buffer when the selected engine changes', () => {
+    const engines = [engine('http://localhost:8000'), engine('http://localhost:8100')]
+    const { rerender } = render(
+      <LogViewer engines={engines} selectedEndpoint="http://localhost:8000" />,
+    )
+    const ws = expand()
+    act(() => ws.connect())
+    act(() => ws.receive('line from engine 8000'))
+    expect(screen.getByText('line from engine 8000')).toBeDefined()
+
+    rerender(<LogViewer engines={engines} selectedEndpoint="http://localhost:8100" />)
+
+    // A second socket is opened against the newly selected engine…
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(MockWebSocket.instances[1].url).toContain(
+      `/ws/logs?engine=${encodeURIComponent('http://localhost:8100')}`,
+    )
+    // …and the previous engine's lines are dropped.
+    expect(screen.queryByText('line from engine 8000')).toBeNull()
+  })
+
+  it('shows which engine is being streamed in the header', () => {
+    render(
+      <LogViewer engines={[engine('http://localhost:8000')]} selectedEndpoint="http://localhost:8000" />,
+    )
+    expect(screen.getByText('http://localhost:8000')).toBeDefined()
   })
 })

--- a/frontend/src/__tests__/LogViewer.test.tsx
+++ b/frontend/src/__tests__/LogViewer.test.tsx
@@ -242,6 +242,46 @@ describe('LogViewer', () => {
     expect(screen.queryByText('line from engine 8000')).toBeNull()
   })
 
+  it('does not show the auto-scroll indicator while following the stream', () => {
+    render(<LogViewer />)
+    const ws = expand()
+    act(() => ws.connect())
+    act(() => {
+      ws.receive('line 1')
+      ws.receive('line 2')
+      ws.receive('line 3')
+    })
+    // Following the bottom: no resume affordance should appear just because
+    // new lines came in.
+    expect(screen.queryByText('↓ Auto-scroll')).toBeNull()
+  })
+
+  it('shows the auto-scroll indicator only after scrolling back, hides it at the bottom', () => {
+    const { container } = render(<LogViewer />)
+    const ws = expand()
+    act(() => ws.connect())
+    act(() => ws.receive('line 1'))
+
+    const scroller = container.querySelector('.overflow-y-auto') as HTMLElement
+    Object.defineProperty(scroller, 'scrollHeight', { configurable: true, value: 1000 })
+    Object.defineProperty(scroller, 'clientHeight', { configurable: true, value: 200 })
+
+    // User scrolls back up: resume affordance appears.
+    scroller.scrollTop = 100
+    fireEvent.scroll(scroller)
+    expect(screen.getByText('↓ Auto-scroll')).toBeDefined()
+
+    // New lines while scrolled back must not touch the viewport or the button.
+    act(() => ws.receive('line 2'))
+    expect(scroller.scrollTop).toBe(100)
+    expect(screen.getByText('↓ Auto-scroll')).toBeDefined()
+
+    // Back at the bottom (within the 50px threshold): affordance disappears.
+    scroller.scrollTop = 990
+    fireEvent.scroll(scroller)
+    expect(screen.queryByText('↓ Auto-scroll')).toBeNull()
+  })
+
   it('shows which engine is being streamed in the header', () => {
     render(
       <LogViewer engines={[engine('http://localhost:8000')]} selectedEndpoint="http://localhost:8000" />,

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,0 +1,245 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+
+/**
+ * Scrollable log viewer that connects to the backend's /ws/logs WebSocket
+ * endpoint and streams Docker container logs in real-time.
+ *
+ * Features:
+ * - Collapsible section at the bottom of the dashboard
+ * - Pause/Resume button — freeze the viewport to read, unpause to catch up
+ * - Text filter — type a keyword to only show lines containing it
+ * - Auto-scroll to newest lines (pauses when scrolled up manually)
+ * - Error/warning color highlighting
+ */
+export function LogViewer({ onExpandChange }: { onExpandChange?: (expanded: boolean) => void }) {
+  const [logs, setLogs] = useState<string[]>([])
+  const [connected, setConnected] = useState(false)
+  const [collapsed, setCollapsed] = useState(true)
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [paused, setPaused] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [excludeMode, setExcludeMode] = useState(false)
+  const filterRef = useRef<HTMLInputElement>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const wsUrl = `${protocol}//${window.location.host}/ws/logs`
+    const ws = new WebSocket(wsUrl)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setConnected(true)
+    }
+
+    ws.onmessage = (event) => {
+      const text = event.data as string
+      setLogs((prev) => {
+        const next = [...prev, text]
+        return next.length > 1000 ? next.slice(-1000) : next
+      })
+    }
+
+    ws.onclose = () => {
+      setConnected(false)
+      wsRef.current = null
+    }
+
+    ws.onerror = () => {
+      ws.close()
+    }
+
+    return () => {
+      ws.close()
+      wsRef.current = null
+    }
+  }, [])
+
+  // Auto-scroll when new logs arrive (only if not paused)
+  useEffect(() => {
+    if (autoScroll && !paused && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [logs, autoScroll, paused])
+
+  const handleScroll = () => {
+    if (!containerRef.current) return
+    const el = containerRef.current
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50
+    setAutoScroll(atBottom)
+  }
+
+  // Filtered log lines — computed from the full buffer
+  const filteredLogs = useMemo(() => {
+    if (!filter.trim()) return logs
+    const lower = filter.toLowerCase()
+    return excludeMode
+      ? logs.filter((line) => !line.toLowerCase().includes(lower))
+      : logs.filter((line) => line.toLowerCase().includes(lower))
+  }, [logs, filter, excludeMode])
+
+  // Toggle pause/resume
+  const togglePause = () => {
+    const next = !paused
+    setPaused(next)
+    if (!next) {
+      // Unpausing: jump to bottom
+      setAutoScroll(true)
+      if (containerRef.current) {
+        containerRef.current.scrollTop = containerRef.current.scrollHeight
+      }
+    }
+  }
+
+  // Keyboard shortcut: Ctrl+F / Cmd+F to focus the filter input
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+      e.preventDefault()
+      filterRef.current?.focus()
+    }
+  }
+
+  if (collapsed) {
+    return (
+      <div className="shrink-0 mt-2">
+        <button
+          onClick={() => { setCollapsed(false); onExpandChange?.(true) }}
+          className="w-full flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-zinc-400 
+                     bg-[#111115] rounded-md border border-white/[0.04] hover:border-zinc-700 
+                     transition-colors duration-200"
+        >
+          <span className={`inline-block w-1.5 h-1.5 rounded-full ${connected ? 'bg-[#76B900]' : 'bg-zinc-500'}`} />
+          Console Logs
+          <span className="text-zinc-600 ml-auto">
+            {connected ? '● Live' : '○ Disconnected'}
+          </span>
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="shrink-0 mt-2" onKeyDown={handleKeyDown}>
+      {/* Header bar */}
+      <div className="flex items-center gap-2 px-3 py-1.5 bg-[#111115] rounded-t-md border border-white/[0.04] border-b-0 flex-wrap">
+        <button
+          onClick={() => { setCollapsed(true); onExpandChange?.(false) }}
+          className="text-xs font-medium text-zinc-400 hover:text-zinc-200 transition-colors shrink-0"
+        >
+          ▼ Console Logs
+        </button>
+
+        {/* Connection indicator */}
+        <span className={`inline-block w-1.5 h-1.5 rounded-full ${connected ? 'bg-[#76B900]' : 'bg-zinc-500'}`} />
+
+        {/* Pause/Resume button */}
+        <button
+          onClick={togglePause}
+          className={`text-[11px] px-2 py-0.5 rounded font-medium transition-colors shrink-0 ${
+            paused
+              ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30'
+              : 'text-zinc-400 hover:text-zinc-200'
+          }`}
+          title={paused ? 'Resume — jump to latest' : 'Pause — freeze viewport'}
+        >
+          {paused ? '⏸ Paused' : '⏵ Live'}
+        </button>
+
+        {/* Line count */}
+        <span className="text-[10px] text-zinc-600 shrink-0">
+          {filteredLogs.length}/{logs.length}
+        </span>
+
+        {/* Scroll-to-bottom button (only when not auto-scrolling) */}
+        {!autoScroll && !paused && (
+          <button
+            onClick={() => {
+              setAutoScroll(true)
+              if (containerRef.current) {
+                containerRef.current.scrollTop = containerRef.current.scrollHeight
+              }
+            }}
+            className="text-[10px] text-yellow-400 hover:text-yellow-300 shrink-0"
+          >
+            ↓ Auto-scroll
+          </button>
+        )}
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-2 px-3 py-1 bg-[#0d0d11] border-x border-white/[0.04]">
+        <button
+          onClick={() => setExcludeMode(!excludeMode)}
+          className={`text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0 border transition-colors ${
+            excludeMode
+              ? 'bg-red-500/15 text-red-400 border-red-500/30'
+              : 'bg-blue-500/15 text-blue-400 border-blue-500/30'
+          }`}
+          title={excludeMode ? 'Exclude mode — hides matching lines' : 'Filter mode — shows only matching lines'}
+        >
+          {excludeMode ? 'Exclude' : 'Filter'}
+        </button>
+        <svg className="w-3 h-3 text-zinc-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+        </svg>
+        <input
+          ref={filterRef}
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={excludeMode ? 'Exclude lines containing...' : 'Filter lines containing...'}
+          className="flex-1 bg-transparent text-[11px] text-zinc-300 placeholder-zinc-600 outline-none border-none"
+        />
+        {filter && (
+          <button
+            onClick={() => setFilter('')}
+            className="text-[10px] text-zinc-500 hover:text-zinc-300 shrink-0"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Log content */}
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className={`h-48 overflow-y-auto bg-black/60 rounded-b-md border border-white/[0.04] 
+                   font-mono text-[11px] leading-[1.4] p-2 space-y-0.5 ${paused ? 'opacity-60' : ''}`}
+        style={{ scrollBehavior: 'smooth' }}
+      >
+        {logs.length === 0 && (
+          <div className="text-zinc-600 italic text-center pt-8">
+            {connected ? 'Waiting for log output...' : 'Connecting...'}
+          </div>
+        )}
+
+        {filteredLogs.length === 0 && logs.length > 0 && (
+          <div className="text-zinc-600 italic text-center pt-8">
+            No lines match &quot;{filter}&quot;
+          </div>
+        )}
+
+        {filteredLogs.map((line, i) => {
+          const isError = line.toLowerCase().includes('error') || line.toLowerCase().includes('traceback')
+          const isWarning = line.toLowerCase().includes('warn') || line.toLowerCase().includes('warning')
+          return (
+            <div
+              key={i}
+              className={`whitespace-pre-wrap break-all ${
+                isError
+                  ? 'text-red-400'
+                  : isWarning
+                    ? 'text-yellow-400'
+                    : 'text-zinc-300'
+              }`}
+            >
+              {line}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
+import type { EngineSnapshot } from '../types/metrics'
 
 /**
  * Scrollable log viewer that connects to the backend's /ws/logs WebSocket
  * endpoint and streams Docker container logs in real-time.
+ *
+ * The stream follows the engine selected in the engine section: when an
+ * engine tab is active its endpoint is passed as `?engine=` so the backend
+ * streams that engine's container; on the Global tab the first Docker engine
+ * is used (mirroring the backend's default). Switching engines reconnects
+ * and clears the buffer — the old lines belong to another container.
  *
  * Features:
  * - Collapsible section at the bottom of the dashboard
@@ -11,9 +18,24 @@ import { useState, useEffect, useRef, useMemo } from 'react'
  * - Auto-scroll to newest lines (pauses when scrolled up manually)
  * - Error/warning color highlighting
  */
-export function LogViewer({ onExpandChange }: { onExpandChange?: (expanded: boolean) => void }) {
+interface LogViewerProps {
+  /** Engine snapshots from the current metrics payload. */
+  engines?: EngineSnapshot[]
+  /** Endpoint of the engine tab selected in the engine section; null on the
+   *  Global tab. */
+  selectedEndpoint?: string | null
+  onExpandChange?: (expanded: boolean) => void
+}
+
+/** Connection lifecycle of the log socket. `idle` while collapsed (lazy
+ *  connect); `unavailable` when the handshake never succeeds — the backend
+ *  runs without --enable-log-viewer, so /ws/logs is not registered. */
+type LogConnState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'unavailable'
+
+export function LogViewer({ engines = [], selectedEndpoint = null, onExpandChange }: LogViewerProps) {
   const [logs, setLogs] = useState<string[]>([])
-  const [connected, setConnected] = useState(false)
+  const [connState, setConnState] = useState<LogConnState>('idle')
+  const connected = connState === 'connected'
   const [collapsed, setCollapsed] = useState(true)
   const [autoScroll, setAutoScroll] = useState(true)
   const [paused, setPaused] = useState(false)
@@ -23,38 +45,85 @@ export function LogViewer({ onExpandChange }: { onExpandChange?: (expanded: bool
   const wsRef = useRef<WebSocket | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
+  // Engine whose container is streamed: the selected tab's engine when one is
+  // active and still present, otherwise the first Docker engine (the backend
+  // applies the same default when no ?engine= is passed).
+  const targetEndpoint = useMemo(() => {
+    if (selectedEndpoint && engines.some((e) => e.endpoint === selectedEndpoint)) {
+      return selectedEndpoint
+    }
+    return engines.find((e) => e.deployment_mode === 'Docker')?.endpoint ?? null
+  }, [engines, selectedEndpoint])
+
+  const targetEngine = engines.find((e) => e.endpoint === targetEndpoint)
+  const engineLabel = targetEngine
+    ? (targetEngine.model?.name ?? targetEngine.endpoint)
+    : null
+
   useEffect(() => {
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const wsUrl = `${protocol}//${window.location.host}/ws/logs`
-    const ws = new WebSocket(wsUrl)
-    wsRef.current = ws
+    // Lazy connect: no socket (and no backend Docker stream) until the console
+    // is first expanded. Collapsing tears the socket down again, which also
+    // lets the backend stop the container stream once its last viewer leaves.
+    if (collapsed) return
 
-    ws.onopen = () => {
-      setConnected(true)
+    let disposed = false
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+    let everOpened = false
+    // Connecting fresh or to a different container: drop the previous lines.
+    setLogs([])
+    setConnState('connecting')
+
+    const connect = () => {
+      if (disposed) return
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const query = targetEndpoint ? `?engine=${encodeURIComponent(targetEndpoint)}` : ''
+      const ws = new WebSocket(`${protocol}//${window.location.host}/ws/logs${query}`)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        everOpened = true
+        setConnState('connected')
+      }
+
+      ws.onmessage = (event) => {
+        const text = event.data as string
+        setLogs((prev) => {
+          const next = [...prev, text]
+          return next.length > 1000 ? next.slice(-1000) : next
+        })
+      }
+
+      ws.onclose = () => {
+        wsRef.current = null
+        if (disposed) return
+        if (!everOpened) {
+          // Handshake never succeeded: /ws/logs is not registered (backend
+          // without --enable-log-viewer) or the server is unreachable. Don't
+          // retry a doomed endpoint; the next expand or engine switch retries.
+          setConnState('unavailable')
+          return
+        }
+        // Live connection dropped (backend restart, network): retry with a
+        // delay, like the metrics socket does.
+        setConnState('reconnecting')
+        retryTimer = setTimeout(connect, 2000)
+      }
+
+      ws.onerror = () => {
+        ws.close()
+      }
     }
 
-    ws.onmessage = (event) => {
-      const text = event.data as string
-      setLogs((prev) => {
-        const next = [...prev, text]
-        return next.length > 1000 ? next.slice(-1000) : next
-      })
-    }
-
-    ws.onclose = () => {
-      setConnected(false)
-      wsRef.current = null
-    }
-
-    ws.onerror = () => {
-      ws.close()
-    }
+    connect()
 
     return () => {
-      ws.close()
+      disposed = true
+      if (retryTimer) clearTimeout(retryTimer)
+      wsRef.current?.close()
       wsRef.current = null
+      setConnState('idle')
     }
-  }, [])
+  }, [collapsed, targetEndpoint])
 
   // Auto-scroll when new logs arrive (only if not paused)
   useEffect(() => {
@@ -109,11 +178,13 @@ export function LogViewer({ onExpandChange }: { onExpandChange?: (expanded: bool
                      bg-[#111115] rounded-md border border-white/[0.04] hover:border-zinc-700 
                      transition-colors duration-200"
         >
-          <span className={`inline-block w-1.5 h-1.5 rounded-full ${connected ? 'bg-[#76B900]' : 'bg-zinc-500'}`} />
-          Console Logs
-          <span className="text-zinc-600 ml-auto">
-            {connected ? '● Live' : '○ Disconnected'}
-          </span>
+          ▶ Console Logs
+          {engineLabel && (
+            <span className="text-[10px] text-zinc-600 truncate max-w-[240px]">
+              {engineLabel}
+            </span>
+          )}
+          <span className="text-zinc-600 ml-auto">click to stream</span>
         </button>
       </div>
     )
@@ -131,7 +202,23 @@ export function LogViewer({ onExpandChange }: { onExpandChange?: (expanded: bool
         </button>
 
         {/* Connection indicator */}
-        <span className={`inline-block w-1.5 h-1.5 rounded-full ${connected ? 'bg-[#76B900]' : 'bg-zinc-500'}`} />
+        <span
+          className={`inline-block w-1.5 h-1.5 rounded-full ${
+            connected
+              ? 'bg-[#76B900]'
+              : connState === 'reconnecting'
+                ? 'bg-yellow-400'
+                : 'bg-zinc-500'
+          }`}
+          title={connState}
+        />
+
+        {/* Which engine's container is being streamed */}
+        {engineLabel && (
+          <span className="text-[10px] text-zinc-600 truncate max-w-[240px] shrink-0">
+            {engineLabel}
+          </span>
+        )}
 
         {/* Pause/Resume button */}
         <button
@@ -211,7 +298,11 @@ export function LogViewer({ onExpandChange }: { onExpandChange?: (expanded: bool
       >
         {logs.length === 0 && (
           <div className="text-zinc-600 italic text-center pt-8">
-            {connected ? 'Waiting for log output...' : 'Connecting...'}
+            {connState === 'connected' && 'Waiting for log output...'}
+            {(connState === 'connecting' || connState === 'idle') && 'Connecting...'}
+            {connState === 'reconnecting' && 'Connection lost — reconnecting…'}
+            {connState === 'unavailable' &&
+              'Log viewer not enabled on this server — start the dashboard with --enable-log-viewer (or SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1).'}
           </div>
         )}
 

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -288,13 +288,15 @@ export function LogViewer({ engines = [], selectedEndpoint = null, onExpandChang
         )}
       </div>
 
-      {/* Log content */}
+      {/* Log content. Auto-follow must jump instantly: with smooth scrolling
+        * every appended line animates toward the bottom, and the scroll events
+        * fired mid-animation read as "not at bottom", flickering autoScroll
+        * (and the resume button) off and on with each batch. */}
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className={`h-48 overflow-y-auto bg-black/60 rounded-b-md border border-white/[0.04] 
+        className={`h-48 overflow-y-auto bg-black/60 rounded-b-md border border-white/[0.04]
                    font-mono text-[11px] leading-[1.4] p-2 space-y-0.5 ${paused ? 'opacity-60' : ''}`}
-        style={{ scrollBehavior: 'smooth' }}
       >
         {logs.length === 0 && (
           <div className="text-zinc-600 italic text-center pt-8">

--- a/frontend/src/components/engines/EngineCard.tsx
+++ b/frontend/src/components/engines/EngineCard.tsx
@@ -64,6 +64,7 @@ interface EngineCardProps {
   ttftHistory?: number[]
   kvHistory?: number[]
   showCharts?: boolean
+  collapseCharts?: boolean
   chartData?: {
     tps: ChartDataPoint[]
     avgTps: ChartDataPoint[]
@@ -102,6 +103,7 @@ interface EngineCardProps {
 export function EngineCard({
   engine,
   showCharts = false,
+  collapseCharts = false,
   chartData,
   requests,
   latencyMode = 'avg',
@@ -344,7 +346,7 @@ export function EngineCard({
           {/* Chart columns mirror metric-card columns:
            *   1 Prefill · 2 Decode · 3 Latency · 4 SLO Goodput · 5 Requests · 6 Cache
            * E2E sits under SLO Goodput (col 4); Requests under col 5; KV under Cache (col 6). */}
-          {showCharts && chartData && (
+          {showCharts && !collapseCharts && chartData && (
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 pt-1">
               <TimeSeriesChart
                 title="Prefill Throughput (tok/s)"

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -119,6 +119,7 @@ interface EngineChartData {
 interface EngineSectionProps {
   engines: EngineSnapshot[]
   showCharts?: boolean
+  collapseCharts?: boolean
   getChartData?: (metric: string) => ChartDataPoint[]
   requests?: InferenceRequest[]
   /** Number of GPUs in the host snapshot. The per-engine GPU badge renders
@@ -131,6 +132,7 @@ interface EngineSectionProps {
 export function EngineSection({
   engines,
   showCharts = false,
+  collapseCharts = false,
   getChartData,
   requests,
   gpuCount = 0,
@@ -497,6 +499,7 @@ export function EngineSection({
                 <EngineCard
                   engine={engine}
                   showCharts={showCharts}
+                  collapseCharts={collapseCharts}
                   chartData={chartDataForEngine}
                   requests={requests}
                   latencyMode={latencyMode}

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -125,6 +125,9 @@ interface EngineSectionProps {
   /** Number of GPUs in the host snapshot. The per-engine GPU badge renders
    *  only when there are 2+ — on single-GPU hosts the placement is trivial. */
   gpuCount?: number
+  /** Notify when the selected engine tab changes; undefined = Global tab.
+   *  The log viewer follows this to stream the selected engine's container. */
+  onActiveEngineChange?: (endpoint: string | undefined) => void
   /** Notify the hardware dashboard when the selected engine has known GPU placement. */
   onActiveEngineGpuChange?: (gpuIndexes?: number[]) => void
 }
@@ -136,6 +139,7 @@ export function EngineSection({
   getChartData,
   requests,
   gpuCount = 0,
+  onActiveEngineChange,
   onActiveEngineGpuChange,
 }: EngineSectionProps) {
   const [activeTab, setActiveTab] = useState<string>(() => {
@@ -243,6 +247,11 @@ export function EngineSection({
     (e) => `${e.engine_type}-${e.endpoint}` === activeTab,
   )
   const activeEngineGpuIndexesKey = activeEngine?.gpu_indexes?.join(',') ?? ''
+
+  const activeEngineEndpoint = isGlobal ? undefined : activeEngine?.endpoint
+  useEffect(() => {
+    onActiveEngineChange?.(activeEngineEndpoint)
+  }, [activeEngineEndpoint, onActiveEngineChange])
 
   useEffect(() => {
     if (isGlobal || !onActiveEngineGpuChange) return

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -19,6 +19,7 @@ interface DashboardProps {
   }
   events: GpuEvent[]
   requests: InferenceRequest[]
+  collapseCharts?: boolean
 }
 
 function HwCard({ title, subtitle, children }: { title?: string; subtitle?: string; children: React.ReactNode }) {
@@ -61,6 +62,7 @@ export function Dashboard({
   history,
   events,
   requests,
+  collapseCharts = false,
 }: DashboardProps) {
   // Which GPU the hardware chart panels show on multi-GPU hosts. Held above
   // the early return so incoming snapshots cannot reset it.
@@ -172,6 +174,7 @@ export function Dashboard({
         <EngineSection
           engines={metrics.engines}
           showCharts={showEngineCharts}
+          collapseCharts={collapseCharts}
           getChartData={history.getChartData}
           requests={requests}
           gpuCount={gpus.length}

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -20,6 +20,9 @@ interface DashboardProps {
   events: GpuEvent[]
   requests: InferenceRequest[]
   collapseCharts?: boolean
+  /** Forwarded to EngineSection; reports the selected engine tab's endpoint
+   *  (undefined = Global tab) so the log viewer can follow the selection. */
+  onActiveEngineChange?: (endpoint: string | undefined) => void
 }
 
 function HwCard({ title, subtitle, children }: { title?: string; subtitle?: string; children: React.ReactNode }) {
@@ -63,6 +66,7 @@ export function Dashboard({
   events,
   requests,
   collapseCharts = false,
+  onActiveEngineChange,
 }: DashboardProps) {
   // Which GPU the hardware chart panels show on multi-GPU hosts. Held above
   // the early return so incoming snapshots cannot reset it.
@@ -175,6 +179,7 @@ export function Dashboard({
           engines={metrics.engines}
           showCharts={showEngineCharts}
           collapseCharts={collapseCharts}
+          onActiveEngineChange={onActiveEngineChange}
           getChartData={history.getChartData}
           requests={requests}
           gpuCount={gpus.length}

--- a/src/engines/detector.rs
+++ b/src/engines/detector.rs
@@ -19,6 +19,11 @@ pub struct DetectedEngine {
     /// for the container. Matched against NVML's per-device compute-process
     /// lists to attribute the engine to the GPU(s) it runs on.
     pub pids: Vec<u32>,
+    /// Docker container id (full) when discovered via the Docker scan layer;
+    /// `None` for natively-detected engines. Used by the log viewer to stream
+    /// the same container the dashboard is showing metrics for, rather than
+    /// re-scanning and potentially picking a different one.
+    pub container_id: Option<String>,
 }
 
 /// Known engine binaries and their default ports.
@@ -91,6 +96,10 @@ fn merge_docker_candidates(
                     }
                 }
                 existing.pids.sort_unstable();
+                // Docker discovery is authoritative for container identity.
+                if existing.container_id.is_none() && dc.container_id.is_some() {
+                    existing.container_id = dc.container_id.clone();
+                }
             }
         } else {
             seen.insert(key);
@@ -154,6 +163,7 @@ fn detect_by_process(sys: &sysinfo::System) -> Vec<DetectedEngine> {
                         deployment_mode: DeploymentMode::Native,
                         served_model,
                         pids: vec![pid],
+                        container_id: None,
                     });
                 }
             }
@@ -511,6 +521,7 @@ pub async fn detect_docker_engines() -> Vec<DetectedEngine> {
                 deployment_mode: DeploymentMode::Docker,
                 served_model,
                 pids,
+                container_id: container.id.clone(),
             });
         } else {
             tracing::debug!(
@@ -715,6 +726,7 @@ mod tests {
             deployment_mode: mode,
             served_model: None,
             pids: pids.to_vec(),
+            container_id: None,
         }
     }
 

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -219,6 +219,12 @@ pub struct EngineSnapshot {
     /// part of the wire format.
     #[serde(skip_serializing)]
     pub pids: Vec<u32>,
+    /// Full Docker container id when the engine is running in a container
+    /// discovered via the Docker scan layer. Internal-only: not serialized to
+    /// the frontend (the dashboard has no use for it), but read by the log
+    /// viewer to stream the exact container the dashboard is showing.
+    #[serde(skip)]
+    pub container_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -266,6 +272,9 @@ pub struct EngineState {
     /// Host-namespace PIDs from the most recent detection tick. Empty for
     /// manual overrides until process/Docker detection also finds the engine.
     pub pids: Vec<u32>,
+    /// Docker container id captured at detection time (Linux Docker scan only).
+    /// Forwarded into each `EngineSnapshot` for the log viewer to consume.
+    pub container_id: Option<String>,
 }
 
 impl EngineState {
@@ -281,6 +290,7 @@ impl EngineState {
             model_fetched_at: None,
             model_attempted_at: None,
             pids: Vec::new(),
+            container_id: None,
         }
     }
 
@@ -523,7 +533,10 @@ pub async fn engine_collector_loop(
                             d.endpoint,
                             d.served_model,
                         );
-                        EngineState::new(adapter, d.deployment_mode.clone())
+                        let mut state =
+                            EngineState::new(adapter, d.deployment_mode.clone());
+                        state.container_id = d.container_id.clone();
+                        state
                     });
                     // Refresh the PID set every detection tick — engines
                     // restart and fork workers over their lifetime.
@@ -589,6 +602,7 @@ pub async fn engine_collector_loop(
                             deployment_mode: state.deployment_mode.clone(),
                             gpu_indexes: Vec::new(),
                             pids: state.pids.clone(),
+                            container_id: state.container_id.clone(),
                         });
                     }
                 }

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -1,0 +1,218 @@
+//! Docker container log streaming via the bollard API.
+//!
+//! Instead of shelling out to `docker logs -f` (which fails on distroless
+//! runtimes that have no shell or `docker` CLI), this module talks directly to
+//! the Docker daemon over its Unix socket via bollard.
+//!
+//! Stream characteristics:
+//! - stdout/stderr are multiplexed in real-time (not drained sequentially).
+//! - The WebSocket connects lazily -- the backend stream is only opened when a
+//!   client connects, not on page load.
+//! - Container discovery uses the Docker API directly rather than needing the
+//!   shared engine state wired into this handler.
+
+#![cfg(target_os = "linux")]
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use bollard::container::LogOutput;
+use bollard::query_parameters::{ListContainersOptionsBuilder, LogsOptionsBuilder};
+use bollard::Docker;
+use futures_util::StreamExt;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tracing::debug;
+
+/// Flag set at startup when `--enable-log-viewer` is passed.
+/// Read by `server.rs` to decide whether to register the `/ws/logs` route.
+static LOG_VIEWER_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable the log viewer feature. Called from `main.rs` when
+/// `--enable-log-viewer` is set.
+pub fn enable_log_viewer() {
+    LOG_VIEWER_ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Returns whether the log viewer was enabled at startup.
+pub fn is_log_viewer_enabled() -> bool {
+    LOG_VIEWER_ENABLED.load(Ordering::Relaxed)
+}
+
+/// WebSocket upgrade handler for `/ws/logs`.
+///
+/// The Docker log stream is started only when a client actually connects
+/// (lazy connect -- no background resource consumption while collapsed).
+pub async fn ws_logs_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_logs_socket)
+}
+
+async fn handle_logs_socket(mut socket: WebSocket) {
+    debug!("Logs WebSocket client connected");
+
+    // Connect to the Docker daemon over the local Unix socket.
+    let docker = match Docker::connect_with_local_defaults() {
+        Ok(d) => d,
+        Err(e) => {
+            let msg = format!("ERR:Could not connect to Docker daemon: {e}");
+            let _ = socket.send(Message::Text(msg.into())).await;
+            return;
+        }
+    };
+
+    // Find the first vLLM container via the Docker API.
+    let container_id = match find_container_via_docker(&docker).await {
+        Some(id) => id,
+        None => {
+            let msg = "ERR:No engine container found".to_string();
+            let _ = socket.send(Message::Text(msg.into())).await;
+            return;
+        }
+    };
+
+    debug!("Streaming logs for container: {container_id}");
+
+    let options = LogsOptionsBuilder::new()
+        .follow(true)
+        .stdout(true)
+        .stderr(true)
+        .tail("100")
+        .build();
+
+    let mut stream = docker.logs(&container_id, Some(options));
+    let mut recv_buffer = String::with_capacity(1024);
+
+    loop {
+        tokio::select! {
+            frame = stream.next() => {
+                match frame {
+                    Some(Ok(LogOutput::StdOut { message })) => {
+                        recv_buffer.push_str(&String::from_utf8_lossy(&message));
+                        while let Some(pos) = recv_buffer.find('\n') {
+                            let line = recv_buffer[..pos].to_string();
+                            recv_buffer.drain(..=pos);
+                            if socket.send(Message::Text(line.into())).await.is_err() {
+                                debug!("Logs client disconnected");
+                                return;
+                            }
+                        }
+                    }
+                    Some(Ok(LogOutput::StdErr { message })) => {
+                        let text = String::from_utf8_lossy(&message).to_string();
+                        for line in text.split('\n') {
+                            if line.is_empty() { continue; }
+                            let tagged = format!("[stderr] {}", line);
+                            if socket.send(Message::Text(tagged.into())).await.is_err() {
+                                debug!("Logs client disconnected");
+                                return;
+                            }
+                        }
+                    }
+                    Some(Ok(LogOutput::Console { message })) => {
+                        let text = String::from_utf8_lossy(&message).to_string();
+                        if socket.send(Message::Text(text.into())).await.is_err() {
+                            debug!("Logs client disconnected");
+                            return;
+                        }
+                    }
+                    Some(Ok(LogOutput::StdIn { .. })) => {
+                        // We don't write to stdin, so ignore
+                    }
+                    Some(Err(e)) => {
+                        let msg = format!("ERR:Log stream error: {e}");
+                        let _ = socket.send(Message::Text(msg.into())).await;
+                        return;
+                    }
+                    None => {
+                        let _ = socket.send(Message::Text("LOG:Stream ended - container stopped".into())).await;
+                        return;
+                    }
+                }
+            }
+            ws_msg = socket.recv() => {
+                match ws_msg {
+                    Some(Ok(Message::Close(_))) | None => {
+                        debug!("Logs client disconnected via close frame");
+                        return;
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => {
+                        debug!("Logs WebSocket error: {e}");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Find a running Docker container whose name or image contains a known engine
+/// identifier (e.g. vllm, deepseek).
+pub async fn find_container_via_docker(docker: &Docker) -> Option<String> {
+    let mut filters = HashMap::new();
+    filters.insert("status".to_string(), vec!["running".to_string()]);
+
+    let options = ListContainersOptionsBuilder::new()
+        .all(false)
+        .filters(&filters)
+        .build();
+
+    let containers = docker.list_containers(Some(options)).await.ok()?;
+
+    for container in &containers {
+        let image = container.image.as_deref().unwrap_or("");
+        let image_lower = image.to_lowercase();
+        let names: Vec<&str> = container
+            .names
+            .as_ref()
+            .map(|n| n.iter().map(|s| s.as_str()).collect())
+            .unwrap_or_default();
+
+        let name_match = names
+            .iter()
+            .any(|n| n.to_lowercase().contains("vllm") || n.to_lowercase().contains("deepseek"));
+
+        let image_match = image_lower.contains("vllm") || image_lower.contains("deepseek");
+
+        if name_match || image_match {
+            return container
+                .id
+                .as_ref()
+                .map(|id| id.chars().take(12).collect());
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn container_id_is_truncated_to_12_chars() {
+        let long_id = "abc123def4567890";
+        let short: String = long_id.chars().take(12).collect();
+        assert_eq!(short.len(), 12);
+        assert_eq!(short, "abc123def456");
+    }
+
+    #[test]
+    fn short_id_under_12_chars_is_unchanged() {
+        let id = "abc123";
+        let short: String = id.chars().take(12).collect();
+        assert_eq!(short, "abc123");
+    }
+
+    #[test]
+    fn stderr_prefix_is_formatted_correctly() {
+        let line = "[stderr] Error: connection refused";
+        assert!(line.starts_with("[stderr]"));
+        assert!(line.contains("connection refused"));
+    }
+
+    #[test]
+    fn log_stream_ended_message_format() {
+        let msg = "LOG:Stream ended - container stopped";
+        assert!(msg.starts_with("LOG:"));
+        assert!(msg.contains("container stopped"));
+    }
+}

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -6,30 +6,62 @@
 //!
 //! Stream characteristics:
 //! - stdout/stderr are multiplexed in real-time (not drained sequentially).
-//! - The WebSocket connects lazily -- the backend stream is only opened when a
-//!   client connects, not on page load.
-//! - Container discovery uses the Docker API directly rather than needing the
-//!   shared engine state wired into this handler.
+//! - One Docker log stream is shared across all connected WebSocket clients
+//!   (same fan-out pattern as the metrics broadcast in `ws.rs`): a single
+//!   background task owns the Docker stream and publishes line-buffered log
+//!   lines over a `broadcast` channel; each WS handler subscribes to it.
+//! - Both stdout and stderr are buffered by lines — bollard frames can split a
+//!   log line mid-way, so partial frames are accumulated until a newline arrives
+//!   before being forwarded. The trailing partial line is flushed when the
+//!   Docker stream ends.
+//! - The container to stream is read from the shared engine state populated by
+//!   `engine_collector_loop`, so the dashboard streams the exact container it is
+//!   showing metrics for rather than re-scanning and potentially picking a
+//!   different one.
 
 #![cfg(target_os = "linux")]
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use bollard::container::LogOutput;
-use bollard::query_parameters::{ListContainersOptionsBuilder, LogsOptionsBuilder};
+use bollard::query_parameters::LogsOptionsBuilder;
 use bollard::Docker;
 use futures_util::StreamExt;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tracing::debug;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::{broadcast, RwLock};
+use tracing::{debug, warn};
+
+use crate::engines::EngineSnapshot;
 
 /// Flag set at startup when `--enable-log-viewer` is passed.
 /// Read by `server.rs` to decide whether to register the `/ws/logs` route.
 static LOG_VIEWER_ENABLED: AtomicBool = AtomicBool::new(false);
 
+/// Broadcast channel carrying line-buffered log lines to all connected WS
+/// clients. Lazily initialized by [`start_log_stream`] the first time a client
+/// connects. Mirrors the `broadcast::Sender<String>` used for metrics in
+/// [`crate::metrics`] / [`crate::ws`]: one producer (the background stream
+/// task) fans out to N subscribers (the WS handlers).
+static LOG_TX: OnceLock<broadcast::Sender<String>> = OnceLock::new();
+
+/// Shared engine state, set at startup when the log viewer is enabled.
+/// The background stream task reads the tracked container id from here so it
+/// streams the same container the dashboard is reporting metrics for.
+static ENGINE_STATE: OnceLock<Arc<RwLock<Vec<EngineSnapshot>>>> = OnceLock::new();
+
+/// Capacity of the log broadcast channel. Sized so a slow WS client can fall a
+/// few seconds behind (log lines are small) without being dropped; lagged
+/// clients simply skip missed lines (see [`handle_logs_socket`]).
+const LOG_CHANNEL_CAPACITY: usize = 256;
+
 /// Enable the log viewer feature. Called from `main.rs` when
-/// `--enable-log-viewer` is set.
-pub fn enable_log_viewer() {
+/// `--enable-log-viewer` is set. Captures the shared engine state so the
+/// background stream can resolve the tracked container id.
+pub fn enable_log_viewer(engine_state: Arc<RwLock<Vec<EngineSnapshot>>>) {
+    // Setting the engine state first avoids a race where a client connects and
+    // the stream task starts before the state pointer is available.
+    let _ = ENGINE_STATE.set(engine_state);
     LOG_VIEWER_ENABLED.store(true, Ordering::Relaxed);
 }
 
@@ -40,8 +72,9 @@ pub fn is_log_viewer_enabled() -> bool {
 
 /// WebSocket upgrade handler for `/ws/logs`.
 ///
-/// The Docker log stream is started only when a client actually connects
-/// (lazy connect -- no background resource consumption while collapsed).
+/// The Docker log stream is started only when the first client actually
+/// connects (lazy connect -- no background resource consumption while
+/// collapsed). Subsequent clients subscribe to the same broadcast.
 pub async fn ws_logs_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
     ws.on_upgrade(handle_logs_socket)
 }
@@ -49,81 +82,35 @@ pub async fn ws_logs_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
 async fn handle_logs_socket(mut socket: WebSocket) {
     debug!("Logs WebSocket client connected");
 
-    // Connect to the Docker daemon over the local Unix socket.
-    let docker = match Docker::connect_with_local_defaults() {
-        Ok(d) => d,
-        Err(e) => {
-            let msg = format!("ERR:Could not connect to Docker daemon: {e}");
-            let _ = socket.send(Message::Text(msg.into())).await;
-            return;
-        }
-    };
+    let tx = start_log_stream().await;
+    let mut rx = tx.subscribe();
 
-    // Find the first vLLM container via the Docker API.
-    let container_id = match find_container_via_docker(&docker).await {
-        Some(id) => id,
-        None => {
-            let msg = "ERR:No engine container found".to_string();
-            let _ = socket.send(Message::Text(msg.into())).await;
-            return;
-        }
-    };
-
-    debug!("Streaming logs for container: {container_id}");
-
-    let options = LogsOptionsBuilder::new()
-        .follow(true)
-        .stdout(true)
-        .stderr(true)
-        .tail("100")
-        .build();
-
-    let mut stream = docker.logs(&container_id, Some(options));
-    let mut recv_buffer = String::with_capacity(1024);
+    // Replay a marker so the client knows streaming has begun.
+    if socket
+        .send(Message::Text("LOG:stream attached".into()))
+        .await
+        .is_err()
+    {
+        debug!("Logs client disconnected before first message");
+        return;
+    }
 
     loop {
         tokio::select! {
-            frame = stream.next() => {
-                match frame {
-                    Some(Ok(LogOutput::StdOut { message })) => {
-                        recv_buffer.push_str(&String::from_utf8_lossy(&message));
-                        while let Some(pos) = recv_buffer.find('\n') {
-                            let line = recv_buffer[..pos].to_string();
-                            recv_buffer.drain(..=pos);
-                            if socket.send(Message::Text(line.into())).await.is_err() {
-                                debug!("Logs client disconnected");
-                                return;
-                            }
-                        }
-                    }
-                    Some(Ok(LogOutput::StdErr { message })) => {
-                        let text = String::from_utf8_lossy(&message).to_string();
-                        for line in text.split('\n') {
-                            if line.is_empty() { continue; }
-                            let tagged = format!("[stderr] {}", line);
-                            if socket.send(Message::Text(tagged.into())).await.is_err() {
-                                debug!("Logs client disconnected");
-                                return;
-                            }
-                        }
-                    }
-                    Some(Ok(LogOutput::Console { message })) => {
-                        let text = String::from_utf8_lossy(&message).to_string();
-                        if socket.send(Message::Text(text.into())).await.is_err() {
+            line = rx.recv() => {
+                match line {
+                    Ok(msg) => {
+                        if socket.send(Message::Text(msg.into())).await.is_err() {
                             debug!("Logs client disconnected");
                             return;
                         }
                     }
-                    Some(Ok(LogOutput::StdIn { .. })) => {
-                        // We don't write to stdin, so ignore
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        debug!("Logs client lagged, skipped {} lines", n);
+                        continue;
                     }
-                    Some(Err(e)) => {
-                        let msg = format!("ERR:Log stream error: {e}");
-                        let _ = socket.send(Message::Text(msg.into())).await;
-                        return;
-                    }
-                    None => {
-                        let _ = socket.send(Message::Text("LOG:Stream ended - container stopped".into())).await;
+                    Err(broadcast::error::RecvError::Closed) => {
+                        debug!("Logs broadcast channel closed");
                         return;
                     }
                 }
@@ -145,74 +132,274 @@ async fn handle_logs_socket(mut socket: WebSocket) {
     }
 }
 
-/// Find a running Docker container whose name or image contains a known engine
-/// identifier (e.g. vllm, deepseek).
-pub async fn find_container_via_docker(docker: &Docker) -> Option<String> {
-    let mut filters = HashMap::new();
-    filters.insert("status".to_string(), vec!["running".to_string()]);
+/// Lazily start the shared Docker log stream (if not already running) and
+/// return a clone of the broadcast sender. Idempotent: the first caller to
+/// populate `LOG_TX` wins; `STREAM_TASK_STARTED` then ensures the background
+/// task is spawned exactly once. Later callers just subscribe.
+async fn start_log_stream() -> broadcast::Sender<String> {
+    let tx = LOG_TX
+        .get_or_init(|| broadcast::channel::<String>(LOG_CHANNEL_CAPACITY).0)
+        .clone();
 
-    let options = ListContainersOptionsBuilder::new()
-        .all(false)
-        .filters(&filters)
-        .build();
-
-    let containers = docker.list_containers(Some(options)).await.ok()?;
-
-    for container in &containers {
-        let image = container.image.as_deref().unwrap_or("");
-        let image_lower = image.to_lowercase();
-        let names: Vec<&str> = container
-            .names
-            .as_ref()
-            .map(|n| n.iter().map(|s| s.as_str()).collect())
-            .unwrap_or_default();
-
-        let name_match = names
-            .iter()
-            .any(|n| n.to_lowercase().contains("vllm") || n.to_lowercase().contains("deepseek"));
-
-        let image_match = image_lower.contains("vllm") || image_lower.contains("deepseek");
-
-        if name_match || image_match {
-            return container
-                .id
-                .as_ref()
-                .map(|id| id.chars().take(12).collect());
-        }
+    // Only one caller wins this CAS; it spawns the single stream task.
+    if STREAM_TASK_STARTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        tokio::spawn(log_stream_task(tx.clone()));
     }
 
+    tx
+}
+
+/// Guarantees the background Docker-stream task is spawned exactly once.
+static STREAM_TASK_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Background task that owns the single Docker log stream and publishes
+/// line-buffered log lines to all WS clients via the broadcast channel.
+async fn log_stream_task(tx: broadcast::Sender<String>) {
+    let docker = match Docker::connect_with_local_defaults() {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = tx.send(format!("ERR:Could not connect to Docker daemon: {e}"));
+            return;
+        }
+    };
+
+    // Resolve the tracked container id from shared engine state. Poll briefly
+    // in case detection hasn't completed yet at first connect.
+    let container_id = match resolve_container_id().await {
+        Some(id) => id,
+        None => {
+            let _ = tx.send("ERR:No engine container found".to_string());
+            return;
+        }
+    };
+
+    debug!("Streaming logs for container: {container_id}");
+
+    let options = LogsOptionsBuilder::new()
+        .follow(true)
+        .stdout(true)
+        .stderr(true)
+        .tail("100")
+        .build();
+
+    let mut stream = docker.logs(&container_id, Some(options));
+    let mut stdout_buf = String::with_capacity(1024);
+    let mut stderr_buf = String::with_capacity(1024);
+
+    loop {
+        match stream.next().await {
+            Some(Ok(LogOutput::StdOut { message })) => {
+                for line in buffer_lines(&mut stdout_buf, &message, None) {
+                    // No subscribers is fine — a client may reconnect; keep streaming.
+                    let _ = tx.send(line);
+                }
+            }
+            Some(Ok(LogOutput::StdErr { message })) => {
+                // Stderr is buffered by lines the same way stdout is: frames
+                // can split a line mid-way, so accumulate until a newline.
+                for line in buffer_lines(&mut stderr_buf, &message, Some("[stderr] ")) {
+                    let _ = tx.send(line);
+                }
+            }
+            Some(Ok(LogOutput::Console { message })) => {
+                // Console frames are whole lines from the Docker daemon itself.
+                let text = String::from_utf8_lossy(&message).to_string();
+                let _ = tx.send(text);
+            }
+            Some(Ok(LogOutput::StdIn { .. })) => {
+                // We don't write to stdin, so ignore.
+            }
+            Some(Err(e)) => {
+                let _ = tx.send(format!("ERR:Log stream error: {e}"));
+                return;
+            }
+            None => {
+                // Stream ended (container stopped). Flush any trailing partial
+                // lines that never received a newline.
+                flush_trailing(&mut stdout_buf, None, &tx);
+                flush_trailing(&mut stderr_buf, Some("[stderr] "), &tx);
+                let _ = tx.send("LOG:Stream ended - container stopped".to_string());
+                return;
+            }
+        }
+    }
+}
+
+/// Read the tracked container id from shared engine state. Waits up to ~10s for
+/// detection to populate a container id, since the log viewer may be connected
+/// before the first detection sweep completes.
+async fn resolve_container_id() -> Option<String> {
+    let state = ENGINE_STATE.get()?;
+    for _ in 0..100 {
+        {
+            let lock = state.read().await;
+            for snap in lock.iter() {
+                if let Some(id) = &snap.container_id {
+                    return Some(id.clone());
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    warn!("Log viewer could not resolve a container id from engine state after 10s");
     None
+}
+
+// ---------------------------------------------------------------------------
+// Line buffering helpers (pure -- exercised by unit tests)
+// ---------------------------------------------------------------------------
+
+/// Accumulate `chunk` into `buffer`, then emit and drain every complete line
+/// (text up to and including a `\n`). Any trailing partial line (no newline
+/// yet) remains in `buffer` for the next chunk. `prefix` is prepended to each
+/// emitted line (used to tag stderr lines with `[stderr] `).
+///
+/// This is the core line-buffering behavior shared by stdout and stderr: a
+/// single log line may arrive split across several bollard frames, so we only
+/// forward text once we have a complete line.
+fn buffer_lines(buffer: &mut String, chunk: &[u8], prefix: Option<&str>) -> Vec<String> {
+    buffer.push_str(&String::from_utf8_lossy(chunk));
+    let mut out = Vec::new();
+    while let Some(pos) = buffer.find('\n') {
+        let line: String = buffer.drain(..=pos).collect();
+        // Strip the trailing newline (already drained) and emit the line
+        // body, with the optional prefix.
+        let body = line.trim_end_matches('\n');
+        let prefixed = match prefix {
+            Some(p) => format!("{p}{body}"),
+            None => body.to_string(),
+        };
+        out.push(prefixed);
+    }
+    out
+}
+
+/// Emit whatever remains in `buffer` as a single final line (no trailing
+/// newline was ever received), then clear it. Called when the Docker stream
+/// ends so a partial last line isn't silently dropped.
+fn flush_trailing(buffer: &mut String, prefix: Option<&str>, tx: &broadcast::Sender<String>) {
+    if buffer.is_empty() {
+        return;
+    }
+    let body = std::mem::take(buffer);
+    let prefixed = match prefix {
+        Some(p) => format!("{p}{body}"),
+        None => body,
+    };
+    let _ = tx.send(prefixed);
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
+    /// A complete line arriving in one frame is emitted immediately, and the
+    /// buffer is left empty (no partial line retained).
     #[test]
-    fn container_id_is_truncated_to_12_chars() {
-        let long_id = "abc123def4567890";
-        let short: String = long_id.chars().take(12).collect();
-        assert_eq!(short.len(), 12);
-        assert_eq!(short, "abc123def456");
+    fn stdout_single_complete_line_is_emitted() {
+        let mut buf = String::new();
+        let lines = buffer_lines(&mut buf, b"hello world\n", None);
+        assert_eq!(lines, vec!["hello world".to_string()]);
+        assert!(buf.is_empty(), "no partial line should remain");
     }
 
+    /// A line split across two frames is only emitted once the newline arrives.
+    /// The first frame leaves a partial line buffered; the second completes it.
     #[test]
-    fn short_id_under_12_chars_is_unchanged() {
-        let id = "abc123";
-        let short: String = id.chars().take(12).collect();
-        assert_eq!(short, "abc123");
+    fn stdout_split_line_is_buffered_until_newline() {
+        let mut buf = String::new();
+
+        // First frame: no newline yet -- nothing emitted, partial buffered.
+        let lines = buffer_lines(&mut buf, b"partial", None);
+        assert!(lines.is_empty(), "no complete line yet");
+        assert_eq!(buf, "partial");
+
+        // Second frame: completes the line.
+        let lines = buffer_lines(&mut buf, b" line\n", None);
+        assert_eq!(lines, vec!["partial line".to_string()]);
+        assert!(buf.is_empty());
     }
 
+    /// Multiple complete lines in a single frame are all emitted, in order.
     #[test]
-    fn stderr_prefix_is_formatted_correctly() {
-        let line = "[stderr] Error: connection refused";
-        assert!(line.starts_with("[stderr]"));
-        assert!(line.contains("connection refused"));
+    fn stdout_multiple_lines_in_one_frame() {
+        let mut buf = String::new();
+        let lines = buffer_lines(&mut buf, b"a\nb\nc\n", None);
+        assert_eq!(
+            lines,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        assert!(buf.is_empty());
     }
 
+    /// Stderr is buffered by lines the same way stdout is: a frame without a
+    /// newline is retained, and each emitted line is tagged with the prefix.
     #[test]
-    fn log_stream_ended_message_format() {
-        let msg = "LOG:Stream ended - container stopped";
-        assert!(msg.starts_with("LOG:"));
-        assert!(msg.contains("container stopped"));
+    fn stderr_is_line_buffered_and_prefixed() {
+        let mut buf = String::new();
+
+        // Split stderr frame: no newline in the first chunk.
+        let lines = buffer_lines(&mut buf, b"err ", Some("[stderr] "));
+        assert!(lines.is_empty());
+        assert_eq!(buf, "err ");
+
+        // Completing chunk emits the tagged line.
+        let lines = buffer_lines(&mut buf, b"half\n", Some("[stderr] "));
+        assert_eq!(lines, vec!["[stderr] err half".to_string()]);
+        assert!(buf.is_empty());
+    }
+
+    /// A partial stdout line that never receives a trailing newline is flushed
+    /// when the stream ends, so it is not silently lost.
+    #[tokio::test]
+    async fn trailing_partial_stdout_line_is_flushed_on_stream_end() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let mut buf = String::new();
+
+        // Buffer a partial line with no newline.
+        let lines = buffer_lines(&mut buf, b"trailing partial", None);
+        assert!(lines.is_empty());
+
+        // Stream ends -> flush the leftover.
+        flush_trailing(&mut buf, None, &tx);
+        assert!(buf.is_empty());
+        assert_eq!(rx.recv().await.unwrap(), "trailing partial");
+    }
+
+    /// A trailing partial stderr line is flushed with its prefix on stream end.
+    #[tokio::test]
+    async fn trailing_partial_stderr_line_is_flushed_with_prefix() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let mut buf = String::new();
+
+        let _ = buffer_lines(&mut buf, b"leftover stderr", Some("[stderr] "));
+        flush_trailing(&mut buf, Some("[stderr] "), &tx);
+        assert_eq!(rx.recv().await.unwrap(), "[stderr] leftover stderr");
+    }
+
+    /// `flush_trailing` on an empty buffer is a no-op (no spurious empty line).
+    #[test]
+    fn flush_trailing_empty_buffer_emits_nothing() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let mut buf = String::new();
+        flush_trailing(&mut buf, None, &tx);
+        // No message should be available.
+        assert!(
+            rx.try_recv().is_err(),
+            "flush of empty buffer must not emit a line"
+        );
+    }
+
+    /// Mixed complete-and-partial frame: the complete line is emitted, the
+    /// trailing partial is retained for the next chunk.
+    #[test]
+    fn stdout_complete_line_then_partial_in_same_frame() {
+        let mut buf = String::new();
+        let lines = buffer_lines(&mut buf, b"done\nstart of next", None);
+        assert_eq!(lines, vec!["done".to_string()]);
+        assert_eq!(buf, "start of next");
     }
 }

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -6,29 +6,38 @@
 //!
 //! Stream characteristics:
 //! - stdout/stderr are multiplexed in real-time (not drained sequentially).
-//! - One Docker log stream is shared across all connected WebSocket clients
-//!   (same fan-out pattern as the metrics broadcast in `ws.rs`): a single
-//!   background task owns the Docker stream and publishes line-buffered log
-//!   lines over a `broadcast` channel; each WS handler subscribes to it.
+//! - One Docker log stream per container is shared across all WebSocket
+//!   clients watching that container (same fan-out pattern as the metrics
+//!   broadcast in `ws.rs`): a background task per container owns the Docker
+//!   stream and publishes line-buffered log lines over a `broadcast` channel;
+//!   each WS handler subscribes to the channel for its container.
+//! - Clients select an engine with `/ws/logs?engine=<endpoint>`. The endpoint
+//!   is matched against the shared engine state populated by
+//!   `engine_collector_loop`, so only containers the dashboard tracks as
+//!   engines can be streamed — a client can never request an arbitrary
+//!   container. Without the parameter the first tracked engine container is
+//!   used (single-engine hosts don't need to select anything).
 //! - Both stdout and stderr are buffered by lines — bollard frames can split a
-//!   log line mid-way, so partial frames are accumulated until a newline arrives
-//!   before being forwarded. The trailing partial line is flushed when the
-//!   Docker stream ends.
-//! - The container to stream is read from the shared engine state populated by
-//!   `engine_collector_loop`, so the dashboard streams the exact container it is
-//!   showing metrics for rather than re-scanning and potentially picking a
-//!   different one.
+//!   log line mid-way, so partial frames are accumulated until a newline
+//!   arrives before being forwarded. The trailing partial line is flushed when
+//!   the Docker stream ends.
+//! - When a container's stream ends (container stopped, Docker error, or the
+//!   last viewer disconnected), its registry entry is removed, so the next
+//!   client connect starts a fresh stream instead of subscribing to a dead
+//!   channel. Streams therefore only run while someone is actually watching.
 
 #![cfg(target_os = "linux")]
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::Query;
 use axum::response::IntoResponse;
 use bollard::container::LogOutput;
 use bollard::query_parameters::LogsOptionsBuilder;
 use bollard::Docker;
 use futures_util::StreamExt;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{debug, warn};
 
@@ -38,26 +47,24 @@ use crate::engines::EngineSnapshot;
 /// Read by `server.rs` to decide whether to register the `/ws/logs` route.
 static LOG_VIEWER_ENABLED: AtomicBool = AtomicBool::new(false);
 
-/// Broadcast channel carrying line-buffered log lines to all connected WS
-/// clients. Lazily initialized by [`start_log_stream`] the first time a client
-/// connects. Mirrors the `broadcast::Sender<String>` used for metrics in
-/// [`crate::metrics`] / [`crate::ws`]: one producer (the background stream
-/// task) fans out to N subscribers (the WS handlers).
-static LOG_TX: OnceLock<broadcast::Sender<String>> = OnceLock::new();
-
 /// Shared engine state, set at startup when the log viewer is enabled.
-/// The background stream task reads the tracked container id from here so it
-/// streams the same container the dashboard is reporting metrics for.
+/// WS handlers resolve engine endpoints to container ids against it, so the
+/// stream always follows the engine the dashboard is showing.
 static ENGINE_STATE: OnceLock<Arc<RwLock<Vec<EngineSnapshot>>>> = OnceLock::new();
 
-/// Capacity of the log broadcast channel. Sized so a slow WS client can fall a
-/// few seconds behind (log lines are small) without being dropped; lagged
+/// One shared log stream per container: container id → broadcast sender.
+/// An entry exists while the container's background stream task is alive; the
+/// task removes its own entry on exit so a later connect restarts the stream.
+static STREAMS: OnceLock<Mutex<HashMap<String, broadcast::Sender<String>>>> = OnceLock::new();
+
+/// Capacity of each log broadcast channel. Sized so a slow WS client can fall
+/// a few seconds behind (log lines are small) without being dropped; lagged
 /// clients simply skip missed lines (see [`handle_logs_socket`]).
 const LOG_CHANNEL_CAPACITY: usize = 256;
 
 /// Enable the log viewer feature. Called from `main.rs` when
-/// `--enable-log-viewer` is set. Captures the shared engine state so the
-/// background stream can resolve the tracked container id.
+/// `--enable-log-viewer` is set. Captures the shared engine state so WS
+/// handlers can resolve engine endpoints to container ids.
 pub fn enable_log_viewer(engine_state: Arc<RwLock<Vec<EngineSnapshot>>>) {
     // Setting the engine state first avoids a race where a client connects and
     // the stream task starts before the state pointer is available.
@@ -70,20 +77,43 @@ pub fn is_log_viewer_enabled() -> bool {
     LOG_VIEWER_ENABLED.load(Ordering::Relaxed)
 }
 
-/// WebSocket upgrade handler for `/ws/logs`.
-///
-/// The Docker log stream is started only when the first client actually
-/// connects (lazy connect -- no background resource consumption while
-/// collapsed). Subsequent clients subscribe to the same broadcast.
-pub async fn ws_logs_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
-    ws.on_upgrade(handle_logs_socket)
+/// Query parameters for `/ws/logs`.
+#[derive(serde::Deserialize)]
+pub struct LogsQuery {
+    /// Engine endpoint (as serialized in `EngineSnapshot.endpoint`) selecting
+    /// which engine's container to stream. Absent → first tracked container.
+    engine: Option<String>,
 }
 
-async fn handle_logs_socket(mut socket: WebSocket) {
-    debug!("Logs WebSocket client connected");
+/// WebSocket upgrade handler for `/ws/logs`.
+///
+/// A container's Docker log stream is started only when the first client for
+/// that container connects (lazy connect — no background resource consumption
+/// while the viewer is unused). Subsequent clients subscribe to the same
+/// broadcast.
+pub async fn ws_logs_handler(
+    Query(query): Query<LogsQuery>,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_logs_socket(socket, query.engine))
+}
 
-    let tx = start_log_stream().await;
-    let mut rx = tx.subscribe();
+async fn handle_logs_socket(mut socket: WebSocket, engine: Option<String>) {
+    debug!("Logs WebSocket client connected (engine: {engine:?})");
+
+    let container_id = match resolve_container_id(engine.as_deref()).await {
+        Some(id) => id,
+        None => {
+            let msg = match engine {
+                Some(e) => format!("ERR:No container found for engine {e}"),
+                None => "ERR:No engine container found".to_string(),
+            };
+            let _ = socket.send(Message::Text(msg.into())).await;
+            return;
+        }
+    };
+
+    let mut rx = subscribe_container(&container_id);
 
     // Replay a marker so the client knows streaming has begun.
     if socket
@@ -132,46 +162,47 @@ async fn handle_logs_socket(mut socket: WebSocket) {
     }
 }
 
-/// Lazily start the shared Docker log stream (if not already running) and
-/// return a clone of the broadcast sender. Idempotent: the first caller to
-/// populate `LOG_TX` wins; `STREAM_TASK_STARTED` then ensures the background
-/// task is spawned exactly once. Later callers just subscribe.
-async fn start_log_stream() -> broadcast::Sender<String> {
-    let tx = LOG_TX
-        .get_or_init(|| broadcast::channel::<String>(LOG_CHANNEL_CAPACITY).0)
-        .clone();
-
-    // Only one caller wins this CAS; it spawns the single stream task.
-    if STREAM_TASK_STARTED
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok()
-    {
-        tokio::spawn(log_stream_task(tx.clone()));
+/// Subscribe to `container_id`'s log stream, lazily spawning the container's
+/// background stream task if it isn't running. The registry lock serializes
+/// concurrent first-connects so exactly one task is spawned per container, and
+/// the receiver is created before the task starts so the stream never observes
+/// zero subscribers while its first client is still attaching.
+fn subscribe_container(container_id: &str) -> broadcast::Receiver<String> {
+    let streams = STREAMS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut map = streams.lock().expect("log stream registry poisoned");
+    if let Some(tx) = map.get(container_id) {
+        return tx.subscribe();
     }
-
-    tx
+    let (tx, rx) = broadcast::channel::<String>(LOG_CHANNEL_CAPACITY);
+    map.insert(container_id.to_string(), tx.clone());
+    tokio::spawn(log_stream_task(container_id.to_string(), tx));
+    rx
 }
 
-/// Guarantees the background Docker-stream task is spawned exactly once.
-static STREAM_TASK_STARTED: AtomicBool = AtomicBool::new(false);
+/// Remove a finished stream's registry entry so the next client connect starts
+/// a fresh Docker stream instead of subscribing to a dead channel.
+fn remove_stream(container_id: &str) {
+    if let Some(streams) = STREAMS.get() {
+        streams
+            .lock()
+            .expect("log stream registry poisoned")
+            .remove(container_id);
+    }
+}
 
-/// Background task that owns the single Docker log stream and publishes
-/// line-buffered log lines to all WS clients via the broadcast channel.
-async fn log_stream_task(tx: broadcast::Sender<String>) {
+/// Background task that owns the Docker log stream for one container and
+/// publishes line-buffered log lines to its subscribers. Deregisters itself on
+/// every exit path so the stream can be restarted by a later connect.
+async fn log_stream_task(container_id: String, tx: broadcast::Sender<String>) {
+    stream_container_logs(&container_id, &tx).await;
+    remove_stream(&container_id);
+}
+
+async fn stream_container_logs(container_id: &str, tx: &broadcast::Sender<String>) {
     let docker = match Docker::connect_with_local_defaults() {
         Ok(d) => d,
         Err(e) => {
             let _ = tx.send(format!("ERR:Could not connect to Docker daemon: {e}"));
-            return;
-        }
-    };
-
-    // Resolve the tracked container id from shared engine state. Poll briefly
-    // in case detection hasn't completed yet at first connect.
-    let container_id = match resolve_container_id().await {
-        Some(id) => id,
-        None => {
-            let _ = tx.send("ERR:No engine container found".to_string());
             return;
         }
     };
@@ -185,7 +216,7 @@ async fn log_stream_task(tx: broadcast::Sender<String>) {
         .tail("100")
         .build();
 
-    let mut stream = docker.logs(&container_id, Some(options));
+    let mut stream = docker.logs(container_id, Some(options));
     let mut stdout_buf = String::with_capacity(1024);
     let mut stderr_buf = String::with_capacity(1024);
 
@@ -193,21 +224,32 @@ async fn log_stream_task(tx: broadcast::Sender<String>) {
         match stream.next().await {
             Some(Ok(LogOutput::StdOut { message })) => {
                 for line in buffer_lines(&mut stdout_buf, &message, None) {
-                    // No subscribers is fine — a client may reconnect; keep streaming.
-                    let _ = tx.send(line);
+                    // Err means no live subscribers: the last viewer left, so
+                    // stop the Docker stream — a later connect restarts it
+                    // through the registry.
+                    if tx.send(line).is_err() {
+                        debug!("No log subscribers left for {container_id}; stopping stream");
+                        return;
+                    }
                 }
             }
             Some(Ok(LogOutput::StdErr { message })) => {
                 // Stderr is buffered by lines the same way stdout is: frames
                 // can split a line mid-way, so accumulate until a newline.
                 for line in buffer_lines(&mut stderr_buf, &message, Some("[stderr] ")) {
-                    let _ = tx.send(line);
+                    if tx.send(line).is_err() {
+                        debug!("No log subscribers left for {container_id}; stopping stream");
+                        return;
+                    }
                 }
             }
             Some(Ok(LogOutput::Console { message })) => {
                 // Console frames are whole lines from the Docker daemon itself.
                 let text = String::from_utf8_lossy(&message).to_string();
-                let _ = tx.send(text);
+                if tx.send(text).is_err() {
+                    debug!("No log subscribers left for {container_id}; stopping stream");
+                    return;
+                }
             }
             Some(Ok(LogOutput::StdIn { .. })) => {
                 // We don't write to stdin, so ignore.
@@ -219,8 +261,8 @@ async fn log_stream_task(tx: broadcast::Sender<String>) {
             None => {
                 // Stream ended (container stopped). Flush any trailing partial
                 // lines that never received a newline.
-                flush_trailing(&mut stdout_buf, None, &tx);
-                flush_trailing(&mut stderr_buf, Some("[stderr] "), &tx);
+                flush_trailing(&mut stdout_buf, None, tx);
+                flush_trailing(&mut stderr_buf, Some("[stderr] "), tx);
                 let _ = tx.send("LOG:Stream ended - container stopped".to_string());
                 return;
             }
@@ -228,24 +270,38 @@ async fn log_stream_task(tx: broadcast::Sender<String>) {
     }
 }
 
-/// Read the tracked container id from shared engine state. Waits up to ~10s for
-/// detection to populate a container id, since the log viewer may be connected
-/// before the first detection sweep completes.
-async fn resolve_container_id() -> Option<String> {
+/// Resolve an engine selection to a container id against the shared engine
+/// state. Waits up to ~10s for detection to populate container ids, since the
+/// log viewer may connect before the first detection sweep completes.
+async fn resolve_container_id(engine: Option<&str>) -> Option<String> {
     let state = ENGINE_STATE.get()?;
     for _ in 0..100 {
         {
             let lock = state.read().await;
-            for snap in lock.iter() {
-                if let Some(id) = &snap.container_id {
-                    return Some(id.clone());
-                }
+            if let Some(id) = find_container(&lock, engine) {
+                return Some(id);
             }
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    warn!("Log viewer could not resolve a container id from engine state after 10s");
+    warn!(
+        "Log viewer could not resolve a container id from engine state after 10s (engine: {engine:?})"
+    );
     None
+}
+
+/// Pick the container id for an engine selection from a snapshot list.
+/// With `engine` given, only that endpoint's container matches — an unknown
+/// endpoint yields `None` rather than falling back to a different engine's
+/// logs. Without it, the first snapshot with a container id wins.
+fn find_container(snapshots: &[EngineSnapshot], engine: Option<&str>) -> Option<String> {
+    match engine {
+        Some(endpoint) => snapshots
+            .iter()
+            .find(|s| s.endpoint == endpoint)
+            .and_then(|s| s.container_id.clone()),
+        None => snapshots.iter().find_map(|s| s.container_id.clone()),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -295,6 +351,107 @@ fn flush_trailing(buffer: &mut String, prefix: Option<&str>, tx: &broadcast::Sen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engines::{DeploymentMode, EngineStatus, EngineType};
+
+    fn snapshot(endpoint: &str, container_id: Option<&str>) -> EngineSnapshot {
+        EngineSnapshot {
+            engine_type: EngineType::Vllm,
+            endpoint: endpoint.to_string(),
+            status: EngineStatus::Running,
+            model: None,
+            metrics: None,
+            recent_requests: Vec::new(),
+            deployment_mode: match container_id {
+                Some(_) => DeploymentMode::Docker,
+                None => DeploymentMode::Native,
+            },
+            gpu_indexes: Vec::new(),
+            pids: Vec::new(),
+            container_id: container_id.map(str::to_string),
+        }
+    }
+
+    /// With an engine endpoint given, only that engine's container matches.
+    #[test]
+    fn find_container_matches_selected_endpoint() {
+        let snaps = vec![
+            snapshot("http://localhost:8000", Some("aaa")),
+            snapshot("http://localhost:8100", Some("bbb")),
+        ];
+        assert_eq!(
+            find_container(&snaps, Some("http://localhost:8100")),
+            Some("bbb".to_string())
+        );
+    }
+
+    /// An unknown endpoint yields None — never another engine's logs.
+    #[test]
+    fn find_container_unknown_endpoint_yields_none() {
+        let snaps = vec![snapshot("http://localhost:8000", Some("aaa"))];
+        assert_eq!(find_container(&snaps, Some("http://localhost:9999")), None);
+    }
+
+    /// A selected engine without a container (native deployment) yields None
+    /// rather than falling back to a different container.
+    #[test]
+    fn find_container_selected_native_engine_yields_none() {
+        let snaps = vec![
+            snapshot("http://localhost:8000", None),
+            snapshot("http://localhost:8100", Some("bbb")),
+        ];
+        assert_eq!(find_container(&snaps, Some("http://localhost:8000")), None);
+    }
+
+    /// Without a selection, the first snapshot with a container id wins —
+    /// native engines (no container) are skipped.
+    #[test]
+    fn find_container_default_picks_first_with_container() {
+        let snaps = vec![
+            snapshot("http://localhost:8000", None),
+            snapshot("http://localhost:8100", Some("bbb")),
+            snapshot("http://localhost:8200", Some("ccc")),
+        ];
+        assert_eq!(find_container(&snaps, None), Some("bbb".to_string()));
+    }
+
+    /// No containers at all → None.
+    #[test]
+    fn find_container_empty_state_yields_none() {
+        assert_eq!(find_container(&[], None), None);
+        assert_eq!(
+            find_container(&[snapshot("http://localhost:8000", None)], None),
+            None
+        );
+    }
+
+    /// A finished stream deregisters itself, so a later connect gets a fresh
+    /// channel instead of the dead one (restart-on-reconnect).
+    #[tokio::test]
+    async fn finished_stream_is_removed_from_registry() {
+        // Bogus container id: the task fails fast (no such container / no
+        // daemon), which is exactly the "stream died" path we want to observe.
+        let mut rx = subscribe_container("test-nonexistent-container");
+        // First message is an ERR from either the daemon connect or the log
+        // stream; after that the task deregisters.
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("stream task should emit an error quickly")
+            .expect("channel closed before error message");
+        assert!(msg.starts_with("ERR:"), "expected error line, got: {msg}");
+        // Poll until the registry entry is gone (deregistration runs after the
+        // error send, so give it a moment).
+        for _ in 0..50 {
+            let gone = STREAMS
+                .get()
+                .map(|s| !s.lock().unwrap().contains_key("test-nonexistent-container"))
+                .unwrap_or(false);
+            if gone {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("finished stream task did not deregister itself");
+    }
 
     /// A complete line arriving in one frame is emitted immediately, and the
     /// buffer is left empty (no partial line retained).

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,8 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
     // Shared engine state: engine collector writes, metrics collector reads
     let engine_state: Arc<RwLock<Vec<engines::EngineSnapshot>>> = Arc::new(RwLock::new(Vec::new()));
 
-    // Spawn engine collector loop as separate tokio task
+    // Spawn engine collector loop as separate tokio task (Research Pitfall 7:
+    // separate task so slow engine API calls don't block hardware metrics)
     tokio::spawn(engines::engine_collector_loop(
         engine_state.clone(),
         overrides,
@@ -210,7 +211,7 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
     // This registers /ws/logs in the router; nothing is exposed by default.
     #[cfg(target_os = "linux")]
     if args.enable_log_viewer {
-        logs::enable_log_viewer();
+        logs::enable_log_viewer(engine_state.clone());
         tracing::info!(
             "Log viewer enabled at /ws/logs - unauthenticated, container logs are exposed"
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ mod metrics;
 mod server;
 mod ws;
 
+#[cfg(target_os = "linux")]
+mod logs;
+
 use clap::{Args, Parser, Subcommand};
 use cli::service::ServiceCommand;
 use engines::{ApiKeyResolver, EngineOverride, EngineType};
@@ -101,6 +104,20 @@ struct RunArgs {
     /// --engine-api-key (also covers auto-detected engines).
     #[arg(long, env = "SPARK_DASHBOARD_PROVIDER_API_KEY")]
     provider_api_key: Option<String>,
+
+    /// Enable the experimental log viewer at /ws/logs (Linux only).
+    ///
+    /// When set, the dashboard streams container logs from the Docker daemon
+    /// using the bollard API. This is opt-in because engine logs can contain
+    /// prompts and request payloads; the dashboard binds 0.0.0.0 by default
+    /// and /ws/logs is unauthenticated.
+    #[cfg(target_os = "linux")]
+    #[arg(
+        long,
+        env = "SPARK_DASHBOARD_ENABLE_LOG_VIEWER",
+        default_value_t = false
+    )]
+    enable_log_viewer: bool,
 }
 
 fn main() -> ExitCode {
@@ -173,8 +190,7 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
     // Shared engine state: engine collector writes, metrics collector reads
     let engine_state: Arc<RwLock<Vec<engines::EngineSnapshot>>> = Arc::new(RwLock::new(Vec::new()));
 
-    // Spawn engine collector loop as separate tokio task (Research Pitfall 7:
-    // separate task so slow engine API calls don't block hardware metrics)
+    // Spawn engine collector loop as separate tokio task
     tokio::spawn(engines::engine_collector_loop(
         engine_state.clone(),
         overrides,
@@ -189,6 +205,16 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
         args.simulate_gpus,
         engine_state.clone(),
     ));
+
+    // Enable the log viewer if the opt-in flag was passed (Linux only).
+    // This registers /ws/logs in the router; nothing is exposed by default.
+    #[cfg(target_os = "linux")]
+    if args.enable_log_viewer {
+        logs::enable_log_viewer();
+        tracing::info!(
+            "Log viewer enabled at /ws/logs - unauthenticated, container logs are exposed"
+        );
+    }
 
     let app = server::create_router(tx);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,12 @@ struct RunArgs {
     #[arg(
         long,
         env = "SPARK_DASHBOARD_ENABLE_LOG_VIEWER",
-        default_value_t = false
+        // BoolishValueParser accepts 1/0, yes/no, on/off besides true/false,
+        // matching the =1 convention of the other SPARK_DASHBOARD_* env vars.
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true"
     )]
     enable_log_viewer: bool,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,9 @@ struct FrontendAssets;
 pub fn create_router(tx: broadcast::Sender<String>) -> Router {
     let mut router = Router::new()
         .route("/ws", get(crate::ws::ws_handler))
+        // Liveness probe for container HEALTHCHECK / orchestrators. Intentionally
+        // dependency-free: it reports that the HTTP server is up, not that any
+        // engine/GPU is healthy (that's surfaced over /ws).
         .route("/healthz", get(healthz))
         .fallback(static_handler)
         .with_state(tx)
@@ -37,6 +40,7 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
         path = "index.html";
     }
 
+    // Try exact file match first
     if let Some(file) = FrontendAssets::get(path) {
         let mime = mime_guess::from_path(path).first_or_octet_stream();
         return (
@@ -47,6 +51,7 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
             .into_response();
     }
 
+    // SPA fallback: serve index.html for any unmatched route
     if let Some(index) = FrontendAssets::get("index.html") {
         return (
             axum::http::StatusCode::OK,

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,15 +9,22 @@ use tower_http::cors::CorsLayer;
 struct FrontendAssets;
 
 pub fn create_router(tx: broadcast::Sender<String>) -> Router {
-    Router::new()
+    let mut router = Router::new()
         .route("/ws", get(crate::ws::ws_handler))
-        // Liveness probe for container HEALTHCHECK / orchestrators. Intentionally
-        // dependency-free: it reports that the HTTP server is up, not that any
-        // engine/GPU is healthy (that's surfaced over /ws).
         .route("/healthz", get(healthz))
         .fallback(static_handler)
         .with_state(tx)
-        .layer(CorsLayer::permissive())
+        .layer(CorsLayer::permissive());
+
+    // Conditionally register the experimental log viewer endpoint.
+    // Gated behind --enable-log-viewer so deployments can opt out of
+    // exposing unauthenticated container logs.
+    #[cfg(target_os = "linux")]
+    if crate::logs::is_log_viewer_enabled() {
+        router = router.route("/ws/logs", get(crate::logs::ws_logs_handler));
+    }
+
+    router
 }
 
 async fn healthz() -> &'static str {
@@ -30,7 +37,6 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
         path = "index.html";
     }
 
-    // Try exact file match first
     if let Some(file) = FrontendAssets::get(path) {
         let mime = mime_guess::from_path(path).first_or_octet_stream();
         return (
@@ -41,7 +47,6 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
             .into_response();
     }
 
-    // SPA fallback: serve index.html for any unmatched route
     if let Some(index) = FrontendAssets::get("index.html") {
         return (
             axum::http::StatusCode::OK,

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,6 +9,8 @@ use tower_http::cors::CorsLayer;
 struct FrontendAssets;
 
 pub fn create_router(tx: broadcast::Sender<String>) -> Router {
+    // `mut` is only exercised by the Linux-gated log-viewer block below.
+    #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
     let mut router = Router::new()
         .route("/ws", get(crate::ws::ws_handler))
         // Liveness probe for container HEALTHCHECK / orchestrators. Intentionally


### PR DESCRIPTION
## Engine-synced container log viewer

Takes over and completes the log-viewer work from #48 and #63 by @Wpnx330. Their commits are included **unchanged with original authorship** (rebase-merge will land them on `main` as-is); the engine-sync and connection-lifecycle work is added on top as two maintainer commits. Originating request: #42.

### From #48 / #63 (@Wpnx330)

- `/ws/logs` WebSocket streaming Docker container logs via bollard (no shell/docker CLI — works in the distroless image), opt-in via `--enable-log-viewer`, line-buffered stdout/stderr
- Collapsible `LogViewer` console panel: pause/resume, include/exclude text filter, auto-scroll, error/warning highlighting, 1000-line ring buffer

### Added on top (maintainer commits)

- **Logs follow the selected engine tab**: the frontend passes the active engine's endpoint as `/ws/logs?engine=<endpoint>`, validated server-side against tracked engine state — only containers the dashboard knows as engines can be streamed. Switching tabs reconnects and clears the buffer; the header shows which engine is streaming.
- **Per-container shared streams** with a self-cleaning registry: one Docker stream per container fans out to its viewers, restarts on the next connect after dying (fixes the round-2 dead-channel deferral), and stops when the last viewer leaves.
- **Lazy connect**: socket opens on first expand, closes on collapse — a never-opened console costs nothing on either side.
- **Reconnect** (2s delay, like the metrics socket) after a dropped live connection, and a **"log viewer not enabled" hint** when the backend runs without the flag, instead of a dead Disconnected badge.
- `SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1` now works (BoolishValueParser; previously only `true`/`false` parsed).

### Testing

- Rust: 141 tests (16 in `logs.rs`: line buffering, endpoint resolution incl. no-fallback-on-unknown, registry self-cleanup), clippy `-D warnings` + rustfmt clean (Linux, rust:1.97-slim)
- Frontend: `npm run build` + 188 Vitest specs (lazy connect, close-on-collapse, not-enabled hint without retry loop, reconnect-after-drop, engine param, switch-clears-buffer)
- Live-tested on the DGX Spark against 4 concurrent vLLM containers: per-engine stream selection verified by PID matching, unknown endpoint rejected, `=1` env launch verified

Version fields untouched — release-please owns them.