### PR TITLE
refactor(frontend): clear the eslint baseline and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - run: npm run lint
       - run: npm run build
       - run: npm test -- --run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,10 @@ cargo test --locked
 Frontend changes (`frontend/`):
 
 ```bash
-cd frontend && npm run build && npm test -- --run
+cd frontend && npm run lint && npm run build && npm test -- --run
 ```
+
+`npm run lint` is enforced by the `frontend` CI job and the baseline is clean — a new error fails the build, so don't let one land.
 
 If both stacks changed, run both blocks. If embedded assets changed, build the frontend first (`rust-embed` needs `frontend/dist/`).
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -20,4 +20,15 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    // Vendored shadcn/ui primitives. These are generated files that export a
+    // component next to its `cva` variants by design, which trips
+    // react-refresh/only-export-components. We don't hand-edit generated
+    // output, and fast refresh across a design-system primitive is not worth
+    // forking them for — scope the rule off here instead.
+    files: ['src/components/ui/**'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/frontend/src/__tests__/LogViewer.test.tsx
+++ b/frontend/src/__tests__/LogViewer.test.tsx
@@ -37,7 +37,7 @@ class MockWebSocket {
     if (this.onclose) this.onclose(new CloseEvent('close'))
   }
 
-  send(_data: string) {}
+  send() {}
 
   // Helper to simulate server messages
   receive(data: string) {
@@ -51,8 +51,10 @@ class MockWebSocket {
   }
 }
 
-// Restore original WebSocket type for the mock
-(globalThis as any).WebSocket = MockWebSocket as unknown as typeof WebSocket
+// Swap the global WebSocket for the mock. `globalThis` is typed without an
+// index signature, so widen it rather than reaching for `any`.
+;(globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+  MockWebSocket as unknown as typeof WebSocket
 
 /** Expand the console (which lazily opens the socket) and return the socket. */
 function expand(): MockWebSocket {

--- a/frontend/src/__tests__/engineSettings.test.ts
+++ b/frontend/src/__tests__/engineSettings.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseLatencyMode,
+  serializeLatencyMode,
+  pickLatencyValue,
+  latencyModeLabel,
+} from '@/lib/latencyMode'
+import { parseRotationState, serializeRotationState } from '@/lib/rotation'
+import { computeTrend, percentileSubline, type ChartDataPoint } from '@/lib/engineStats'
+import { fmtVal, fmtInt } from '@/lib/format'
+
+// These helpers were extracted out of the engine control/primitive components
+// so those files export components only. The behaviour is unchanged; these
+// specs pin it at the new module boundary.
+
+describe('parseLatencyMode', () => {
+  it('accepts every valid mode', () => {
+    expect(parseLatencyMode('avg')).toBe('avg')
+    expect(parseLatencyMode('p50')).toBe('p50')
+    expect(parseLatencyMode('p95')).toBe('p95')
+    expect(parseLatencyMode('p99')).toBe('p99')
+  })
+
+  it('falls back to avg for absent or unrecognised values', () => {
+    expect(parseLatencyMode(null)).toBe('avg')
+    expect(parseLatencyMode(undefined)).toBe('avg')
+    expect(parseLatencyMode('')).toBe('avg')
+    expect(parseLatencyMode('p42')).toBe('avg')
+  })
+
+  it('round-trips through serialization', () => {
+    expect(parseLatencyMode(serializeLatencyMode('p95'))).toBe('p95')
+  })
+})
+
+describe('pickLatencyValue', () => {
+  const percentiles = { p50_ms: 10, p95_ms: 20, p99_ms: 30 }
+
+  it('returns the average for avg mode, ignoring percentiles', () => {
+    expect(pickLatencyValue('avg', 5, percentiles)).toBe(5)
+    expect(pickLatencyValue('avg', null, percentiles)).toBeNull()
+  })
+
+  it('selects the matching quantile', () => {
+    expect(pickLatencyValue('p50', 5, percentiles)).toBe(10)
+    expect(pickLatencyValue('p95', 5, percentiles)).toBe(20)
+    expect(pickLatencyValue('p99', 5, percentiles)).toBe(30)
+  })
+
+  it('returns null when percentiles have not been observed', () => {
+    expect(pickLatencyValue('p95', 5, null)).toBeNull()
+  })
+})
+
+describe('latencyModeLabel', () => {
+  it('labels avg in lowercase and passes quantiles through', () => {
+    expect(latencyModeLabel('avg')).toBe('avg')
+    expect(latencyModeLabel('p99')).toBe('p99')
+  })
+})
+
+describe('parseRotationState', () => {
+  it("reads 'off' as disabled while keeping the default interval", () => {
+    expect(parseRotationState('off')).toEqual({ enabled: false, interval: 10000 })
+  })
+
+  it('reads a supported interval as enabled', () => {
+    expect(parseRotationState('3000')).toEqual({ enabled: true, interval: 3000 })
+    expect(parseRotationState('20000')).toEqual({ enabled: true, interval: 20000 })
+  })
+
+  it('falls back to the default interval for junk or absent values', () => {
+    expect(parseRotationState(null)).toEqual({ enabled: true, interval: 10000 })
+    expect(parseRotationState('7500')).toEqual({ enabled: true, interval: 10000 })
+  })
+
+  it('round-trips through serialization', () => {
+    const off = { enabled: false, interval: 5000 } as const
+    expect(parseRotationState(serializeRotationState(off)).enabled).toBe(false)
+    const on = { enabled: true, interval: 5000 } as const
+    expect(parseRotationState(serializeRotationState(on))).toEqual(on)
+  })
+})
+
+describe('computeTrend', () => {
+  const series = (values: number[]): ChartDataPoint[] =>
+    values.map((value, i) => ({ timestamp: i, value }))
+
+  it('is stable below the minimum sample count', () => {
+    expect(computeTrend(series([1, 2, 3, 4, 5]))).toBe('stable')
+  })
+
+  it('detects a rise beyond the threshold', () => {
+    expect(computeTrend(series([1, 1, 1, 1, 1, 1, 10, 10, 10]))).toBe('up')
+  })
+
+  it('detects a fall beyond the threshold', () => {
+    expect(computeTrend(series([10, 10, 10, 10, 10, 10, 1, 1, 1]))).toBe('down')
+  })
+
+  it('stays stable inside the threshold band', () => {
+    expect(computeTrend(series([100, 100, 100, 100, 100, 100, 101, 101, 101]))).toBe('stable')
+  })
+
+  it('treats growth from a zero baseline as a rise', () => {
+    expect(computeTrend(series([0, 0, 0, 0, 0, 0, 5, 5, 5]))).toBe('up')
+  })
+})
+
+describe('percentileSubline', () => {
+  it('renders all three quantiles', () => {
+    expect(percentileSubline({ p50_ms: 10.4, p95_ms: 20.6, p99_ms: 30 })).toBe(
+      'p50 10 · p95 21 · p99 30',
+    )
+  })
+
+  it('dashes individual missing quantiles', () => {
+    expect(percentileSubline({ p50_ms: 10, p95_ms: null, p99_ms: 30 })).toBe(
+      'p50 10 · p95 — · p99 30',
+    )
+  })
+
+  it('returns undefined when there is nothing to show', () => {
+    expect(percentileSubline(null)).toBeUndefined()
+    expect(percentileSubline(undefined)).toBeUndefined()
+    expect(percentileSubline({ p50_ms: null, p95_ms: null, p99_ms: null })).toBeUndefined()
+  })
+})
+
+describe('fmtVal / fmtInt', () => {
+  it('renders the placeholder for absent values', () => {
+    expect(fmtVal(null, (n) => `${n}`)).toBe('--')
+    expect(fmtInt(null)).toBe('--')
+  })
+
+  it('applies the formatter and rounds integers', () => {
+    expect(fmtVal(3, (n) => `${n} tps`)).toBe('3 tps')
+    expect(fmtInt(3.6)).toBe('4')
+    expect(fmtInt(0)).toBe('0')
+  })
+})

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -60,6 +60,23 @@ export function LogViewer({ engines = [], selectedEndpoint = null, onExpandChang
     ? (targetEngine.model?.name ?? targetEngine.endpoint)
     : null
 
+  // Identity of the connection the buffer belongs to: null while collapsed (no
+  // socket at all), otherwise the container being streamed.
+  const connectionKey = collapsed ? null : (targetEndpoint ?? '')
+  const [prevConnectionKey, setPrevConnectionKey] = useState<string | null>(null)
+
+  // Connecting fresh or to a different container: drop the previous lines. The
+  // buffer is derived from the connection identity, so it is reset during
+  // render — resetting it synchronously inside the socket effect below would
+  // paint one frame of the previous container's logs under the new label.
+  if (prevConnectionKey !== connectionKey) {
+    setPrevConnectionKey(connectionKey)
+    if (connectionKey !== null) {
+      setLogs([])
+      setConnState('connecting')
+    }
+  }
+
   useEffect(() => {
     // Lazy connect: no socket (and no backend Docker stream) until the console
     // is first expanded. Collapsing tears the socket down again, which also
@@ -69,9 +86,6 @@ export function LogViewer({ engines = [], selectedEndpoint = null, onExpandChang
     let disposed = false
     let retryTimer: ReturnType<typeof setTimeout> | null = null
     let everOpened = false
-    // Connecting fresh or to a different container: drop the previous lines.
-    setLogs([])
-    setConnState('connecting')
 
     const connect = () => {
       if (disposed) return

--- a/frontend/src/components/engines/AnimatedCounter.tsx
+++ b/frontend/src/components/engines/AnimatedCounter.tsx
@@ -39,6 +39,32 @@ export function AnimatedCounter({
   const [display, setDisplay] = useState<number | null>(value)
   const displayRef = useRef<number | null>(value)
   const rafRef = useRef<number | null>(null)
+  const [prevValue, setPrevValue] = useState<number | null>(value)
+
+  // A target we snap to rather than animate towards is derived state, so it is
+  // applied during render. Doing it from the effect below would commit one
+  // frame of the stale number before correcting it.
+  //
+  // `display` is read here instead of `displayRef` — during render the state
+  // itself is the committed value the ref mirrors, and refs must not be read
+  // while rendering. The effect syncing `display` into `displayRef` is
+  // declared first, so the animation effect below still sees the snapped
+  // value without the ref being written during render.
+  if (prevValue !== value) {
+    setPrevValue(value)
+    const from = display
+    // No previous numeric value, reduced motion, or a counter reset
+    // (target below current) -> snap, never animate downward.
+    if (
+      value === null ||
+      from === null ||
+      from === value ||
+      prefersReducedMotion() ||
+      value < from
+    ) {
+      setDisplay(value)
+    }
+  }
 
   useEffect(() => {
     displayRef.current = display
@@ -54,16 +80,13 @@ export function AnimatedCounter({
 
     if (value === null) {
       cancel()
-      setDisplay(null)
       return
     }
 
     const from = displayRef.current
-    // No previous numeric value, reduced motion, or a counter reset
-    // (target below current) -> snap, never animate downward.
+    // Snapped during render — nothing left to animate.
     if (from === null || from === value || prefersReducedMotion() || value < from) {
       cancel()
-      setDisplay(value)
       return
     }
 

--- a/frontend/src/components/engines/EngineCard.tsx
+++ b/frontend/src/components/engines/EngineCard.tsx
@@ -1,22 +1,18 @@
 import { TimeSeriesChart, type ChartSeries } from '@/components/charts/TimeSeriesChart'
-import { formatTps, formatTtft, formatDurationMs, formatCompactTokens } from '@/lib/format'
+import { formatTps, formatTtft, formatDurationMs, formatCompactTokens, fmtVal, fmtInt } from '@/lib/format'
 import type { EngineSnapshot } from '@/types/metrics'
 import type { InferenceRequest } from '@/types/events'
 import {
-  type ChartDataPoint,
-  type Trend,
   MetricTile,
   LiveWithTotal,
   KvBar,
   TrendArrow,
   GoodputTile,
   SpecDecodeSection,
-  computeTrend,
-  fmtVal,
-  fmtInt,
 } from './EngineCardPrimitives'
+import { type ChartDataPoint, type Trend, computeTrend } from '@/lib/engineStats'
 import { AnimatedCounter } from './AnimatedCounter'
-import { type LatencyMode, latencyModeLabel, pickLatencyValue } from './LatencyModeControl'
+import { type LatencyMode, latencyModeLabel, pickLatencyValue } from '@/lib/latencyMode'
 import { combinedGoodput, recomputeGoodputPct } from '@/lib/slo'
 import { useSloSettings } from '@/hooks/useSloSettings'
 import { SloSettingsControl } from './SloSettingsControl'

--- a/frontend/src/components/engines/EngineCardPrimitives.tsx
+++ b/frontend/src/components/engines/EngineCardPrimitives.tsx
@@ -4,45 +4,9 @@
  * one visual vocabulary without duplicating logic.
  */
 
-import type { LatencyPercentiles } from '@/types/metrics'
-import { formatCompactTokens, formatAcceptanceLength } from '@/lib/format'
+import { formatCompactTokens, formatAcceptanceLength, fmtVal } from '@/lib/format'
+import type { Trend } from '@/lib/engineStats'
 import { AnimatedCounter } from './AnimatedCounter'
-
-export interface ChartDataPoint {
-  timestamp: number
-  value: number
-}
-
-/**
- * Compact one-line "p50 X · p95 Y · p99 Z" rendering of histogram-derived
- * percentiles in milliseconds. Returns undefined when every quantile is
- * missing so the tile renders without a trailing line.
- */
-export function percentileSubline(p: LatencyPercentiles | null | undefined): string | undefined {
-  if (!p) return undefined
-  const fmt = (v: number | null) => (v === null ? null : Math.round(v).toString())
-  const p50 = fmt(p.p50_ms)
-  const p95 = fmt(p.p95_ms)
-  const p99 = fmt(p.p99_ms)
-  if (p50 === null && p95 === null && p99 === null) return undefined
-  return `p50 ${p50 ?? '—'} · p95 ${p95 ?? '—'} · p99 ${p99 ?? '—'}`
-}
-
-export type Trend = 'up' | 'down' | 'stable'
-
-export function computeTrend(data: ChartDataPoint[], threshold = 0.05): Trend {
-  if (data.length < 6) return 'stable'
-  const recent = data.slice(-3)
-  const older = data.slice(Math.max(0, data.length - 15), data.length - 3)
-  if (older.length < 3) return 'stable'
-  const recentAvg = recent.reduce((s, p) => s + p.value, 0) / recent.length
-  const olderAvg = older.reduce((s, p) => s + p.value, 0) / older.length
-  if (olderAvg === 0) return recentAvg > 0 ? 'up' : 'stable'
-  const change = (recentAvg - olderAvg) / Math.abs(olderAvg)
-  if (change > threshold) return 'up'
-  if (change < -threshold) return 'down'
-  return 'stable'
-}
 
 interface TrendArrowProps {
   trend: Trend
@@ -162,10 +126,6 @@ export function KvBar({ percent }: KvBarProps) {
   )
 }
 
-export function fmtVal(v: number | null, fmt: (n: number) => string): string {
-  return v === null ? '--' : fmt(v)
-}
-
 interface SpecDecodeSectionProps {
   /** Lifetime token acceptance rate (TAR), 0-100. */
   acceptanceRate: number | null
@@ -265,10 +225,6 @@ export function SpecDecodeSection({
       </div>
     </div>
   )
-}
-
-export function fmtInt(v: number | null): string {
-  return v === null ? '--' : String(Math.round(v))
 }
 
 interface GoodputTileProps {

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -5,18 +5,18 @@ import { EngineTab } from './EngineTab'
 import { EngineCard } from './EngineCard'
 import { GlobalEngineTab, GLOBAL_TAB_VALUE } from './GlobalEngineTab'
 import { GlobalEngineCard } from './GlobalEngineCard'
+import { TabRotationControl } from './TabRotationControl'
+import { LatencyModeControl } from './LatencyModeControl'
 import {
-  TabRotationControl,
   parseRotationState,
   serializeRotationState,
   type RotationInterval,
-} from './TabRotationControl'
+} from '@/lib/rotation'
 import {
-  LatencyModeControl,
   parseLatencyMode,
   serializeLatencyMode,
   type LatencyMode,
-} from './LatencyModeControl'
+} from '@/lib/latencyMode'
 import { aggregateEngines, groupRunningByProvider } from '@/lib/engineAggregate'
 import { engineDisplayName, formatGpuIndexes } from '@/lib/format'
 import { getProviderLogo } from '@/lib/providerLogo'

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -260,13 +260,6 @@ export function EngineSection({
       : undefined
     onActiveEngineGpuChange(gpuIndexes)
   }, [activeEngineGpuIndexesKey, isGlobal, onActiveEngineGpuChange])
-  useEffect(() => {
-    if (showGlobalControls || engines.length === 0) return
-    const onlyEngineKey = `${engines[0].engine_type}-${engines[0].endpoint}`
-    if (activeTab !== onlyEngineKey) {
-      setActiveTab(onlyEngineKey)
-    }
-  }, [showGlobalControls, activeTab, engines])
 
   const tabOrder = useMemo(
     () => [
@@ -276,17 +269,38 @@ export function EngineSection({
     [engines, showGlobalControls],
   )
 
+  // `activeTab` can fall out of step with the engines actually present: it is
+  // restored from localStorage before any metrics arrive, and engines come and
+  // go at runtime. Both corrections are applied during render rather than from
+  // an effect — React discards this render pass and re-runs it, so a tab that
+  // does not exist is never committed. Done in an effect it would paint one
+  // frame of an empty or wrong tab first.
+  if (!showGlobalControls && engines.length > 0) {
+    // Single running engine: there is no global tab to sit on.
+    const onlyEngineKey = `${engines[0].engine_type}-${engines[0].endpoint}`
+    if (activeTab !== onlyEngineKey) setActiveTab(onlyEngineKey)
+  } else if (
+    engines.length > 0 &&
+    activeTab !== GLOBAL_TAB_VALUE &&
+    !tabOrder.includes(activeTab)
+  ) {
+    // The selected engine is gone — fall back to the aggregate tab.
+    setActiveTab(GLOBAL_TAB_VALUE)
+  }
+
+  // Clearing the persisted tab is a write to an external store, so it stays in
+  // an effect. Runs after the correction above has settled.
   useEffect(() => {
     if (engines.length === 0) return
-    if (activeTab === GLOBAL_TAB_VALUE) return
-    if (tabOrder.includes(activeTab)) return
-    setActiveTab(GLOBAL_TAB_VALUE)
-    if (typeof window !== 'undefined') {
-      try {
+    if (activeTab !== GLOBAL_TAB_VALUE) return
+    if (typeof window === 'undefined') return
+    try {
+      const stored = window.localStorage.getItem(ACTIVE_TAB_STORAGE_KEY)
+      if (stored !== null && stored !== GLOBAL_TAB_VALUE && !tabOrder.includes(stored)) {
         window.localStorage.removeItem(ACTIVE_TAB_STORAGE_KEY)
-      } catch {
-        // ignore storage errors
       }
+    } catch {
+      // ignore storage errors
     }
   }, [engines.length, activeTab, tabOrder])
 

--- a/frontend/src/components/engines/GlobalEngineCard.tsx
+++ b/frontend/src/components/engines/GlobalEngineCard.tsx
@@ -1,8 +1,8 @@
-import { formatTps, formatTtft, formatDurationMs, formatCompactTokens } from '@/lib/format'
+import { formatTps, formatTtft, formatDurationMs, formatCompactTokens, fmtVal, fmtInt } from '@/lib/format'
 import type { AggregateSnapshot } from '@/lib/engineAggregate'
-import { MetricTile, LiveWithTotal, KvBar, GoodputTile, SpecDecodeSection, fmtVal, fmtInt } from './EngineCardPrimitives'
+import { MetricTile, LiveWithTotal, KvBar, GoodputTile, SpecDecodeSection } from './EngineCardPrimitives'
 import { AnimatedCounter } from './AnimatedCounter'
-import { type LatencyMode, latencyModeLabel, pickLatencyValue } from './LatencyModeControl'
+import { type LatencyMode, latencyModeLabel, pickLatencyValue } from '@/lib/latencyMode'
 import { SLO, combinedGoodput } from '@/lib/slo'
 
 interface GlobalEngineCardProps {

--- a/frontend/src/components/engines/LatencyModeControl.tsx
+++ b/frontend/src/components/engines/LatencyModeControl.tsx
@@ -1,12 +1,11 @@
 /**
- * Global selector for which latency value the dashboard surfaces in TTFT,
- * E2E, and ITL tiles. "avg" matches the historical default; p50/p95/p99
- * pull from the histogram-derived percentiles exposed by the backend.
+ * Dropdown for the global latency statistic (avg / p50 / p95 / p99).
+ *
+ * The mode's type and its pure helpers live in `@/lib/latencyMode` so this
+ * file exports only its component.
  */
 
-export type LatencyMode = 'avg' | 'p50' | 'p95' | 'p99'
-
-const DEFAULT_MODE: LatencyMode = 'avg'
+import { isLatencyMode, type LatencyMode } from '@/lib/latencyMode'
 
 const OPTIONS: { value: LatencyMode; label: string }[] = [
   { value: 'avg', label: 'Avg' },
@@ -14,19 +13,6 @@ const OPTIONS: { value: LatencyMode; label: string }[] = [
   { value: 'p95', label: 'p95' },
   { value: 'p99', label: 'p99' },
 ]
-
-function isLatencyMode(v: string): v is LatencyMode {
-  return v === 'avg' || v === 'p50' || v === 'p95' || v === 'p99'
-}
-
-export function parseLatencyMode(raw: string | null | undefined): LatencyMode {
-  if (raw && isLatencyMode(raw)) return raw
-  return DEFAULT_MODE
-}
-
-export function serializeLatencyMode(mode: LatencyMode): string {
-  return mode
-}
 
 interface LatencyModeControlProps {
   mode: LatencyMode
@@ -64,29 +50,4 @@ export function LatencyModeControl({ mode, onModeChange }: LatencyModeControlPro
       </div>
     </div>
   )
-}
-
-/**
- * Resolve the millisecond value to display for a given latency dimension.
- * Returns null when the requested mode has no data (e.g. percentiles not
- * yet observed) so consumers render a dash.
- */
-import type { LatencyPercentiles } from '@/types/metrics'
-
-export function pickLatencyValue(
-  mode: LatencyMode,
-  avgMs: number | null,
-  percentiles: LatencyPercentiles | null,
-): number | null {
-  if (mode === 'avg') return avgMs
-  if (!percentiles) return null
-  if (mode === 'p50') return percentiles.p50_ms
-  if (mode === 'p95') return percentiles.p95_ms
-  return percentiles.p99_ms
-}
-
-/** Title-friendly label for the active mode. */
-export function latencyModeLabel(mode: LatencyMode): string {
-  if (mode === 'avg') return 'avg'
-  return mode
 }

--- a/frontend/src/components/engines/SloSettingsControl.tsx
+++ b/frontend/src/components/engines/SloSettingsControl.tsx
@@ -52,11 +52,15 @@ export function SloSettingsControl({
   const [draft, setDraft] = useState<FieldDraft>(() => toDraft(thresholds))
   const containerRef = useRef<HTMLDivElement | null>(null)
 
-  // Sync the local draft when external thresholds change (e.g. user
-  // switches model and the hook reloads stored values).
-  useEffect(() => {
+  // Sync the local draft when external thresholds change (e.g. user switches
+  // model and the hook reloads stored values). The draft is derived from the
+  // prop, so it is adjusted during render rather than from an effect, which
+  // would show the previous model's numbers for one frame.
+  const [prevThresholds, setPrevThresholds] = useState(thresholds)
+  if (prevThresholds !== thresholds) {
+    setPrevThresholds(thresholds)
     setDraft(toDraft(thresholds))
-  }, [thresholds])
+  }
 
   // Click-outside + Escape close the popover.
   useEffect(() => {

--- a/frontend/src/components/engines/TabRotationControl.tsx
+++ b/frontend/src/components/engines/TabRotationControl.tsx
@@ -1,9 +1,15 @@
-export type RotationInterval = 3000 | 5000 | 10000 | 20000
+/**
+ * Toggle plus interval dropdown for engine tab auto-rotation.
+ *
+ * The rotation state's types and pure helpers live in `@/lib/rotation` so
+ * this file exports only its component.
+ */
 
-export interface RotationState {
-  enabled: boolean
-  interval: RotationInterval
-}
+import {
+  parseInterval,
+  serializeInterval,
+  type RotationInterval,
+} from '@/lib/rotation'
 
 interface TabRotationControlProps {
   enabled: boolean
@@ -18,32 +24,6 @@ const OPTIONS: { value: RotationInterval; label: string }[] = [
   { value: 10000, label: '10s' },
   { value: 20000, label: '20s' },
 ]
-
-const DEFAULT_INTERVAL: RotationInterval = 10000
-
-function isRotationInterval(n: number): n is RotationInterval {
-  return n === 3000 || n === 5000 || n === 10000 || n === 20000
-}
-
-export function serializeRotationState(state: RotationState): string {
-  return state.enabled ? String(state.interval) : 'off'
-}
-
-export function parseRotationState(raw: string | null | undefined): RotationState {
-  if (raw === 'off') return { enabled: false, interval: DEFAULT_INTERVAL }
-  const n = Number(raw)
-  if (isRotationInterval(n)) return { enabled: true, interval: n }
-  return { enabled: true, interval: DEFAULT_INTERVAL }
-}
-
-function serializeInterval(value: RotationInterval): string {
-  return String(value)
-}
-
-function parseInterval(raw: string): RotationInterval {
-  const n = Number(raw)
-  return isRotationInterval(n) ? n : DEFAULT_INTERVAL
-}
 
 export function TabRotationControl({
   enabled,

--- a/frontend/src/hooks/useMetrics.ts
+++ b/frontend/src/hooks/useMetrics.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import type { MetricsSnapshot } from '../types/metrics'
 
 export type ConnectionStatus = 'connected' | 'reconnecting' | 'disconnected'
@@ -14,51 +14,57 @@ export function useMetrics() {
   const pendingRef = useRef<MetricsSnapshot | null>(null)
   const initialFlushDone = useRef(false)
 
-  const connect = useCallback(() => {
-    const wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`
-    const ws = new WebSocket(wsUrl)
-    wsRef.current = ws
-
-    ws.onopen = () => {
-      setConnectionStatus('connected')
-      attemptRef.current = 0
-    }
-
-    ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data) as MetricsSnapshot
-        lastMessageTime.current = Date.now()
-        pendingRef.current = data
-        // Render the very first snapshot immediately so the UI isn't blank
-        if (!initialFlushDone.current) {
-          initialFlushDone.current = true
-          setMetrics(data)
-          pendingRef.current = null
-          setIsStale(false)
-        }
-      } catch { /* ignore parse errors */ }
-    }
-
-    ws.onclose = () => {
-      wsRef.current = null
-      setConnectionStatus('reconnecting')
-      const delay = Math.min(1000 * Math.pow(2, attemptRef.current), 10000)
-      attemptRef.current++
-      reconnectTimeout.current = setTimeout(connect, delay)
-    }
-
-    ws.onerror = () => {
-      ws.close()
-    }
-  }, [])
-
+  // `connect` is declared inside the effect rather than as a `useCallback`
+  // because the reconnect path schedules `connect` itself. A `useCallback`
+  // cannot reference its own binding without reading it before it is
+  // initialised; a function declaration in the effect scope is hoisted, so
+  // the self-reference is well-defined. The socket is a mount-scoped external
+  // resource, so the effect is its natural owner anyway.
   useEffect(() => {
+    function connect() {
+      const wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`
+      const ws = new WebSocket(wsUrl)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        setConnectionStatus('connected')
+        attemptRef.current = 0
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data) as MetricsSnapshot
+          lastMessageTime.current = Date.now()
+          pendingRef.current = data
+          // Render the very first snapshot immediately so the UI isn't blank
+          if (!initialFlushDone.current) {
+            initialFlushDone.current = true
+            setMetrics(data)
+            pendingRef.current = null
+            setIsStale(false)
+          }
+        } catch { /* ignore parse errors */ }
+      }
+
+      ws.onclose = () => {
+        wsRef.current = null
+        setConnectionStatus('reconnecting')
+        const delay = Math.min(1000 * Math.pow(2, attemptRef.current), 10000)
+        attemptRef.current++
+        reconnectTimeout.current = setTimeout(connect, delay)
+      }
+
+      ws.onerror = () => {
+        ws.close()
+      }
+    }
+
     connect()
     return () => {
       wsRef.current?.close()
       if (reconnectTimeout.current) clearTimeout(reconnectTimeout.current)
     }
-  }, [connect])
+  }, [])
 
   // Periodic flush: push the latest pending snapshot into React state.
   // Skips when the tab is hidden so the browser can fully throttle the page.

--- a/frontend/src/hooks/useSloSettings.ts
+++ b/frontend/src/hooks/useSloSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { DEFAULT_SLO, type SloThresholds } from '@/lib/slo'
 
 const STORAGE_PREFIX = 'spark-dashboard:slo'
@@ -81,12 +81,16 @@ export function useSloSettings(engineKey: string, modelName: string | null): {
   })
 
   // When the engine/model identity changes (e.g. user switches tabs to a
-  // different served model in the same browser session), reload the value
-  // for that key. Without this effect, the hook would stick to whatever
-  // was loaded on first mount.
-  useEffect(() => {
+  // different served model in the same browser session), reload the value for
+  // that key. Without this the hook would stick to whatever was loaded on
+  // first mount. Done during render rather than in an effect: the thresholds
+  // are derived from `key`, and re-deriving in an effect would render one
+  // frame of the previous model's thresholds before correcting itself.
+  const [prevKey, setPrevKey] = useState(key)
+  if (prevKey !== key) {
+    setPrevKey(key)
     setThresholdsState(readFromStorage(key) ?? DEFAULT_SLO)
-  }, [key])
+  }
 
   const setThresholds = useCallback(
     (next: SloThresholds) => {

--- a/frontend/src/hooks/useTabRotation.ts
+++ b/frontend/src/hooks/useTabRotation.ts
@@ -51,10 +51,21 @@ export function useTabRotation({
 
   const active = enabled && intervalMs > 0 && order.length > 1
 
+  // A new rotation cycle starts whenever any input to the timer changes. That
+  // makes `cycle` derived state, so it is adjusted during render rather than
+  // from an effect — calling setState synchronously inside the timer effect
+  // below would schedule a second render pass on every cycle.
+  const cycleKey = `${active}|${intervalMs}|${activeTab}|${orderKey}`
+  const [prevCycleKey, setPrevCycleKey] = useState<string | null>(null)
+  if (prevCycleKey !== cycleKey) {
+    setPrevCycleKey(cycleKey)
+    // Deactivating ends the current cycle without starting a new one, so the
+    // countdown bar is not restarted just to be hidden.
+    if (active) setCycle((c) => c + 1)
+  }
+
   useEffect(() => {
     if (!active) return
-
-    setCycle((c) => c + 1)
 
     const id = window.setTimeout(() => {
       const currentOrder = orderRef.current

--- a/frontend/src/lib/engineStats.ts
+++ b/frontend/src/lib/engineStats.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure derivations over engine chart data and histogram percentiles.
+ *
+ * Lives here rather than beside `EngineCardPrimitives` so that file exports
+ * only components — a file mixing component and non-component exports breaks
+ * Vite fast refresh (`react-refresh/only-export-components`).
+ */
+
+import type { LatencyPercentiles } from '@/types/metrics'
+
+export interface ChartDataPoint {
+  timestamp: number
+  value: number
+}
+
+export type Trend = 'up' | 'down' | 'stable'
+
+/**
+ * Compact one-line "p50 X · p95 Y · p99 Z" rendering of histogram-derived
+ * percentiles in milliseconds. Returns undefined when every quantile is
+ * missing so the tile renders without a trailing line.
+ */
+export function percentileSubline(p: LatencyPercentiles | null | undefined): string | undefined {
+  if (!p) return undefined
+  const fmt = (v: number | null) => (v === null ? null : Math.round(v).toString())
+  const p50 = fmt(p.p50_ms)
+  const p95 = fmt(p.p95_ms)
+  const p99 = fmt(p.p99_ms)
+  if (p50 === null && p95 === null && p99 === null) return undefined
+  return `p50 ${p50 ?? '—'} · p95 ${p95 ?? '—'} · p99 ${p99 ?? '—'}`
+}
+
+export function computeTrend(data: ChartDataPoint[], threshold = 0.05): Trend {
+  if (data.length < 6) return 'stable'
+  const recent = data.slice(-3)
+  const older = data.slice(Math.max(0, data.length - 15), data.length - 3)
+  if (older.length < 3) return 'stable'
+  const recentAvg = recent.reduce((s, p) => s + p.value, 0) / recent.length
+  const olderAvg = older.reduce((s, p) => s + p.value, 0) / older.length
+  if (olderAvg === 0) return recentAvg > 0 ? 'up' : 'stable'
+  const change = (recentAvg - olderAvg) / Math.abs(olderAvg)
+  if (change > threshold) return 'up'
+  if (change < -threshold) return 'down'
+  return 'stable'
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -150,3 +150,14 @@ export function engineDisplayName(engineType: EngineType): string {
   }
   return names[engineType]
 }
+
+/** Apply a formatter to a nullable metric, rendering '--' when absent.
+ *  The engine tiles' universal "no data yet" placeholder. */
+export function fmtVal(v: number | null, fmt: (n: number) => string): string {
+  return v === null ? '--' : fmt(v)
+}
+
+/** Render a nullable metric as a rounded integer, '--' when absent. */
+export function fmtInt(v: number | null): string {
+  return v === null ? '--' : String(Math.round(v))
+}

--- a/frontend/src/lib/latencyMode.ts
+++ b/frontend/src/lib/latencyMode.ts
@@ -1,0 +1,51 @@
+/**
+ * Global selector for which latency value the dashboard surfaces in TTFT,
+ * E2E, and ITL tiles. "avg" matches the historical default; p50/p95/p99
+ * pull from the histogram-derived percentiles exposed by the backend.
+ *
+ * Lives here rather than beside `LatencyModeControl` so the control file
+ * exports only its component — a file mixing component and non-component
+ * exports breaks Vite fast refresh (`react-refresh/only-export-components`).
+ */
+
+import type { LatencyPercentiles } from '@/types/metrics'
+
+export type LatencyMode = 'avg' | 'p50' | 'p95' | 'p99'
+
+export const DEFAULT_LATENCY_MODE: LatencyMode = 'avg'
+
+export function isLatencyMode(v: string): v is LatencyMode {
+  return v === 'avg' || v === 'p50' || v === 'p95' || v === 'p99'
+}
+
+export function parseLatencyMode(raw: string | null | undefined): LatencyMode {
+  if (raw && isLatencyMode(raw)) return raw
+  return DEFAULT_LATENCY_MODE
+}
+
+export function serializeLatencyMode(mode: LatencyMode): string {
+  return mode
+}
+
+/**
+ * Resolve the millisecond value to display for a given latency dimension.
+ * Returns null when the requested mode has no data (e.g. percentiles not
+ * yet observed) so consumers render a dash.
+ */
+export function pickLatencyValue(
+  mode: LatencyMode,
+  avgMs: number | null,
+  percentiles: LatencyPercentiles | null,
+): number | null {
+  if (mode === 'avg') return avgMs
+  if (!percentiles) return null
+  if (mode === 'p50') return percentiles.p50_ms
+  if (mode === 'p95') return percentiles.p95_ms
+  return percentiles.p99_ms
+}
+
+/** Title-friendly label for the active mode. */
+export function latencyModeLabel(mode: LatencyMode): string {
+  if (mode === 'avg') return 'avg'
+  return mode
+}

--- a/frontend/src/lib/rotation.ts
+++ b/frontend/src/lib/rotation.ts
@@ -1,0 +1,42 @@
+/**
+ * Auto-rotation state for the engine tab strip: whether rotation is on, and
+ * how long each tab is held. Persisted as a single string ('off' or the
+ * interval in ms).
+ *
+ * Lives here rather than beside `TabRotationControl` so the control file
+ * exports only its component — a file mixing component and non-component
+ * exports breaks Vite fast refresh (`react-refresh/only-export-components`).
+ */
+
+export type RotationInterval = 3000 | 5000 | 10000 | 20000
+
+export interface RotationState {
+  enabled: boolean
+  interval: RotationInterval
+}
+
+export const DEFAULT_ROTATION_INTERVAL: RotationInterval = 10000
+
+export function isRotationInterval(n: number): n is RotationInterval {
+  return n === 3000 || n === 5000 || n === 10000 || n === 20000
+}
+
+export function serializeRotationState(state: RotationState): string {
+  return state.enabled ? String(state.interval) : 'off'
+}
+
+export function parseRotationState(raw: string | null | undefined): RotationState {
+  if (raw === 'off') return { enabled: false, interval: DEFAULT_ROTATION_INTERVAL }
+  const n = Number(raw)
+  if (isRotationInterval(n)) return { enabled: true, interval: n }
+  return { enabled: true, interval: DEFAULT_ROTATION_INTERVAL }
+}
+
+export function serializeInterval(value: RotationInterval): string {
+  return String(value)
+}
+
+export function parseInterval(raw: string): RotationInterval {
+  const n = Number(raw)
+  return isRotationInterval(n) ? n : DEFAULT_ROTATION_INTERVAL
+}


### PR DESCRIPTION
Clears the frontend lint baseline and wires `npm run lint` into CI, so it stays clear.

Prerequisite for #70 (the panel rework), which called this out as an open decision:

> four of the seven derived-state fixes are in engine-block components that this rework decomposes and rewrites. Fixing them now is arguably churn. The options are to fix all 23 for a clean baseline, or to fix only the durable ones.

**Resolved as: fix all 23, and enforce in CI.** The churn argument is real but loses to a simpler one — the entire point of clearing the baseline is that new errors become detectable during a change of this size. A partial fix leaves lint red, so CI cannot enforce it, so nothing detects new errors. You avoid the churn and forfeit the benefit with it. Four extra fixes in files due for rewrite is the cheap half of that trade. Recorded on #70.

## The 23 errors, by class

| Class | Count | Fix |
|---|---|---|
| `react-refresh/only-export-components` | 13 | Extract non-component exports to `src/lib/`; scoped override for vendored `ui/` |
| `react-hooks/set-state-in-effect` | 7 | Adjust derived state during render |
| `react-hooks/immutability` | 1 | Declare `connect` inside its effect |
| test hygiene (`no-unused-vars`, `no-explicit-any`) | 2 | Drop the parameter, widen `globalThis` |

## Commits

Five, each building standalone (this repo rebase-merges). Verified per commit: `tsc -b` clean on all five, and lint errors go 23 → 10 → 3 → 2 → 0, with CI enforcement landing last so no commit fails its own gate.

1. **`refactor(frontend): extract pure helpers out of component files`** — new `src/lib/latencyMode.ts`, `src/lib/rotation.ts`, `src/lib/engineStats.ts`; `fmtVal`/`fmtInt` join the other formatters in `format.ts`. Functions moved verbatim.
2. **`refactor(frontend): adjust derived state during render, not in effects`** — `useTabRotation`, `useSloSettings`, `SloSettingsControl`, `AnimatedCounter`, `LogViewer`, `EngineSection`.
3. **`refactor(frontend): declare the metrics socket's connect inside its effect`**
4. **`test(frontend): tighten the LogViewer spec's WebSocket mock`**
5. **`ci(frontend): enforce eslint in the frontend job`** — plus the documented pre-push command in `CLAUDE.md`.

All `refactor`/`test`/`ci`, so no version bump and nothing user-facing in the changelog — correct for a lint cleanup with no behaviour change.

## Notes for review

**The vendored shadcn primitives get a config override, not an edit.** Three of the 13 are `badge.tsx`, `button.tsx` and `tabs.tsx`, which export a component next to its `cva` variants by design. They are generated files; the rule is scoped off for `src/components/ui/**` with the reasoning in `eslint.config.js`.

**`EngineSection`'s localStorage cleanup stays in an effect.** The active-tab *correction* moved to render, but clearing the persisted key is a write to an external store, not derived state, so it remains an effect keyed on the settled tab.

**`AnimatedCounter` reads `display`, not `displayRef`, during render.** Refs must not be read while rendering. The effect mirroring `display` into `displayRef` is declared before the animation effect, so the animation still sees the snapped value without the ref being written during render.

**`EngineSection`'s two tab-correction effects collapsed into one guarded block.** Previously both could fire in the same commit and fight, converging over two passes; the `else if` form reaches the same final tab in one.

## Verification

```
npx eslint .        ✓  0 errors (was 23)
npm run build       ✓  tsc -b + vite, clean
npm test -- --run   ✓  22 files, 213 tests
```

Test count 192 → 213: 21 new cases in `engineSettings.test.ts` pinning the extracted pure functions at their new module boundary. No existing spec changed except the mock typing in commit 4.

Run locally in a `node:24-slim` container (no local node); CI is the authority.

Refs #70
