### PR TITLE
feat(server): state directory and dashboard-configuration API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2100,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "tempfile",
  "tokio",
  "tower-http 0.7.0",
  "tracing",
@@ -2200,6 +2207,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ futures-util = "0.3"
 nvml-wrapper = "0.12"
 procfs = "0.18"
 bollard = "0.21"
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ sudo spark-dashboard service status       # same as `systemctl status`
 
 Optional overrides live in `/etc/spark-dashboard/config.env` — set
 `SPARK_DASHBOARD_PORT`, `SPARK_DASHBOARD_BIND`, `SPARK_DASHBOARD_POLL_INTERVAL`,
-`SPARK_DASHBOARD_GPU_INDEX`, `SPARK_DASHBOARD_PROVIDER_API_KEY`, or `RUST_LOG`, then
+`SPARK_DASHBOARD_GPU_INDEX`, `SPARK_DASHBOARD_STATE_DIR`,
+`SPARK_DASHBOARD_PROVIDER_API_KEY`, or `RUST_LOG`, then
 `sudo systemctl restart spark-dashboard`.
 
 ### Upgrade
@@ -236,6 +237,7 @@ spark-dashboard service status
   -p, --port <PORT>           Listen port [default: 3000] [env: SPARK_DASHBOARD_PORT]
   -b, --bind <BIND>           Bind address [default: 0.0.0.0] [env: SPARK_DASHBOARD_BIND]
       --poll-interval <MS>    Polling interval ms [default: 1000] [env: SPARK_DASHBOARD_POLL_INTERVAL]
+      --state-dir <DIR>       Directory for saved state [default: /var/lib/spark-dashboard] [env: SPARK_DASHBOARD_STATE_DIR]
       --gpu-index <IDX>       Optional NVML GPU index to monitor [env: SPARK_DASHBOARD_GPU_INDEX]
       --simulate-gpus <N>     Append N fictive GPUs with simulated data (dev aid) [env: SPARK_DASHBOARD_SIMULATE_GPUS]
       --engine <TYPE>         Manual engine type (e.g. vllm) [env: SPARK_DASHBOARD_ENGINE]
@@ -258,6 +260,38 @@ For auth-gated deployments (e.g. vLLM started with `--api-key`), pass
 engines too. Model info is resolved from `/v1/models` once and cached —
 re-resolved only on engine restart or every 10 minutes — so an auth-gated
 engine is no longer hit on every poll tick.
+
+### Dashboard configuration API
+
+The dashboard configuration is a single document shared by everyone who opens
+the instance, stored at `<state-dir>/dashboards.json`. The server keeps it as
+opaque bytes — it never parses or validates the contents, and enforces only a
+1 MiB size cap. Writes are atomic, and last write wins.
+
+```
+GET    /api/dashboard   the document, or 204 when none is stored
+PUT    /api/dashboard   replaces it wholesale (204 on success)
+DELETE /api/dashboard   removes it, resetting to the default preset (204)
+```
+
+`204` on read means "nothing saved" rather than an error — a fresh install and
+a reset look identical, and the dashboard renders its default preset for both.
+A write over the cap is rejected with `413`, leaving the stored document
+untouched.
+
+Every response carries `x-spark-dashboard-read-only`. It is `true` when the
+state directory was not writable at startup, in which case reads still work,
+writes are refused with `503`, and the dashboard shows a read-only banner
+instead of pretending a save succeeded. A write that fails for some other
+reason — a full disk, say — returns `500` and leaves the header `false`.
+
+```bash
+curl -i localhost:3000/api/dashboard                       # read
+curl -X PUT localhost:3000/api/dashboard -d '{"pages":[]}' # save
+curl -X DELETE localhost:3000/api/dashboard                # reset
+```
+
+Unmatched paths under `/api` return `404` rather than the app shell.
 
 ### Log viewer (`--enable-log-viewer`, Linux only, opt-in)
 

--- a/src/cli/healthcheck.rs
+++ b/src/cli/healthcheck.rs
@@ -46,7 +46,11 @@ mod tests {
     #[tokio::test]
     async fn probe_succeeds_against_running_server() {
         let (tx, _rx) = broadcast::channel::<String>(16);
-        let app = crate::server::create_router(tx);
+        let dir = tempfile::tempdir().unwrap();
+        let app = crate::server::create_router(crate::server::AppState {
+            metrics_tx: tx,
+            config: std::sync::Arc::new(crate::config_store::ConfigStore::new(dir.path()).await),
+        });
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();

--- a/src/config_store.rs
+++ b/src/config_store.rs
@@ -1,0 +1,339 @@
+//! Storage for the dashboard configuration document.
+//!
+//! The document is a single instance-scoped file under the state directory. The
+//! server treats it as **opaque bytes**: it never parses, validates or migrates
+//! the contents. All schema knowledge lives in the frontend, which deliberately
+//! avoids a second cross-language contract alongside the metrics contract.
+//!
+//! "No stored document" is a first-class state rather than an error — it is what
+//! a fresh install looks like, and it is what a reset returns to. The frontend
+//! reads it as "render the default preset".
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::io::AsyncWriteExt;
+
+/// Largest document the server will store.
+///
+/// The document holds panel geometry and per-panel configuration for a handful
+/// of pages — kilobytes in practice. The cap exists so an unauthenticated write
+/// endpoint cannot fill the state volume, not because a real configuration is
+/// expected to come close to it.
+pub const MAX_DOCUMENT_BYTES: usize = 1024 * 1024;
+
+const DOCUMENT_FILE_NAME: &str = "dashboards.json";
+
+/// Reads and writes the dashboard configuration document.
+#[derive(Debug)]
+pub struct ConfigStore {
+    path: PathBuf,
+    read_only: bool,
+}
+
+impl ConfigStore {
+    /// Prepares the state directory and probes whether it can be written to.
+    ///
+    /// A directory that cannot be created or written is not fatal: the server
+    /// still starts and still serves reads, and [`ConfigStore::is_read_only`]
+    /// reports the degraded state so the client can show its banner. Falling
+    /// back to browser-local storage is deliberately not an option — the
+    /// configuration is shared by everyone who opens the instance.
+    pub async fn new(state_dir: &Path) -> Self {
+        let path = state_dir.join(DOCUMENT_FILE_NAME);
+
+        let writable = match tokio::fs::create_dir_all(state_dir).await {
+            Ok(()) => probe_writable(state_dir).await,
+            Err(err) => {
+                tracing::warn!(
+                    "state directory {} could not be created ({err})",
+                    state_dir.display()
+                );
+                false
+            }
+        };
+
+        if !writable {
+            tracing::warn!(
+                "state directory {} is not writable; the dashboard configuration \
+                 cannot be saved and the dashboard will run read-only",
+                state_dir.display()
+            );
+        }
+
+        Self {
+            path,
+            read_only: !writable,
+        }
+    }
+
+    /// Returns the stored document, or `None` when nothing has been stored.
+    pub async fn load(&self) -> io::Result<Option<Vec<u8>>> {
+        match tokio::fs::read(&self.path).await {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Replaces the stored document wholesale.
+    ///
+    /// The write is atomic — the bytes land in a uniquely named temporary file
+    /// in the same directory, are flushed to disk, and are then renamed over the
+    /// target. A crash mid-write therefore leaves either the old document or the
+    /// new one, never a truncated file that would brick the dashboard for every
+    /// viewer at once.
+    pub async fn store(&self, bytes: &[u8]) -> io::Result<()> {
+        let tmp = self.path.with_extension(format!("tmp-{}", unique_suffix()));
+
+        match write_and_sync(&tmp, bytes).await {
+            Ok(()) => {}
+            Err(err) => {
+                let _ = tokio::fs::remove_file(&tmp).await;
+                return Err(err);
+            }
+        }
+
+        // Same-directory rename is atomic, so concurrent writers race to be last
+        // rather than corrupting each other. Last-write-wins is the documented
+        // semantic for an instance-scoped configuration with no authentication.
+        if let Err(err) = tokio::fs::rename(&tmp, &self.path).await {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    /// Removes the stored document. Deleting an absent document succeeds:
+    /// "no document" is the state the caller asked for, and it is already true.
+    pub async fn delete(&self) -> io::Result<()> {
+        match tokio::fs::remove_file(&self.path).await {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Whether the state directory was unwritable at startup, meaning no write
+    /// can succeed. A write that fails for some other reason later — a full or
+    /// failing disk — is a plain error, not this.
+    pub fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
+async fn write_and_sync(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let mut file = tokio::fs::File::create(path).await?;
+    file.write_all(bytes).await?;
+    // Without this the rename can be durable while the contents are not.
+    file.sync_all().await?;
+    Ok(())
+}
+
+async fn probe_writable(dir: &Path) -> bool {
+    let probe = dir.join(format!(".write-probe-{}", unique_suffix()));
+    match tokio::fs::write(&probe, b"").await {
+        Ok(()) => {
+            let _ = tokio::fs::remove_file(&probe).await;
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Distinguishes temporary files belonging to concurrent writers, in this
+/// process and across processes sharing a state directory.
+fn unique_suffix() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!(
+        "{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Root ignores directory permissions, so the read-only tests below cannot
+    /// hold when the suite runs privileged (a root container, say). CI runs as
+    /// an unprivileged user, where they do exercise the real path.
+    #[cfg(unix)]
+    async fn can_still_write(dir: &Path) -> bool {
+        let probe = dir.join(".privilege-check");
+        match tokio::fs::write(&probe, b"").await {
+            Ok(()) => {
+                let _ = tokio::fs::remove_file(&probe).await;
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    #[tokio::test]
+    async fn load_reports_absent_when_nothing_is_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::new(dir.path()).await;
+
+        assert_eq!(store.load().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn store_then_load_round_trips_byte_identically() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::new(dir.path()).await;
+
+        store.store(b"{\"schemaVersion\":1}").await.unwrap();
+
+        assert_eq!(
+            store.load().await.unwrap().as_deref(),
+            Some(&b"{\"schemaVersion\":1}"[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn store_round_trips_bytes_the_server_cannot_interpret() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::new(dir.path()).await;
+
+        // Not JSON, not even UTF-8. The store must not care.
+        let opaque = [0xff, 0xfe, 0x00, 0x01, b'n', b'o', b't', b' ', b'j'];
+        store.store(&opaque).await.unwrap();
+
+        assert_eq!(store.load().await.unwrap().as_deref(), Some(&opaque[..]));
+    }
+
+    #[tokio::test]
+    async fn store_replaces_the_previous_document_wholesale() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::new(dir.path()).await;
+
+        store.store(b"first-and-considerably-longer").await.unwrap();
+        store.store(b"second").await.unwrap();
+
+        assert_eq!(store.load().await.unwrap().as_deref(), Some(&b"second"[..]));
+    }
+
+    #[tokio::test]
+    async fn store_leaves_no_temporary_files_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::new(dir.path()).await;
+
+        store.store(b"{}").await.unwrap();
+
+        let mut entries = tokio::fs::read_dir(dir.path()).await.unwrap();
+        let mut names = Vec::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            names.push(entry.file_name().to_string_lossy().into_owned());
+        }
+        assert_eq!(names, vec![DOCUMENT_FILE_NAME.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_the_document_and_load_reports_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::new(dir.path()).await;
+
+        store.store(b"{}").await.unwrap();
+        store.delete().await.unwrap();
+
+        assert_eq!(store.load().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn delete_succeeds_when_no_document_is_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ConfigStore::new(dir.path()).await;
+
+        store.delete().await.expect("deleting an absent document");
+    }
+
+    #[tokio::test]
+    async fn a_missing_state_directory_is_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("deeper").join("still");
+
+        let store = ConfigStore::new(&nested).await;
+
+        assert!(!store.is_read_only());
+        assert!(nested.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_unwritable_state_directory_reports_read_only_and_still_reads() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join("state");
+        tokio::fs::create_dir(&state_dir).await.unwrap();
+
+        // Seed a document while the directory is still writable, so the read
+        // path has something to return once it is locked down.
+        tokio::fs::write(state_dir.join(DOCUMENT_FILE_NAME), b"{\"seeded\":true}")
+            .await
+            .unwrap();
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
+            .await
+            .unwrap();
+
+        if can_still_write(&state_dir).await {
+            tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+                .await
+                .unwrap();
+            eprintln!("skipping: running privileged, directory permissions do not apply");
+            return;
+        }
+
+        let store = ConfigStore::new(&state_dir).await;
+
+        assert!(store.is_read_only(), "read-only directory must be detected");
+        assert_eq!(
+            store.load().await.unwrap().as_deref(),
+            Some(&b"{\"seeded\":true}"[..]),
+            "reads must keep working while writes cannot"
+        );
+        assert!(store.store(b"{}").await.is_err());
+
+        // Restore permissions so the temp dir can clean itself up.
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_failed_write_leaves_the_previous_document_intact() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join("state");
+        tokio::fs::create_dir(&state_dir).await.unwrap();
+
+        let store = ConfigStore::new(&state_dir).await;
+        store.store(b"original").await.unwrap();
+
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
+            .await
+            .unwrap();
+        let privileged = can_still_write(&state_dir).await;
+        if !privileged {
+            assert!(store.store(b"replacement").await.is_err());
+        }
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
+        if privileged {
+            eprintln!("skipping: running privileged, directory permissions do not apply");
+            return;
+        }
+
+        assert_eq!(
+            store.load().await.unwrap().as_deref(),
+            Some(&b"original"[..])
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod config_store;
 mod engines;
 mod metrics;
 mod server;
@@ -72,6 +73,19 @@ struct RunArgs {
     /// Metrics polling interval in milliseconds
     #[arg(long, env = "SPARK_DASHBOARD_POLL_INTERVAL", default_value_t = 1000)]
     poll_interval: u64,
+
+    /// Directory holding mutable state, currently the dashboard configuration
+    /// document (`<state-dir>/dashboards.json`). The default is the path a
+    /// systemd StateDirectory grant yields; until the unit grants one, and in
+    /// containers, point this somewhere writable explicitly.
+    /// An unwritable directory is not fatal — the dashboard runs read-only.
+    #[arg(
+        long,
+        value_name = "DIR",
+        env = "SPARK_DASHBOARD_STATE_DIR",
+        default_value = "/var/lib/spark-dashboard"
+    )]
+    state_dir: String,
 
     /// Optional NVML GPU index to monitor. By default, all available NVIDIA GPUs
     /// are monitored; set this to keep the dashboard focused on one device.
@@ -237,7 +251,19 @@ async fn run_server_inner(args: RunArgs) -> Result<(), Box<dyn std::error::Error
         );
     }
 
-    let app = server::create_router(tx);
+    // Persistence is always on: writing one small document is not the kind of
+    // capability the opt-in flags gate (a Docker socket, an unbounded database).
+    let config =
+        Arc::new(config_store::ConfigStore::new(std::path::Path::new(&args.state_dir)).await);
+    tracing::info!(
+        "Dashboard configuration state directory: {}",
+        args.state_dir
+    );
+
+    let app = server::create_router(server::AppState {
+        metrics_tx: tx,
+        config,
+    });
 
     let addr = format!("{}:{}", args.bind, args.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
@@ -254,9 +280,9 @@ mod tests {
     use std::sync::Mutex;
 
     /// Clap reads the environment on every parse, so any test in this module
-    /// could observe the SPARK_DASHBOARD_ENGINE* variables another test set.
+    /// could observe the SPARK_DASHBOARD_* variables another test set.
     /// Every test takes this lock; env-setting tests clean up before releasing.
-    static ENGINE_ENV_LOCK: Mutex<()> = Mutex::new(());
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn parse(args: &[&str]) -> RunArgs {
         Cli::try_parse_from(std::iter::once("spark-dashboard").chain(args.iter().copied()))
@@ -265,7 +291,7 @@ mod tests {
     }
 
     fn with_env_vars(vars: &[(&str, &str)], f: impl FnOnce()) {
-        let _guard = ENGINE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let saved: Vec<_> = vars
             .iter()
             .map(|(key, value)| {
@@ -288,7 +314,7 @@ mod tests {
 
     #[test]
     fn engine_flags_split_on_commas_and_pair_by_position() {
-        let _guard = ENGINE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let args = parse(&[
             "--engine",
             "vllm,vllm",
@@ -307,7 +333,7 @@ mod tests {
 
     #[test]
     fn repeated_engine_flags_accumulate_in_order() {
-        let _guard = ENGINE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let args = parse(&[
             "--engine",
             "vllm",
@@ -347,6 +373,27 @@ mod tests {
                 assert_eq!(args.engine_api_key, vec!["key-a", "key-b"]);
             },
         );
+    }
+
+    #[test]
+    fn state_dir_defaults_to_the_systemd_state_directory() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(parse(&[]).state_dir, "/var/lib/spark-dashboard");
+    }
+
+    #[test]
+    fn state_dir_reads_its_env_var() {
+        with_env_vars(&[("SPARK_DASHBOARD_STATE_DIR", "/srv/spark/state")], || {
+            assert_eq!(parse(&[]).state_dir, "/srv/spark/state");
+        });
+    }
+
+    #[test]
+    fn state_dir_flag_takes_precedence_over_its_env_var() {
+        with_env_vars(&[("SPARK_DASHBOARD_STATE_DIR", "/srv/spark/state")], || {
+            let args = parse(&["--state-dir", "/tmp/override"]);
+            assert_eq!(args.state_dir, "/tmp/override");
+        });
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,14 +1,57 @@
+use axum::body::Bytes;
+use axum::extract::{DefaultBodyLimit, FromRef, State};
 use axum::response::IntoResponse;
 use axum::{routing::get, Router};
 use rust_embed::Embed;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
+
+use crate::config_store::{ConfigStore, MAX_DOCUMENT_BYTES};
 
 #[derive(Embed)]
 #[folder = "frontend/dist"]
 struct FrontendAssets;
 
-pub fn create_router(tx: broadcast::Sender<String>) -> Router {
+/// Reports that the dashboard configuration cannot be saved, so the client can
+/// show its read-only banner *before* the operator arranges panels and tries.
+/// Sent on every configuration response; the document itself has to come back
+/// byte-identical, so the status cannot ride along in the body.
+const READ_ONLY_HEADER: &str = "x-spark-dashboard-read-only";
+
+/// Everything the router's handlers need. The metrics sender was previously the
+/// whole state; it is reachable through [`FromRef`] so existing handlers keep
+/// extracting `State<broadcast::Sender<String>>` unchanged.
+#[derive(Clone)]
+pub struct AppState {
+    pub metrics_tx: broadcast::Sender<String>,
+    pub config: Arc<ConfigStore>,
+}
+
+impl FromRef<AppState> for broadcast::Sender<String> {
+    fn from_ref(state: &AppState) -> Self {
+        state.metrics_tx.clone()
+    }
+}
+
+pub fn create_router(state: AppState) -> Router {
+    let api = Router::new()
+        .route(
+            "/dashboard",
+            get(get_dashboard)
+                .put(put_dashboard)
+                .delete(delete_dashboard),
+        )
+        // One cap, enforced twice at the same threshold: the layer stops the
+        // server buffering anything larger, and the handler rejects a body that
+        // is exactly one byte over so the limit is ours rather than a tower
+        // default that could drift.
+        .layer(DefaultBodyLimit::max(MAX_DOCUMENT_BYTES + 1))
+        // Without this, the SPA fallback below would answer a typo'd or
+        // unregistered API path with the app shell and status 200 — a client bug
+        // would look like success.
+        .fallback(api_not_found);
+
     // `mut` is only exercised by the Linux-gated log-viewer block below.
     #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
     let mut router = Router::new()
@@ -17,8 +60,9 @@ pub fn create_router(tx: broadcast::Sender<String>) -> Router {
         // dependency-free: it reports that the HTTP server is up, not that any
         // engine/GPU is healthy (that's surfaced over /ws).
         .route("/healthz", get(healthz))
+        .nest("/api", api)
         .fallback(static_handler)
-        .with_state(tx)
+        .with_state(state)
         .layer(CorsLayer::permissive());
 
     // Conditionally register the experimental log viewer endpoint.
@@ -36,8 +80,135 @@ async fn healthz() -> &'static str {
     "ok"
 }
 
+/// Returns the stored document verbatim, or `204 No Content` when nothing has
+/// been stored. Absence is not an error — it is what a fresh install and a reset
+/// both look like, and the client renders the default preset for it.
+async fn get_dashboard(State(state): State<AppState>) -> impl IntoResponse {
+    match state.config.load().await {
+        Ok(Some(document)) => (
+            axum::http::StatusCode::OK,
+            [
+                (
+                    axum::http::header::CONTENT_TYPE,
+                    // The server does not parse the document; this describes the
+                    // media type the resource is defined to carry, not a claim
+                    // that these particular bytes were validated.
+                    "application/json".to_string(),
+                ),
+                (
+                    axum::http::HeaderName::from_static(READ_ONLY_HEADER),
+                    state.config.is_read_only().to_string(),
+                ),
+            ],
+            document,
+        )
+            .into_response(),
+        Ok(None) => no_content(&state),
+        Err(err) => {
+            tracing::error!("reading the dashboard configuration failed: {err}");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                read_only_headers(&state),
+                "Failed to read the dashboard configuration",
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Replaces the document wholesale. The body is stored exactly as received —
+/// no parsing, no validation, no schema knowledge on this side of the wire.
+async fn put_dashboard(State(state): State<AppState>, body: Bytes) -> impl IntoResponse {
+    if body.len() > MAX_DOCUMENT_BYTES {
+        return (
+            axum::http::StatusCode::PAYLOAD_TOO_LARGE,
+            read_only_headers(&state),
+            "Dashboard configuration exceeds the size limit",
+        )
+            .into_response();
+    }
+
+    if state.config.is_read_only() {
+        return read_only_response(&state);
+    }
+
+    match state.config.store(&body).await {
+        Ok(()) => no_content(&state),
+        Err(err) => {
+            tracing::error!("writing the dashboard configuration failed: {err}");
+            write_failed_response(&state)
+        }
+    }
+}
+
+/// Removes the document, which is how a reset works: "the default preset" *is*
+/// "the file does not exist".
+async fn delete_dashboard(State(state): State<AppState>) -> impl IntoResponse {
+    if state.config.is_read_only() {
+        return read_only_response(&state);
+    }
+
+    match state.config.delete().await {
+        Ok(()) => no_content(&state),
+        Err(err) => {
+            tracing::error!("deleting the dashboard configuration failed: {err}");
+            write_failed_response(&state)
+        }
+    }
+}
+
+async fn api_not_found() -> impl IntoResponse {
+    not_found()
+}
+
+fn not_found() -> axum::response::Response {
+    (axum::http::StatusCode::NOT_FOUND, "Not Found").into_response()
+}
+
+fn no_content(state: &AppState) -> axum::response::Response {
+    (axum::http::StatusCode::NO_CONTENT, read_only_headers(state)).into_response()
+}
+
+/// This instance cannot save at all, and no retry will change that.
+fn read_only_response(state: &AppState) -> axum::response::Response {
+    (
+        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+        read_only_headers(state),
+        "Dashboard configuration storage is read-only",
+    )
+        .into_response()
+}
+
+/// The state directory was writable at startup but this write still failed — a
+/// full or failing disk, say. Deliberately *not* the read-only response: that
+/// one promises a permanent condition the client should surface as a banner,
+/// and the read-only header would contradict it.
+fn write_failed_response(state: &AppState) -> axum::response::Response {
+    (
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        read_only_headers(state),
+        "Failed to save the dashboard configuration",
+    )
+        .into_response()
+}
+
+fn read_only_headers(state: &AppState) -> [(axum::http::HeaderName, String); 1] {
+    [(
+        axum::http::HeaderName::from_static(READ_ONLY_HEADER),
+        state.config.is_read_only().to_string(),
+    )]
+}
+
 async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
     let mut path = uri.path().trim_start_matches('/');
+
+    // The nested API router's own fallback catches most unmatched API paths, but
+    // not the bare prefix (`/api`, `/api/`), which never routes into the nest.
+    // Those must not answer with the app shell either.
+    if path == "api" || path.starts_with("api/") {
+        return not_found();
+    }
+
     if path.is_empty() {
         path = "index.html";
     }
@@ -70,10 +241,15 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn healthz_returns_ok() {
+    /// Spawns the server over a fresh state directory and returns its address
+    /// alongside the directory guard, which must stay alive for the test.
+    async fn spawn(state_dir: &std::path::Path) -> String {
         let (tx, _rx) = broadcast::channel::<String>(16);
-        let app = create_router(tx);
+        let state = AppState {
+            metrics_tx: tx,
+            config: Arc::new(ConfigStore::new(state_dir).await),
+        };
+        let app = create_router(state);
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -81,10 +257,287 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
 
-        let resp = reqwest::get(format!("http://{addr}/healthz"))
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+
+        let resp = reqwest::get(format!("{base}/healthz"))
             .await
             .expect("request to /healthz");
         assert_eq!(resp.status(), reqwest::StatusCode::OK);
         assert_eq!(resp.text().await.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn reading_with_no_document_reports_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+
+        let resp = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::NO_CONTENT);
+        assert_eq!(resp.text().await.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn write_then_read_returns_the_document_byte_identically() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+        let document = r#"{"schemaVersion":1,"pages":[{"name":"Overview"}]}"#;
+
+        let put = reqwest::Client::new()
+            .put(format!("{base}/api/dashboard"))
+            .body(document)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(put.status(), reqwest::StatusCode::NO_CONTENT);
+
+        let resp = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(resp.text().await.unwrap(), document);
+    }
+
+    #[tokio::test]
+    async fn a_document_the_server_cannot_interpret_round_trips_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+        // Deliberately not JSON: the server must store bytes, not documents.
+        let opaque: Vec<u8> = vec![0xff, 0xfe, 0x00, b'{', b'n', b'o', b'p', b'e'];
+
+        let put = reqwest::Client::new()
+            .put(format!("{base}/api/dashboard"))
+            .body(opaque.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(put.status(), reqwest::StatusCode::NO_CONTENT);
+
+        let resp = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(resp.bytes().await.unwrap().to_vec(), opaque);
+    }
+
+    #[tokio::test]
+    async fn a_write_over_the_size_cap_is_rejected_and_leaves_the_document_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+        let client = reqwest::Client::new();
+
+        client
+            .put(format!("{base}/api/dashboard"))
+            .body("original")
+            .send()
+            .await
+            .unwrap();
+
+        let oversized = vec![b'x'; MAX_DOCUMENT_BYTES + 1];
+        let put = client
+            .put(format!("{base}/api/dashboard"))
+            .body(oversized)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(put.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
+
+        let resp = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+        assert_eq!(resp.text().await.unwrap(), "original");
+    }
+
+    #[tokio::test]
+    async fn delete_removes_the_document_and_a_later_read_reports_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+        let client = reqwest::Client::new();
+
+        client
+            .put(format!("{base}/api/dashboard"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+
+        let deleted = client
+            .delete(format!("{base}/api/dashboard"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(deleted.status(), reqwest::StatusCode::NO_CONTENT);
+
+        let resp = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn a_writable_instance_reports_that_it_is_not_read_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+
+        let resp = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+
+        assert_eq!(
+            resp.headers().get(READ_ONLY_HEADER).unwrap(),
+            "false",
+            "read-only status must be discoverable from the read"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_unwritable_state_directory_serves_reads_and_refuses_writes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join("state");
+        tokio::fs::create_dir(&state_dir).await.unwrap();
+        tokio::fs::write(state_dir.join("dashboards.json"), b"{\"seeded\":true}")
+            .await
+            .unwrap();
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
+            .await
+            .unwrap();
+
+        // Root ignores directory permissions; CI runs unprivileged, where this
+        // exercises the real read-only path.
+        let probe = state_dir.join(".privilege-check");
+        if tokio::fs::write(&probe, b"").await.is_ok() {
+            let _ = tokio::fs::remove_file(&probe).await;
+            tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+                .await
+                .unwrap();
+            eprintln!("skipping: running privileged, directory permissions do not apply");
+            return;
+        }
+
+        let base = spawn(&state_dir).await;
+
+        // The server came up rather than refusing to start.
+        let health = reqwest::get(format!("{base}/healthz")).await.unwrap();
+        assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+        let read = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+        assert_eq!(read.status(), reqwest::StatusCode::OK);
+        assert_eq!(read.headers().get(READ_ONLY_HEADER).unwrap(), "true");
+        assert_eq!(read.text().await.unwrap(), "{\"seeded\":true}");
+
+        let client = reqwest::Client::new();
+        let write = client
+            .put(format!("{base}/api/dashboard"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(write.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            write.headers().get(READ_ONLY_HEADER).unwrap(),
+            "true",
+            "the refusal must agree with the read-only header it carries"
+        );
+
+        let deleted = client
+            .delete(format!("{base}/api/dashboard"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(deleted.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(deleted.headers().get(READ_ONLY_HEADER).unwrap(), "true");
+
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
+    }
+
+    /// A directory that was writable at startup but is not any more. This is a
+    /// plain failure, not the permanent read-only condition — reporting it as
+    /// read-only would contradict the header, which still says `false`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_write_that_fails_after_startup_is_not_reported_as_read_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join("state");
+        tokio::fs::create_dir(&state_dir).await.unwrap();
+
+        let base = spawn(&state_dir).await;
+        let client = reqwest::Client::new();
+
+        // Writable at startup, so the store probed clean.
+        let first = client
+            .put(format!("{base}/api/dashboard"))
+            .body("original")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(first.status(), reqwest::StatusCode::NO_CONTENT);
+
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
+            .await
+            .unwrap();
+
+        let probe = state_dir.join(".privilege-check");
+        if tokio::fs::write(&probe, b"").await.is_ok() {
+            let _ = tokio::fs::remove_file(&probe).await;
+            tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+                .await
+                .unwrap();
+            eprintln!("skipping: running privileged, directory permissions do not apply");
+            return;
+        }
+
+        let failed = client
+            .put(format!("{base}/api/dashboard"))
+            .body("replacement")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(failed.status(), reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            failed.headers().get(READ_ONLY_HEADER).unwrap(),
+            "false",
+            "the instance is not read-only; this write just failed"
+        );
+
+        tokio::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
+
+        // The failed write left the previous document untouched.
+        let resp = reqwest::get(format!("{base}/api/dashboard")).await.unwrap();
+        assert_eq!(resp.text().await.unwrap(), "original");
+    }
+
+    #[tokio::test]
+    async fn an_unmatched_api_path_returns_404_rather_than_the_app_shell() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+
+        for path in ["/api/nope", "/api/dashboard/extra", "/api/", "/api"] {
+            let resp = reqwest::get(format!("{base}{path}")).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                reqwest::StatusCode::NOT_FOUND,
+                "{path} should 404"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unsupported_method_on_the_config_route_is_not_the_app_shell() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = spawn(dir.path()).await;
+
+        let resp = reqwest::Client::new()
+            .post(format!("{base}/api/dashboard"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::METHOD_NOT_ALLOWED);
     }
 }


### PR DESCRIPTION
Implements #72 — the first ticket of the panel rework (#70). Nothing in the UI changes yet; the deliverable is verifiable end to end with `curl`.

## The contract

```
GET    /api/dashboard   the document, or 204 when none is stored
PUT    /api/dashboard   replaces it wholesale (204)
DELETE /api/dashboard   removes it, resetting to the default preset (204)
```

The server stores the document as **opaque bytes** at `<state-dir>/dashboards.json` — it never parses, validates or migrates the contents, and enforces only a 1 MiB size cap. All schema knowledge lives in the frontend, which deliberately avoids a second cross-language contract alongside the metrics contract.

`204` on read means "nothing saved" rather than an error: a fresh install and a reset look identical, and both mean "render the default preset". Deleting an absent document succeeds for the same reason.

Writes are atomic — temp file in the same directory, fsync, rename over the target. A crash mid-write leaves either the old document or the new one, never a truncated file that would brick the dashboard for every viewer at once.

## Failure modes stay distinguishable

The client reacts differently to each, so they do not collapse into one status:

| Condition | Status | `x-spark-dashboard-read-only` |
|---|---|---|
| Document over the 1 MiB cap | `413` | unchanged |
| State directory unwritable at startup | `503` | `true` |
| Write failed anyway (full/failing disk) | `500` | `false` |

An unwritable state directory is **not fatal**: the server starts, serves reads, and reports it in the header so the client can show its banner *before* the operator arranges panels and tries to save. The status rides in a header because the document itself has to come back byte-identical.

The 500 case came out of review. Reporting a post-startup write failure as `503 read-only` made the response body contradict the header the banner keys off.

## Two things moved out of the way

- **The SPA fallback answered every unmatched path with the app shell and status 200**, so a typo'd API path looked like success. Unmatched `/api` paths now 404. The nested router's fallback covers most; the bare prefix (`/api`, `/api/`) never routes into the nest, so `static_handler` guards those directly — caught by a test, not by inspection.
- **Router state held only the metrics broadcast sender.** It is now `AppState`; the sender is reachable through `FromRef`, so `ws_handler` keeps extracting `State<broadcast::Sender<String>>` unchanged and `src/ws.rs` is untouched.

## Commits

Two, both building standalone (this repo rebase-merges):

1. `feat(server): store the dashboard configuration in a state directory`
2. `docs(readme): document the dashboard configuration API`

`feat` is the correct type — the endpoints are new user-facing behaviour, so this bumps minor pre-1.0.

## Notes for review

**`Content-Type: application/json` on bytes the server refuses to parse.** Deliberate: the resource's *declared* media type is JSON, and the frontend wants `res.json()`. The server not validating is an implementation choice, not a statement that the resource is typeless. Flagging it as the one judgement call worth overruling if you disagree — #77 consumes this.

**`--state-dir` defaults to `/var/lib/spark-dashboard`**, matching what a systemd `StateDirectory` grant yields, so systemd deployments need zero configuration once #73 lands. A local unprivileged run therefore boots read-only — visibly, via a startup warning and the banner, which is the designed degradation rather than a silent failure.

**`state_dir` is a `String`, not a `PathBuf`**, matching the repo's existing path flag (`service install --prefix`).

**Deployment is #73's**, not missing here: the systemd `StateDirectory` grant, the Docker named volume, and the example env files all land there. The unit currently has no `StateDirectory=` and `ProtectSystem=strict`, so the default path is not yet writable under systemd.

## Verification

```
cargo clippy --all-targets --locked -- -D warnings   ✓ clean (Linux)
cargo fmt --all -- --check                           ✓
cargo test --locked                                  ✓ 168 passed (Linux)
```

Every acceptance criterion in #72 has a test hitting a spawned server with reqwest; env-var tests take the existing env lock, which loses its `ENGINE_` prefix now that it guards more than the engine variables.

The read-only tests turn a directory to mode `0555`, **which root ignores** — so they were run both as root and as an unprivileged user, since a root-only run would have passed them vacuously. CI's Rust job runs unprivileged on the runner, where they exercise the real path; the tests self-skip with a message when run privileged.

Clippy is clean on Linux. The two dead-code errors it reports on macOS reproduce on unmodified `main` (Linux-gated collector paths) and are unrelated to this branch.

`tempfile` joins as a dev-dependency for temporary state directories, resolving to 3.27.0, the latest stable; there was no `dev-dependencies` section before.

**Metrics contract: N/A** — no metrics fields added, and `MemoryMetrics`/`GpuMetrics`/`CpuMetrics` and their TS types are untouched.

Closes #72