### PR TITLE
feat(deploy): state directory in the systemd and Docker deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Prefer containers? Run the published multi-arch image (needs the
 ```bash
 docker run --rm --gpus all --pid=host -p 3000:3000 \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v spark-dashboard-state:/var/lib/spark-dashboard \
   --group-add "$(getent group docker | cut -d: -f3)" \
   ghcr.io/niklasfrick/spark-dashboard:latest
 ```
@@ -40,7 +41,8 @@ docker run --rm --gpus all --pid=host -p 3000:3000 \
 `--group-add` puts the container in the host's `docker` group so it can read the
 mounted socket and discover vLLM **containers**. Skip it (or get the GID wrong)
 and engine discovery silently falls back to host processes only — containerized
-engines won't appear.
+engines won't appear. The named volume keeps saved dashboards across container
+replacement; without it they die with the container.
 
 Or with Compose (host networking + GPU + socket mount preconfigured):
 
@@ -223,8 +225,11 @@ binary, and starts it again, preserving `/etc/spark-dashboard/config.env`.
 
 ```bash
 sudo spark-dashboard service uninstall         # keep /etc/spark-dashboard
-sudo spark-dashboard service uninstall --purge # remove everything
+sudo spark-dashboard service uninstall --purge # also remove /etc/spark-dashboard
 ```
+
+Neither form touches `/var/lib/spark-dashboard`, so saved dashboards survive an
+uninstall/reinstall cycle. Remove that directory by hand to start clean.
 
 ### CLI options
 
@@ -267,6 +272,19 @@ The dashboard configuration is a single document shared by everyone who opens
 the instance, stored at `<state-dir>/dashboards.json`. The server keeps it as
 opaque bytes — it never parses or validates the contents, and enforces only a
 1 MiB size cap. Writes are atomic, and last write wins.
+
+Both deployments arrange for `<state-dir>` to be `/var/lib/spark-dashboard`, the
+binary's default:
+
+| Deployment | Where it lives                    | Provided by                                        |
+| ---------- | --------------------------------- | -------------------------------------------------- |
+| systemd    | `/var/lib/spark-dashboard`        | the unit's `StateDirectory=` grant, created and chowned to the service user on start |
+| Docker     | the `spark-dashboard-state` volume | the Compose named volume; survives everything short of `down -v` |
+
+The document therefore outlives restarts, upgrades and container replacement.
+Override the location with `--state-dir` / `SPARK_DASHBOARD_STATE_DIR` — under
+systemd that also needs a unit override, since `ProtectSystem=strict` leaves the
+granted state directory the only writable path.
 
 ```
 GET    /api/dashboard   the document, or 204 when none is stored

--- a/deploy/docker/.env.docker.example
+++ b/deploy/docker/.env.docker.example
@@ -20,6 +20,13 @@ SPARK_DASHBOARD_PORT=3000
 SPARK_DASHBOARD_BIND=0.0.0.0
 SPARK_DASHBOARD_POLL_INTERVAL=1000
 SPARK_DASHBOARD_GPU_INDEX=0
+# In-container directory for saved dashboards (<dir>/dashboards.json), backed by
+# the `spark-dashboard-state` named volume. Compose mounts the volume at this
+# same path, so the two stay in step — but only the default is pre-created in
+# the image owned by the container's non-root user, and a volume created at any
+# other path is root-owned and unwritable, leaving the dashboard read-only.
+# Relocate with a bind mount you have chowned to 65532:65532 instead.
+# SPARK_DASHBOARD_STATE_DIR=/var/lib/spark-dashboard
 # Development aid: append N fictive GPUs (simulated metrics + thermal events)
 # after the real ones so multi-GPU UI paths can be tested on single-GPU hosts.
 # SPARK_DASHBOARD_SIMULATE_GPUS=1

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -46,6 +46,11 @@ COPY deploy/host/systemd ./deploy/host/systemd
 COPY deploy/host/config.env.example ./deploy/host/config.env.example
 COPY --from=frontend /app/frontend/dist ./frontend/dist/
 RUN cargo build --release --locked
+# Skeleton for the runtime's state directory. It has to be built here because
+# the runtime stage is distroless — no shell, so no `RUN mkdir` there — and an
+# empty directory cannot be COPY'd from the build context either (git does not
+# track empty directories). See the runtime stage for why it must pre-exist.
+RUN mkdir -p /state
 
 # ---------- stage: runtime ----------
 # Distroless: glibc + CA certs and nothing else — no shell, no package manager,
@@ -67,6 +72,15 @@ LABEL org.opencontainers.image.source="https://github.com/niklasfrick/spark-dash
     org.opencontainers.image.version="${VERSION}"
 
 COPY --from=builder /app/target/release/spark-dashboard /usr/local/bin/spark-dashboard
+
+# State directory for the dashboard configuration document, matching the
+# binary's default --state-dir. It must exist *in the image*, owned by the
+# runtime user: Docker seeds a fresh named volume from whatever the image has at
+# the mount point, ownership included, and creates the path root-owned when the
+# image lacks it — unwritable for uid 65532, with no shell here to chown it
+# after the fact. See docker.md, "Saved dashboards". Numeric uid:gid so the copy
+# does not depend on the base image's /etc/passwd.
+COPY --from=builder --chown=65532:65532 --chmod=750 /state /var/lib/spark-dashboard
 
 # Already uid 65532 via the :nonroot tag; stated explicitly for clarity. NVML,
 # /proc, and the docker socket all work non-root given the device/group access

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -43,8 +43,14 @@ services:
     # Read-only Docker socket so the dashboard can list vLLM containers. The
     # added group must match the host's docker GID — set DOCKER_GID in .env
     # (find it with: getent group docker | cut -d: -f3). Defaults to 999.
+
+    # Saved dashboards, on a named volume so they outlive the container. Mount
+    # point and SPARK_DASHBOARD_STATE_DIR below read the same variable so they
+    # cannot drift apart. See docker.md, "Saved dashboards", for why the image
+    # has to pre-create the directory.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - spark-dashboard-state:${SPARK_DASHBOARD_STATE_DIR:-/var/lib/spark-dashboard}
     group_add:
       - "${DOCKER_GID:-999}"
 
@@ -52,6 +58,7 @@ services:
       - SPARK_DASHBOARD_PORT=${SPARK_DASHBOARD_PORT:-3000}
       - SPARK_DASHBOARD_BIND=${SPARK_DASHBOARD_BIND:-0.0.0.0}
       - SPARK_DASHBOARD_POLL_INTERVAL=${SPARK_DASHBOARD_POLL_INTERVAL:-1000}
+      - SPARK_DASHBOARD_STATE_DIR=${SPARK_DASHBOARD_STATE_DIR:-/var/lib/spark-dashboard}
       - SPARK_DASHBOARD_GPU_INDEX
       - SPARK_DASHBOARD_SIMULATE_GPUS=${SPARK_DASHBOARD_SIMULATE_GPUS:-0}
       - SPARK_DASHBOARD_PROVIDER_API_KEY=${SPARK_DASHBOARD_PROVIDER_API_KEY:-}
@@ -62,3 +69,11 @@ services:
       - RUST_LOG=${RUST_LOG:-info}
 
     restart: unless-stopped
+
+volumes:
+  # Removed only by an explicit `docker compose down -v` — a plain `down` keeps
+  # the saved dashboards. `name:` pins the volume as-written: without it Compose
+  # prefixes the project name (`docker_spark-dashboard-state`, after this file's
+  # directory), which every documented `docker volume` command would then miss.
+  spark-dashboard-state:
+    name: spark-dashboard-state

--- a/deploy/docker/docker.md
+++ b/deploy/docker/docker.md
@@ -79,6 +79,57 @@ services. **Tradeoff:** engines bound only to the host network are no longer
 auto-discovered. Container-based discovery over the Docker socket still works
 (`pid:host` is inherited).
 
+## Saved dashboards (persistent state)
+
+The dashboard layout an operator saves in the UI is stored server-side as a
+single document, `dashboards.json`, under the container's
+`/var/lib/spark-dashboard` — the value of `SPARK_DASHBOARD_STATE_DIR`. Compose
+backs that path with a named volume, `spark-dashboard-state`, so the
+configuration outlives container replacement:
+
+```yaml
+volumes:
+  - spark-dashboard-state:/var/lib/spark-dashboard
+```
+
+`docker compose down && docker compose up -d`, an image upgrade, or a
+`docker compose pull` all keep the saved dashboards. **`docker compose down -v`
+deletes them** — that is the reset button. Inspect or back up the document
+without a shell in the container (there isn't one):
+
+```bash
+docker volume inspect spark-dashboard-state         # where it lives on the host
+docker run --rm -v spark-dashboard-state:/state -w /state \
+  busybox cat dashboards.json > dashboards.backup.json
+```
+
+With plain `docker run`, pass the volume yourself — otherwise the configuration
+lives on the container's writable layer and dies with the container:
+
+```bash
+-v spark-dashboard-state:/var/lib/spark-dashboard
+```
+
+**Why the mount point already exists in the image:** Docker creates a mount
+target the image lacks as a *root-owned* directory, and the container runs as
+uid 65532 with no shell and no entrypoint script to `chown` from — a distroless
+image has neither. The image therefore ships `/var/lib/spark-dashboard`
+pre-created and owned by 65532, and Docker seeds the fresh named volume from it,
+ownership included.
+
+That is why `SPARK_DASHBOARD_STATE_DIR` is worth leaving alone. Compose feeds it
+to both the mount point and the app, so the two cannot drift — but only the
+default path is pre-created in the image, so any other value gives you a
+root-owned volume the app cannot write. It then serves reads, refuses writes
+with `503`, and marks every response `x-spark-dashboard-read-only: true`. To
+relocate the state anyway, use a bind mount you have chowned to `65532:65532`
+yourself. The startup log line naming the state directory is the first place to
+look:
+
+```bash
+docker compose logs spark-dashboard | grep 'state directory'
+```
+
 ## GPU passthrough
 
 GPU metrics come from **NVML**, not device-file mounts — so no `/dev/nvidia*`
@@ -110,6 +161,7 @@ All are optional; defaults match the binary. Set them in `.env`.
 | `SPARK_DASHBOARD_PORT`              | `3000`      | Listen port.                                         |
 | `SPARK_DASHBOARD_BIND`              | `0.0.0.0`   | Bind address.                                        |
 | `SPARK_DASHBOARD_POLL_INTERVAL`     | `1000`      | Metrics polling interval (ms).                       |
+| `SPARK_DASHBOARD_STATE_DIR`         | `/var/lib/spark-dashboard` | Where saved dashboards live; move the volume mount with it. |
 | `SPARK_DASHBOARD_GPU_INDEX`         | _(unset)_   | Optional NVML GPU index; unset monitors all GPUs.    |
 | `SPARK_DASHBOARD_SIMULATE_GPUS`     | `0`         | Dev aid: append N fictive GPUs with simulated data.  |
 | `SPARK_DASHBOARD_PROVIDER_API_KEY`  | _(unset)_   | Fallback API key for auth-gated engines.             |

--- a/deploy/host/config.env.example
+++ b/deploy/host/config.env.example
@@ -14,6 +14,13 @@
 # Metrics polling interval in milliseconds (default: 1000)
 # SPARK_DASHBOARD_POLL_INTERVAL=1000
 
+# Directory for saved dashboards, i.e. <dir>/dashboards.json
+# (default: /var/lib/spark-dashboard). The default is what the unit's
+# StateDirectory= grant creates and hands to the service user; the unit's
+# ProtectSystem=strict makes it the only writable path, so pointing this
+# somewhere else needs a matching unit override or the dashboard runs read-only.
+# SPARK_DASHBOARD_STATE_DIR=/var/lib/spark-dashboard
+
 # Explicit engine endpoint (optional). Use this when process or Docker discovery
 # cannot see an engine, for example when vLLM runs as a different systemd user.
 # Comma-separated engine and URL lists are paired by position.

--- a/deploy/host/systemd/spark-dashboard.service
+++ b/deploy/host/systemd/spark-dashboard.service
@@ -11,6 +11,15 @@ Group=spark-dashboard
 SupplementaryGroups=video render docker
 EnvironmentFile=-/etc/spark-dashboard/config.env
 ExecStart=/usr/local/bin/spark-dashboard
+
+# Mutable state: the dashboard configuration document. systemd creates
+# /var/lib/spark-dashboard, chowns it to the service user and punches it through
+# ProtectSystem=strict — which is why the hardening below needs no exception and
+# no ReadWritePaths=. The directory survives restarts, upgrades and
+# `systemctl disable`; the service user has no home, so there is no XDG fallback
+# if this grant is removed. The binary defaults to this exact path.
+StateDirectory=spark-dashboard
+StateDirectoryMode=0750
 Restart=on-failure
 RestartSec=3
 StandardOutput=journal

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -278,3 +278,35 @@ mod linux {
         std::process::exit(status.code().unwrap_or(1));
     }
 }
+
+/// Tests over the unit file as *text*, so they run on any host: the file is
+/// embedded into the binary above and shipped verbatim by `service install`,
+/// which makes its contents part of this module's behaviour rather than a
+/// deployment detail. They are deliberately outside the Linux-only module.
+#[cfg(test)]
+mod tests {
+    use crate::deploy_files::{directive, UNIT};
+
+    #[test]
+    fn the_state_directory_is_not_world_readable() {
+        // The document is instance-wide configuration, not a secret, but the
+        // directory belongs to the service user alone — nothing else on the host
+        // has a reason to read it.
+        assert_eq!(directive(UNIT, "StateDirectoryMode"), Some("0750"));
+    }
+
+    #[test]
+    fn the_state_directory_grant_replaces_rather_than_relaxes_the_sandbox() {
+        // The whole point of StateDirectory= is that one directory becomes
+        // writable without weakening the sandbox around it. These two are what a
+        // future "the dashboard can't save" report would tempt someone to
+        // loosen; the rest of the hardening block is not this change's business.
+        assert_eq!(directive(UNIT, "ProtectSystem"), Some("strict"));
+        assert_eq!(directive(UNIT, "ProtectHome"), Some("true"));
+
+        // ReadWritePaths= would be the other tempting shortcut. It is not
+        // needed, and it would hand the service a path systemd neither creates
+        // nor owns.
+        assert_eq!(directive(UNIT, "ReadWritePaths"), None);
+    }
+}

--- a/src/deploy_files.rs
+++ b/src/deploy_files.rs
@@ -1,19 +1,22 @@
 //! Keeps the deployment files honest about where state lives.
 //!
 //! `DEFAULT_STATE_DIR` is one constant, but the path it names has to be spelled
-//! out again in every deployment artifact that has to agree with it — starting
-//! with the systemd unit that grants the directory. Nothing in the build links
-//! those copies together, and a mismatch produces no error: the service starts
-//! and the dashboard silently comes up read-only.
+//! out again in every deployment artifact: the systemd unit grants it, the
+//! container image pre-creates it, Compose mounts a volume at it. Nothing in the
+//! build links those copies together — a Dockerfile typo produces a perfectly
+//! good image whose dashboard silently comes up read-only, and no Rust test
+//! would notice.
 //!
 //! So the files are read as text and asserted against the constant. That is a
-//! weaker check than executing them, which is what the installer CI job is for;
-//! it is a fast one that catches drift the moment it is introduced rather than
-//! at deploy time.
+//! weaker check than executing them, which is what `dev/docker-dev.sh` and the
+//! installer CI job are for; it is a fast one that catches drift the moment it
+//! is introduced rather than at deploy time.
 
 use crate::DEFAULT_STATE_DIR;
 
 pub const UNIT: &str = include_str!("../deploy/host/systemd/spark-dashboard.service");
+const DOCKERFILE: &str = include_str!("../deploy/docker/Dockerfile");
+const COMPOSE: &str = include_str!("../deploy/docker/docker-compose.yml");
 
 /// Value of the first `Name=value` directive in a systemd unit, ignoring
 /// section headers and comments.
@@ -37,5 +40,48 @@ mod tests {
         // otherwise a fresh install writes somewhere ProtectSystem=strict
         // forbids and the dashboard silently comes up read-only.
         assert_eq!(format!("/var/lib/{granted}"), DEFAULT_STATE_DIR);
+    }
+
+    #[test]
+    fn the_image_pre_creates_the_binarys_default_state_directory() {
+        // Owned by the runtime uid, because Docker seeds a fresh named volume
+        // from the image — including ownership — and a distroless runtime has no
+        // shell to fix it up afterwards.
+        let expected = format!(
+            "COPY --from=builder --chown=65532:65532 --chmod=750 /state {DEFAULT_STATE_DIR}"
+        );
+        assert!(
+            DOCKERFILE.lines().any(|line| line.trim() == expected),
+            "Dockerfile should contain `{expected}`"
+        );
+    }
+
+    #[test]
+    fn compose_mounts_the_state_volume_where_the_container_looks_for_it() {
+        // One variable feeds both the mount point and the app, so an operator
+        // who overrides it cannot leave the two pointing at different paths.
+        let path = format!("${{SPARK_DASHBOARD_STATE_DIR:-{DEFAULT_STATE_DIR}}}");
+        for expected in [
+            format!("- spark-dashboard-state:{path}"),
+            format!("- SPARK_DASHBOARD_STATE_DIR={path}"),
+        ] {
+            assert!(
+                COMPOSE.lines().any(|line| line.trim() == expected),
+                "docker-compose.yml should contain `{expected}`"
+            );
+        }
+    }
+
+    #[test]
+    fn the_state_volume_keeps_its_name_across_projects() {
+        // Without an explicit `name:`, Compose prefixes the project name and the
+        // volume becomes `docker_spark-dashboard-state` — which every
+        // `docker volume` command in the docs would miss.
+        assert!(
+            COMPOSE
+                .lines()
+                .any(|l| l.trim() == "name: spark-dashboard-state"),
+            "the state volume should pin its own name"
+        );
     }
 }

--- a/src/deploy_files.rs
+++ b/src/deploy_files.rs
@@ -1,0 +1,41 @@
+//! Keeps the deployment files honest about where state lives.
+//!
+//! `DEFAULT_STATE_DIR` is one constant, but the path it names has to be spelled
+//! out again in every deployment artifact that has to agree with it — starting
+//! with the systemd unit that grants the directory. Nothing in the build links
+//! those copies together, and a mismatch produces no error: the service starts
+//! and the dashboard silently comes up read-only.
+//!
+//! So the files are read as text and asserted against the constant. That is a
+//! weaker check than executing them, which is what the installer CI job is for;
+//! it is a fast one that catches drift the moment it is introduced rather than
+//! at deploy time.
+
+use crate::DEFAULT_STATE_DIR;
+
+pub const UNIT: &str = include_str!("../deploy/host/systemd/spark-dashboard.service");
+
+/// Value of the first `Name=value` directive in a systemd unit, ignoring
+/// section headers and comments.
+pub fn directive<'a>(unit: &'a str, name: &str) -> Option<&'a str> {
+    let prefix = format!("{name}=");
+    unit.lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix(prefix.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_systemd_unit_grants_the_binarys_default_state_directory() {
+        let granted = directive(UNIT, "StateDirectory").expect("unit grants a state directory");
+
+        // systemd creates /var/lib/<name> for a system unit and chowns it to the
+        // service user. That derived path is what the binary must default to,
+        // otherwise a fresh install writes somewhere ProtectSystem=strict
+        // forbids and the dashboard silently comes up read-only.
+        assert_eq!(format!("/var/lib/{granted}"), DEFAULT_STATE_DIR);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 mod cli;
 mod config_store;
+/// Test-only: asserts the deployment files agree with [`DEFAULT_STATE_DIR`].
+#[cfg(test)]
+mod deploy_files;
 mod engines;
 mod metrics;
 mod server;
@@ -14,6 +17,16 @@ use engines::{ApiKeyResolver, EngineOverride, EngineType};
 use std::process::ExitCode;
 use std::sync::Arc;
 use tokio::sync::{broadcast, RwLock};
+
+/// Default directory for mutable state.
+///
+/// Both deployments are arranged to hand the service exactly this path, so the
+/// binary needs no deployment-specific default: the systemd unit's
+/// `StateDirectory=spark-dashboard` grant resolves here, and the container image
+/// creates it owned by its non-root user for a named volume to be mounted over.
+/// `src/deploy_files.rs` holds the tests that keep those files and this constant
+/// in agreement.
+const DEFAULT_STATE_DIR: &str = "/var/lib/spark-dashboard";
 
 /// Spark Dashboard — Real-time hardware and LLM monitoring for Linux hosts with NVIDIA GPUs.
 #[derive(Parser, Debug)]
@@ -75,15 +88,15 @@ struct RunArgs {
     poll_interval: u64,
 
     /// Directory holding mutable state, currently the dashboard configuration
-    /// document (`<state-dir>/dashboards.json`). The default is the path a
-    /// systemd StateDirectory grant yields; until the unit grants one, and in
-    /// containers, point this somewhere writable explicitly.
+    /// document (`<state-dir>/dashboards.json`). The default is the path the
+    /// unit's `StateDirectory=` grant yields; the container image points it at
+    /// the same path, backed by a named volume.
     /// An unwritable directory is not fatal — the dashboard runs read-only.
     #[arg(
         long,
         value_name = "DIR",
         env = "SPARK_DASHBOARD_STATE_DIR",
-        default_value = "/var/lib/spark-dashboard"
+        default_value = DEFAULT_STATE_DIR
     )]
     state_dir: String,
 


### PR DESCRIPTION
Closes #73.

Makes the state directory #72 introduced actually exist and be writable in both
supported deployments, so an operator's saved dashboard survives container
replacement and host upgrades.

## systemd

`StateDirectory=spark-dashboard` + `StateDirectoryMode=0750`. systemd creates
`/var/lib/spark-dashboard`, chowns it to the service user and punches it through
`ProtectSystem=strict` — so **no hardening directive was removed or loosened**,
and no `ReadWritePaths=` was needed. The service user still has no home, and
nothing here depends on one.

## Docker

The runtime is distroless-nonroot, and a named volume mounted at a path the
image lacks is created root-owned — with no shell and no entrypoint script to
`chown` from. So the image pre-creates the directory owned by `65532:65532`
(built in the builder stage, copied in with `--chown --chmod`), and Docker seeds
the fresh volume from it, ownership included.

Compose mounts `spark-dashboard-state` there. The volume pins its own `name:`:
without it Compose prefixes the project name, and the volume would really be
`docker_spark-dashboard-state`, which every documented `docker volume` command
would miss. The mount point and `SPARK_DASHBOARD_STATE_DIR` read the same
variable so an override cannot leave them pointing at different paths.

## Tests

Nothing in the build ties these copies of the path together, and a mismatch
fails quietly — the service starts and the dashboard comes up read-only. The new
test-only `deploy_files` module reads the unit, the Dockerfile and the compose
file as text and asserts each against `DEFAULT_STATE_DIR` (the `--state-dir`
default, now a named constant). It sits outside the Linux-only part of
`cli::service` so it runs on any host.

Frontend: N/A — no `frontend/` change, and the read-only banner belongs to the
rework tickets.

## Acceptance criteria

- [x] **Fresh systemd install** — booted systemd in a privileged `debian:trixie`
      container with the unit installed and the binary from the built image:
      service active, `/var/lib/spark-dashboard` owned `spark-dashboard:spark-dashboard`
      mode 750, `PUT /api/dashboard` → 204, document survives `systemctl restart`.
      Hardening block unchanged apart from the two added directives.
- [x] **`systemd-analyze verify`** — clean apart from the "binary is not
      executable" note the CI host also produces.
- [x] **Fresh `docker compose up` against a clean named volume** — volume seeded
      `65532:65532` mode 750 with no entrypoint chown, `PUT` → 204 with
      `x-spark-dashboard-read-only: false`, document still served after
      `down` && `up`, removed by `down -v`. Run against the real base compose
      file with a throwaway override stripping the GPU reservation and host
      networking, since this was verified on macOS.
- [x] **`./dev/docker-dev.sh --build-local`** passes (16 MB image).
- [x] **Both example env files and the deployment docs** describe the variable
      and the volume. Every command in the new `docker.md` section was run
      against a live stack.
- [x] **Rust, installer and docker CI jobs green** — Rust (aarch64-linux), Installer lint, Docker build (amd64 + arm64) all pass; Frontend skipped, no `frontend/` change.

## Notes for the reviewer

- `docker.md` deliberately does *not* promise a read-only banner: the API-level
  `503` + `x-spark-dashboard-read-only` are real, the UI part is not built yet.
  The README has carried that claim since #72; left alone here rather than
  widening this PR's scope.
- `service uninstall --purge` still does not touch `/var/lib/spark-dashboard`.
  That's deliberate — configuration surviving a reinstall is the point — and the
  README wording was corrected to match.
- Not verified on a real GPU host; nothing here depends on NVML, but
  `--deploy-remote` would be the honest final check.