### PR TITLE
refactor(frontend): named engine and GPU identity helpers

### DIFF
--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { findEngineByEndpoint } from '../lib/identity'
 import type { EngineSnapshot } from '../types/metrics'
 
 /**
@@ -49,13 +50,13 @@ export function LogViewer({ engines = [], selectedEndpoint = null, onExpandChang
   // active and still present, otherwise the first Docker engine (the backend
   // applies the same default when no ?engine= is passed).
   const targetEndpoint = useMemo(() => {
-    if (selectedEndpoint && engines.some((e) => e.endpoint === selectedEndpoint)) {
+    if (selectedEndpoint && findEngineByEndpoint(engines, selectedEndpoint)) {
       return selectedEndpoint
     }
     return engines.find((e) => e.deployment_mode === 'Docker')?.endpoint ?? null
   }, [engines, selectedEndpoint])
 
-  const targetEngine = engines.find((e) => e.endpoint === targetEndpoint)
+  const targetEngine = findEngineByEndpoint(engines, targetEndpoint)
   const engineLabel = targetEngine
     ? (targetEngine.model?.name ?? targetEngine.endpoint)
     : null

--- a/frontend/src/components/engines/EngineCard.tsx
+++ b/frontend/src/components/engines/EngineCard.tsx
@@ -1,5 +1,6 @@
 import { TimeSeriesChart, type ChartSeries } from '@/components/charts/TimeSeriesChart'
 import { formatTps, formatTtft, formatDurationMs, formatCompactTokens, fmtVal, fmtInt } from '@/lib/format'
+import { engineKey } from '@/lib/identity'
 import type { EngineSnapshot } from '@/types/metrics'
 import type { InferenceRequest } from '@/types/events'
 import {
@@ -144,10 +145,9 @@ export function EngineCard({
   // sits at 0 on a freshly-started idle engine — gating on >0 keeps the card
   // from showing an all-dashes section until the metrics carry real values.
   const hasSpecDecode = specDraftTokens !== null && specDraftTokens > 0
-  const engineKey = `${engine.engine_type}-${engine.endpoint}`
   const modelName = engine.model?.name ?? null
   const { thresholds: slo, setThresholds: setSlo, reset: resetSlo, isCustomized: sloCustomized } =
-    useSloSettings(engineKey, modelName)
+    useSloSettings(engineKey(engine), modelName)
 
   // Recompute goodput from histogram buckets so user-customized SLO
   // thresholds actually move the displayed percentages. Falls back to the

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/latencyMode'
 import { aggregateEngines, groupRunningByProvider } from '@/lib/engineAggregate'
 import { engineDisplayName, formatGpuIndexes } from '@/lib/format'
+import { engineKey, findEngineByKey } from '@/lib/identity'
 import { getProviderLogo } from '@/lib/providerLogo'
 import { useTabRotation } from '@/hooks/useTabRotation'
 import type { EngineSnapshot, EngineType, DeploymentMode } from '@/types/metrics'
@@ -243,9 +244,7 @@ export function EngineSection({
   const showGlobalControls = aggregate.running_count > 1
 
   const isGlobal = activeTab === GLOBAL_TAB_VALUE
-  const activeEngine = engines.find(
-    (e) => `${e.engine_type}-${e.endpoint}` === activeTab,
-  )
+  const activeEngine = findEngineByKey(engines, activeTab)
   const activeEngineGpuIndexesKey = activeEngine?.gpu_indexes?.join(',') ?? ''
 
   const activeEngineEndpoint = isGlobal ? undefined : activeEngine?.endpoint
@@ -264,7 +263,7 @@ export function EngineSection({
   const tabOrder = useMemo(
     () => [
       ...(showGlobalControls ? [GLOBAL_TAB_VALUE] : []),
-      ...engines.map((e) => `${e.engine_type}-${e.endpoint}`),
+      ...engines.map(engineKey),
     ],
     [engines, showGlobalControls],
   )
@@ -277,7 +276,7 @@ export function EngineSection({
   // frame of an empty or wrong tab first.
   if (!showGlobalControls && engines.length > 0) {
     // Single running engine: there is no global tab to sit on.
-    const onlyEngineKey = `${engines[0].engine_type}-${engines[0].endpoint}`
+    const onlyEngineKey = engineKey(engines[0])
     if (activeTab !== onlyEngineKey) setActiveTab(onlyEngineKey)
   } else if (
     engines.length > 0 &&
@@ -437,11 +436,11 @@ export function EngineSection({
                 </>
               )}
               {engines.map((engine) => {
-                const engineKey = `${engine.engine_type}-${engine.endpoint}`
-                const isActive = engineKey === activeTab
+                const key = engineKey(engine)
+                const isActive = key === activeTab
                 return (
                   <EngineTab
-                    key={engineKey}
+                    key={key}
                     engine={engine}
                     cycle={cycle}
                     intervalMs={activeIntervalMs}
@@ -477,46 +476,46 @@ export function EngineSection({
           </TabsContent>
 
           {engines.map((engine) => {
-            const engineKey = `${engine.engine_type}-${engine.endpoint}`
+            const key = engineKey(engine)
 
             const chartDataForEngine: EngineChartData | undefined = getChartData
               ? {
-                  tps: getChartData(`${engineKey}:tps`),
-                  avgTps: getChartData(`${engineKey}:avgTps`),
-                  perReqTps: getChartData(`${engineKey}:perReqTps`),
-                  ttft: getChartData(`${engineKey}:ttft`),
-                  kv: getChartData(`${engineKey}:kvCache`),
-                  prefixCacheHit: getChartData(`${engineKey}:prefixCacheHit`),
-                  e2eLatency: getChartData(`${engineKey}:e2eLatency`),
-                  promptTps: getChartData(`${engineKey}:promptTps`),
-                  avgPromptTps: getChartData(`${engineKey}:avgPromptTps`),
-                  perReqPromptTps: getChartData(`${engineKey}:perReqPromptTps`),
-                  queueTime: getChartData(`${engineKey}:queueTime`),
-                  interTokenLatency: getChartData(`${engineKey}:interTokenLatency`),
-                  batchSize: getChartData(`${engineKey}:batchSize`),
-                  ttftP50: getChartData(`${engineKey}:ttftP50`),
-                  ttftP95: getChartData(`${engineKey}:ttftP95`),
-                  ttftP99: getChartData(`${engineKey}:ttftP99`),
-                  itlP50: getChartData(`${engineKey}:itlP50`),
-                  itlP95: getChartData(`${engineKey}:itlP95`),
-                  itlP99: getChartData(`${engineKey}:itlP99`),
-                  e2eP50: getChartData(`${engineKey}:e2eP50`),
-                  e2eP95: getChartData(`${engineKey}:e2eP95`),
-                  e2eP99: getChartData(`${engineKey}:e2eP99`),
-                  tpot: getChartData(`${engineKey}:tpot`),
-                  tpotP50: getChartData(`${engineKey}:tpotP50`),
-                  tpotP95: getChartData(`${engineKey}:tpotP95`),
-                  tpotP99: getChartData(`${engineKey}:tpotP99`),
-                  activeRequests: getChartData(`${engineKey}:activeRequests`),
-                  queuedRequests: getChartData(`${engineKey}:queuedRequests`),
-                  totalRequests: getChartData(`${engineKey}:totalRequests`),
+                  tps: getChartData(`${key}:tps`),
+                  avgTps: getChartData(`${key}:avgTps`),
+                  perReqTps: getChartData(`${key}:perReqTps`),
+                  ttft: getChartData(`${key}:ttft`),
+                  kv: getChartData(`${key}:kvCache`),
+                  prefixCacheHit: getChartData(`${key}:prefixCacheHit`),
+                  e2eLatency: getChartData(`${key}:e2eLatency`),
+                  promptTps: getChartData(`${key}:promptTps`),
+                  avgPromptTps: getChartData(`${key}:avgPromptTps`),
+                  perReqPromptTps: getChartData(`${key}:perReqPromptTps`),
+                  queueTime: getChartData(`${key}:queueTime`),
+                  interTokenLatency: getChartData(`${key}:interTokenLatency`),
+                  batchSize: getChartData(`${key}:batchSize`),
+                  ttftP50: getChartData(`${key}:ttftP50`),
+                  ttftP95: getChartData(`${key}:ttftP95`),
+                  ttftP99: getChartData(`${key}:ttftP99`),
+                  itlP50: getChartData(`${key}:itlP50`),
+                  itlP95: getChartData(`${key}:itlP95`),
+                  itlP99: getChartData(`${key}:itlP99`),
+                  e2eP50: getChartData(`${key}:e2eP50`),
+                  e2eP95: getChartData(`${key}:e2eP95`),
+                  e2eP99: getChartData(`${key}:e2eP99`),
+                  tpot: getChartData(`${key}:tpot`),
+                  tpotP50: getChartData(`${key}:tpotP50`),
+                  tpotP95: getChartData(`${key}:tpotP95`),
+                  tpotP99: getChartData(`${key}:tpotP99`),
+                  activeRequests: getChartData(`${key}:activeRequests`),
+                  queuedRequests: getChartData(`${key}:queuedRequests`),
+                  totalRequests: getChartData(`${key}:totalRequests`),
                 }
               : undefined
 
             return (
               <TabsContent
-                key={engineKey}
-                value={engineKey}
+                key={key}
+                value={key}
                 className="data-[state=active]:flex flex-col"
               >
                 <EngineCard

--- a/frontend/src/components/engines/EngineTab.tsx
+++ b/frontend/src/components/engines/EngineTab.tsx
@@ -1,5 +1,6 @@
 import { TabsTrigger } from '@/components/ui/tabs'
 import { engineDisplayName } from '@/lib/format'
+import { engineKey } from '@/lib/identity'
 import { getProviderLogo } from '@/lib/providerLogo'
 import type { EngineSnapshot } from '@/types/metrics'
 
@@ -52,7 +53,7 @@ export function EngineTab({ engine, cycle, intervalMs, showCountdown }: EngineTa
 
   return (
     <TabsTrigger
-      value={`${engine.engine_type}-${engine.endpoint}`}
+      value={engineKey(engine)}
       className={`relative flex items-center gap-2.5 px-6 py-4 leading-none rounded-md transition-colors duration-200 min-w-0 !flex-initial hover:bg-white/[0.03] data-[active]:bg-white/[0.05] ${
         isStopped ? 'opacity-40' : ''
       } data-[active]:border-b-2 data-[active]:border-[#76B900]`}

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -8,6 +8,7 @@ import { useElementSize } from '@/hooks/useElementSize'
 import { THRESHOLDS } from '@/lib/theme'
 import { formatBytes, formatGiB, formatMhz, formatRate } from '@/lib/format'
 import { computePowerScale, powerPeak } from '@/lib/gpuPower'
+import { findGpuByIndex, gpuIndexOf, snapshotGpus } from '@/lib/identity'
 import type { MetricsSnapshot } from '@/types/metrics'
 import type { GpuEvent, InferenceRequest } from '@/types/events'
 
@@ -98,11 +99,10 @@ export function Dashboard({
 
   if (!metrics) return null
 
-  const gpus = metrics.gpus && metrics.gpus.length > 0 ? metrics.gpus : [metrics.gpu]
+  const gpus = snapshotGpus(metrics)
   const multiGpu = gpus.length > 1
-  const gpuIndexOf = (gpu: MetricsSnapshot['gpu']) => gpu.index ?? 0
   // Fall back to the primary GPU if the selected index vanishes from the feed.
-  const activeGpu = gpus.find((g) => gpuIndexOf(g) === selectedGpuIndex) ?? gpus[0]
+  const activeGpu = findGpuByIndex(gpus, selectedGpuIndex) ?? gpus[0]
   const activeGpuIndex = gpuIndexOf(activeGpu)
   // Single-GPU hosts keep the legacy un-prefixed history keys so the
   // pre-multi-GPU rendering stays identical; multi-GPU hosts read the

--- a/frontend/src/components/views/Dashboard.tsx
+++ b/frontend/src/components/views/Dashboard.tsx
@@ -195,7 +195,7 @@ export function Dashboard({
               const isActive = gpuIndexOf(gpu) === activeGpuIndex
               return (
                 <button
-                  key={gpu.index ?? 'primary'}
+                  key={gpuIndexOf(gpu)}
                   type="button"
                   onClick={() => setSelectedGpuIndex(gpuIndexOf(gpu))}
                   aria-pressed={isActive}
@@ -206,6 +206,9 @@ export function Dashboard({
                   }`}
                 >
                   <div className="flex items-baseline justify-between gap-2 min-w-0">
+                    {/* The label deliberately does not normalize: a GPU the
+                        backend gave no index is shown as plain "GPU", not as
+                        "GPU 0" it may not be. */}
                     <span className="text-[10px] lg:text-[11px] font-semibold text-zinc-200 truncate">
                       {gpu.index !== null && gpu.index !== undefined ? `GPU ${gpu.index}` : 'GPU'}
                     </span>

--- a/frontend/src/hooks/useMetricsHistory.ts
+++ b/frontend/src/hooks/useMetricsHistory.ts
@@ -369,6 +369,8 @@ export function useMetricsHistory(
       .filter((e) => e.timestamp_ms >= cutoff)
   }, [version])
 
+  /** Recent requests, optionally narrowed to one engine. `key` is an engine
+   *  key as produced by `engineKey()`; omit it for every engine's requests. */
   const getRequests = useCallback(
     (key?: string): InferenceRequestData[] => {
       void version

--- a/frontend/src/hooks/useMetricsHistory.ts
+++ b/frontend/src/hooks/useMetricsHistory.ts
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, useEffect } from 'react'
 import { CircularBuffer } from '../lib/circular-buffer'
+import { engineKey, gpuIndexOf, snapshotGpus } from '../lib/identity'
 import type { MetricsSnapshot, GpuEventData, InferenceRequestData } from '../types/metrics'
 
 interface DataPoint {
@@ -118,9 +119,8 @@ export function useMetricsHistory(
       }
     }
 
-    const gpus = metrics.gpus && metrics.gpus.length > 0 ? metrics.gpus : [metrics.gpu]
-    for (const gpu of gpus) {
-      const gpuKey = String(gpu.index ?? 0)
+    for (const gpu of snapshotGpus(metrics)) {
+      const gpuKey = String(gpuIndexOf(gpu))
       if (!gpuBuffersRef.current[gpuKey]) {
         gpuBuffersRef.current[gpuKey] = createBuffers()
       }
@@ -135,9 +135,9 @@ export function useMetricsHistory(
 
     // Engine-specific metrics
     for (const engine of metrics.engines) {
-      const engineKey = `${engine.engine_type}-${engine.endpoint}`
-      if (!engineBuffersRef.current[engineKey]) {
-        engineBuffersRef.current[engineKey] = {
+      const key = engineKey(engine)
+      if (!engineBuffersRef.current[key]) {
+        engineBuffersRef.current[key] = {
           tps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
           avgTps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
           perReqTps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
@@ -169,7 +169,7 @@ export function useMetricsHistory(
           totalRequests: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
         }
       }
-      const eb = engineBuffersRef.current[engineKey]
+      const eb = engineBuffersRef.current[key]
       if (engine.metrics) {
         if (engine.metrics.tokens_per_sec !== null) {
           eb.tps.push({ timestamp: ts, value: engine.metrics.tokens_per_sec })
@@ -256,12 +256,12 @@ export function useMetricsHistory(
 
       // Accumulate per-engine inference requests
       if (engine.recent_requests && engine.recent_requests.length > 0) {
-        if (!requestBuffersRef.current[engineKey]) {
-          requestBuffersRef.current[engineKey] =
+        if (!requestBuffersRef.current[key]) {
+          requestBuffersRef.current[key] =
             new CircularBuffer<InferenceRequestData>(REQUEST_BUFFER_CAPACITY)
         }
         for (const req of engine.recent_requests) {
-          requestBuffersRef.current[engineKey].push(req)
+          requestBuffersRef.current[key].push(req)
         }
       }
     }
@@ -308,9 +308,9 @@ export function useMetricsHistory(
       // Check engine metrics (format: "engineKey:metricName")
       const colonIndex = metric.lastIndexOf(':')
       if (colonIndex > 0) {
-        const engineKey = metric.substring(0, colonIndex)
+        const key = metric.substring(0, colonIndex)
         const metricName = metric.substring(colonIndex + 1)
-        const eb = engineBuffersRef.current[engineKey]
+        const eb = engineBuffersRef.current[key]
         if (eb && eb[metricName]) {
           return eb[metricName]
             .toArray()
@@ -344,9 +344,9 @@ export function useMetricsHistory(
 
       const colonIndex = metric.lastIndexOf(':')
       if (colonIndex > 0) {
-        const engineKey = metric.substring(0, colonIndex)
+        const key = metric.substring(0, colonIndex)
         const metricName = metric.substring(colonIndex + 1)
-        const eb = engineBuffersRef.current[engineKey]
+        const eb = engineBuffersRef.current[key]
         if (eb && eb[metricName]) {
           return eb[metricName].last(count).map((dp) => dp.value)
         }
@@ -370,15 +370,15 @@ export function useMetricsHistory(
   }, [version])
 
   const getRequests = useCallback(
-    (engineKey?: string): InferenceRequestData[] => {
+    (key?: string): InferenceRequestData[] => {
       void version
 
       const windowMs = DEFAULT_WINDOW_SECONDS * 1000
       const now = lastTimestampRef.current
       const cutoff = now - windowMs
 
-      if (engineKey) {
-        const buf = requestBuffersRef.current[engineKey]
+      if (key) {
+        const buf = requestBuffersRef.current[key]
         if (!buf) return []
         return buf.toArray().filter((r) => r.end_ms >= cutoff)
       }

--- a/frontend/src/hooks/useViewMode.ts
+++ b/frontend/src/hooks/useViewMode.ts
@@ -1,9 +1,0 @@
-import { useState } from 'react'
-import type { ViewMode } from '../types/events'
-
-export function useViewMode() {
-  const [mode, setMode] = useState<ViewMode>('detailed')
-  const toggle = () =>
-    setMode((m) => (m === 'glanceable' ? 'detailed' : 'glanceable'))
-  return { mode, toggle }
-}

--- a/frontend/src/lib/identity.test.ts
+++ b/frontend/src/lib/identity.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import {
+  engineKey,
+  findEngineByEndpoint,
+  findEngineByKey,
+  findGpuByIndex,
+  gpuIndexOf,
+  snapshotGpus,
+} from './identity'
+import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '@/types/metrics'
+
+function engine(endpoint: string): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status: { type: 'Running' },
+    model: null,
+    metrics: null,
+    recent_requests: [],
+    deployment_mode: 'Docker',
+  }
+}
+
+function gpu(overrides: Partial<GpuMetrics> = {}): GpuMetrics {
+  return {
+    name: 'NVIDIA GB10',
+    utilization_percent: 10,
+    temperature_celsius: 40,
+    power_watts: 50,
+    power_limit_watts: null,
+    clock_graphics_mhz: null,
+    clock_sm_mhz: null,
+    clock_memory_mhz: null,
+    fan_speed_percent: null,
+    ...overrides,
+  }
+}
+
+function snapshot(gpus: GpuMetrics[] | undefined, primary: GpuMetrics): Pick<MetricsSnapshot, 'gpu' | 'gpus'> {
+  return { gpu: primary, gpus }
+}
+
+describe('engineKey', () => {
+  it('composes the engine type and endpoint', () => {
+    expect(engineKey(engine('http://localhost:8000'))).toBe('Vllm-http://localhost:8000')
+  })
+
+  it('separates engines of the same type on different endpoints', () => {
+    expect(engineKey(engine('http://localhost:8000'))).not.toBe(
+      engineKey(engine('http://localhost:8001')),
+    )
+  })
+
+  it('accepts anything carrying the identity fields', () => {
+    expect(engineKey({ engine_type: 'Vllm', endpoint: 'http://host:1' })).toBe(
+      'Vllm-http://host:1',
+    )
+  })
+})
+
+describe('findEngineByKey', () => {
+  const engines = [engine('http://localhost:8000'), engine('http://localhost:8001')]
+
+  it('finds the engine whose key matches', () => {
+    expect(findEngineByKey(engines, 'Vllm-http://localhost:8001')).toBe(engines[1])
+  })
+
+  it('returns undefined for a key no engine carries', () => {
+    expect(findEngineByKey(engines, 'Vllm-http://localhost:9999')).toBeUndefined()
+  })
+
+  it('returns undefined for an absent key rather than guessing', () => {
+    expect(findEngineByKey(engines, null)).toBeUndefined()
+    expect(findEngineByKey(engines, undefined)).toBeUndefined()
+  })
+})
+
+describe('findEngineByEndpoint', () => {
+  const engines = [engine('http://localhost:8000'), engine('http://localhost:8001')]
+
+  it('finds the engine bound to the endpoint', () => {
+    expect(findEngineByEndpoint(engines, 'http://localhost:8000')).toBe(engines[0])
+  })
+
+  it('returns undefined when the bound engine is gone', () => {
+    expect(findEngineByEndpoint(engines, 'http://localhost:9999')).toBeUndefined()
+  })
+
+  it('returns undefined for an absent endpoint', () => {
+    expect(findEngineByEndpoint(engines, null)).toBeUndefined()
+    expect(findEngineByEndpoint(engines, undefined)).toBeUndefined()
+  })
+})
+
+describe('gpuIndexOf', () => {
+  it('reads an explicit index', () => {
+    expect(gpuIndexOf(gpu({ index: 3 }))).toBe(3)
+    expect(gpuIndexOf(gpu({ index: 0 }))).toBe(0)
+  })
+
+  it('treats an absent index as the primary GPU', () => {
+    expect(gpuIndexOf(gpu())).toBe(0)
+  })
+
+  it('treats a null index as the primary GPU', () => {
+    expect(gpuIndexOf(gpu({ index: null }))).toBe(0)
+  })
+})
+
+describe('snapshotGpus', () => {
+  it('returns the per-GPU list when the backend ships one', () => {
+    const gpus = [gpu({ index: 0 }), gpu({ index: 1 })]
+    expect(snapshotGpus(snapshot(gpus, gpus[0]))).toEqual(gpus)
+  })
+
+  it('falls back to the single `gpu` field on legacy snapshots', () => {
+    const primary = gpu({ index: null })
+    expect(snapshotGpus(snapshot(undefined, primary))).toEqual([primary])
+  })
+
+  it('falls back to the single `gpu` field when the list is empty', () => {
+    const primary = gpu()
+    expect(snapshotGpus(snapshot([], primary))).toEqual([primary])
+  })
+
+  it('always yields at least one GPU', () => {
+    expect(snapshotGpus(snapshot(undefined, gpu())).length).toBeGreaterThan(0)
+  })
+})
+
+describe('findGpuByIndex', () => {
+  it('finds a GPU by its explicit index', () => {
+    const gpus = [gpu({ index: 0 }), gpu({ index: 1 })]
+    expect(findGpuByIndex(gpus, 1)).toBe(gpus[1])
+  })
+
+  it('matches the normalized index of a legacy GPU', () => {
+    const gpus = [gpu({ index: null })]
+    expect(findGpuByIndex(gpus, 0)).toBe(gpus[0])
+    expect(findGpuByIndex([gpu()], 0)).toBeDefined()
+  })
+
+  it('returns undefined when the index is not in the list', () => {
+    expect(findGpuByIndex([gpu({ index: 0 })], 2)).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/identity.ts
+++ b/frontend/src/lib/identity.ts
@@ -1,0 +1,94 @@
+import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '@/types/metrics'
+
+/**
+ * Identity helpers for the two things the dashboard binds to: an inference
+ * engine and a GPU.
+ *
+ * Both identities were previously re-derived by hand at every use site, which
+ * made it impossible to tell whether two places meant the same entity. They
+ * live here so panels can pin to a target — a GPU by integer index, an engine
+ * by endpoint — against one definition.
+ */
+
+/** The fields of an engine snapshot that make up its identity. */
+export type EngineIdentity = Pick<EngineSnapshot, 'engine_type' | 'endpoint'>
+
+/** The field of a GPU snapshot that makes up its identity. */
+export type GpuIdentity = Pick<GpuMetrics, 'index'>
+
+/**
+ * Composite identity of one engine. A host can run several engines of the
+ * same type, so neither half is unique on its own.
+ *
+ * This is the key for the per-engine history buffers, the value of the engine
+ * tab, the tab id persisted to localStorage and the scope of the per-model SLO
+ * settings — every one of those must agree, so they all come through here.
+ *
+ * Not the same string as the endpoint the log socket and panel bindings use:
+ * those name the engine to the *backend*, which knows engines by endpoint
+ * alone. Use `findEngineByEndpoint` for that direction.
+ */
+export function engineKey(engine: EngineIdentity): string {
+  return `${engine.engine_type}-${engine.endpoint}`
+}
+
+/**
+ * Resolve an engine key back to its snapshot. Returns undefined when the key
+ * names an engine that is not in the list — restored from localStorage before
+ * any metrics arrived, or stopped since it was selected. Callers decide what
+ * to fall back to; substituting a different engine here would silently show
+ * one engine's numbers under another's label.
+ */
+export function findEngineByKey<T extends EngineIdentity>(
+  engines: readonly T[],
+  key: string | null | undefined,
+): T | undefined {
+  if (!key) return undefined
+  return engines.find((engine) => engineKey(engine) === key)
+}
+
+/**
+ * Resolve an endpoint to its engine snapshot — the direction panel bindings
+ * and the log socket use, since the backend addresses engines by endpoint.
+ * Undefined when the bound engine is absent, same contract as
+ * `findEngineByKey`.
+ */
+export function findEngineByEndpoint<T extends Pick<EngineSnapshot, 'endpoint'>>(
+  engines: readonly T[],
+  endpoint: string | null | undefined,
+): T | undefined {
+  if (!endpoint) return undefined
+  return engines.find((engine) => engine.endpoint === endpoint)
+}
+
+/**
+ * A GPU's index, normalized. The field is optional (older backends omit it)
+ * and nullable (the collector reports null when NVML has no index for the
+ * device); both cases mean the primary GPU.
+ */
+export function gpuIndexOf(gpu: GpuIdentity): number {
+  return gpu.index ?? 0
+}
+
+/**
+ * The GPUs on a snapshot. Backends that predate multi-GPU support ship only
+ * the single `gpu` field, so an absent or empty `gpus` list falls back to it —
+ * the result always holds at least one GPU.
+ */
+export function snapshotGpus(
+  snapshot: Pick<MetricsSnapshot, 'gpu' | 'gpus'>,
+): GpuMetrics[] {
+  return snapshot.gpus && snapshot.gpus.length > 0 ? snapshot.gpus : [snapshot.gpu]
+}
+
+/**
+ * Resolve a GPU index to its snapshot, matching on the normalized index so a
+ * legacy GPU with no index answers to 0. Undefined when the index is not on
+ * the host; callers decide what to fall back to.
+ */
+export function findGpuByIndex<T extends GpuIdentity>(
+  gpus: readonly T[],
+  index: number,
+): T | undefined {
+  return gpus.find((gpu) => gpuIndexOf(gpu) === index)
+}

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -20,7 +20,6 @@ export interface InferenceRequest {
 }
 
 export type TimeWindow = '5m' | '10m' | '15m'
-export type ViewMode = 'glanceable' | 'detailed'
 
 export const TIME_WINDOW_SECONDS: Record<TimeWindow, number> = {
   '5m': 300,


### PR DESCRIPTION
Closes #74.

Behaviour-preserving prefactor: make engine and GPU identity one named, tested thing before the panel work starts binding to them.

## What changed

New `frontend/src/lib/identity.ts` holds one definition of each identity:

| Helper | Replaces |
| --- | --- |
| `engineKey(engine)` | the `` `${engine_type}-${endpoint}` `` template, hand-derived at seven sites |
| `findEngineByKey(engines, key)` | the active-engine lookup in `EngineSection` |
| `findEngineByEndpoint(engines, endpoint)` | the log viewer's two bare-endpoint lookups — the second, unnamed identity scheme |
| `gpuIndexOf(gpu)` | `gpu.index ?? 0`, duplicated across the dashboard and the history layer |
| `snapshotGpus(snapshot)` | the legacy single-GPU fallback, duplicated in the same two places |
| `findGpuByIndex(gpus, index)` | the active-GPU lookup in `Dashboard` |

The engine key doubles as the history-buffer key, the tab value, the persisted active tab and the SLO settings scope — every one of those must agree, so they all come through one function now.

Both lookups return `undefined` for an absent target rather than substituting a neighbour, so callers keep the fallback decision where it is visible. `Dashboard` keeps its explicit `?? gpus[0]`.

Also removes `useViewMode` and the `ViewMode` type, which lost their last consumer when the unused components were deleted.

## Notes

- No user-visible change. The existing specs pass **untouched** — no mechanical edits were needed.
- The GPU selector's React key used a third fallback (`gpu.index ?? 'primary'`) that disagreed with the `isActive` and click handlers beside it; it now goes through `gpuIndexOf`. The sibling *label* still deliberately distinguishes absent from 0 — a GPU with no index reads as "GPU", never "GPU 0" — and carries a comment saying so.
- Unblocks #76 and #78.

## Verification

`npm run lint && npm run build && npm test -- --run` green: **220 tests, up from 201 on `main`** (19 new in `identity.test.ts`, covering absent index, null index, the legacy single-GPU snapshot shape, and absent lookup targets). Run in a `node:24` container — this machine has no local node.