### PR TITLE
test(frontend): DOM matchers, user interaction and browser mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,28 @@ jobs:
       - run: npm run build
       - run: npm test -- --run
 
+  frontend-browser:
+    name: Frontend (browser mode)
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      # Its own job so the chromium download is paid here and nowhere else —
+      # the jsdom suite in `frontend` runs without any browser binary.
+      - name: Install chromium
+        run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
+
   installer:
     name: Installer lint
     needs: changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Project-specific. Global rules in `~/.claude/rules/` still apply.
 - `main` is protected. No direct pushes. Every change goes through a PR.
 - Branch name: `<type>/<slug>` (`feat/...`, `fix/...`, `docs/...`).
 - **Rebase-merge** PRs (never squash) so every commit lands individually on `main` and appears in the release notes. **Every commit** must be a valid Conventional Commit, not just the PR title.
-- All `ci.yml` jobs (rust, frontend, installer) must pass before merge.
+- All `ci.yml` jobs (rust, frontend, frontend-browser, installer) must pass before merge.
 
 ## Commits drive releases
 
@@ -40,9 +40,14 @@ Frontend changes (`frontend/`):
 
 ```bash
 cd frontend && npm run lint && npm run build && npm test -- --run
+
+# only when a *.browser.test.tsx changed (one-time: npx playwright install chromium)
+cd frontend && npm run test:browser
 ```
 
 `npm run lint` is enforced by the `frontend` CI job and the baseline is clean — a new error fails the build, so don't let one land.
+
+Vitest runs two projects, so `npm test` alone does not cover both. `npm test` is `unit` (jsdom); specs named `*.browser.test.tsx` belong to `browser`, run in headless chromium, and are enforced by the `frontend-browser` CI job. Put a spec there only when it depends on real layout or CSS — jsdom measures every box as 0×0 — and keep that project small, since it costs a browser download.
 
 If both stacks changed, run both blocks. If embedded assets changed, build the frontend first (`rust-embed` needs `frontend/dist/`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,15 @@ cd frontend && npm test
 cargo test
 ```
 
+`npm test` is the jsdom suite. Specs named `*.browser.test.tsx` run in a real
+headless chromium instead — jsdom has no layout engine, so anything that
+measures an element belongs there:
+
+```bash
+cd frontend && npx playwright install chromium   # one-time, ~150 MB
+npm run test:browser
+```
+
 If you change the `deploy/docker/Dockerfile` or `deploy/docker/docker-compose*.yml`,
 also smoke-test the image build before pushing (see [`deploy/docker/docker.md`](./deploy/docker/docker.md)):
 

--- a/README.md
+++ b/README.md
@@ -404,8 +404,11 @@ the latest stable version; see [CHANGELOG.md](./CHANGELOG.md) for release notes.
 ## Testing
 
 ```bash
-# Frontend
+# Frontend (jsdom)
 cd frontend && npm test
+
+# Frontend layout-dependent specs (headless chromium)
+cd frontend && npx playwright install chromium && npm run test:browser
 
 # Backend (on Linux)
 cargo test

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Vitest browser-mode failure artifacts
+__screenshots__
+.vitest-attachments
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,11 +30,13 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "@vitest/browser-playwright": "^4.1.10",
         "eslint": "^10.5.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
+        "playwright": "^1.62.0",
         "tailwindcss": "^4.3.1",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.61.1",
@@ -573,6 +575,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -1398,6 +1407,13 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
@@ -2554,6 +2570,53 @@
         },
         "babel-plugin-react-compiler": {
           "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+      "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
         }
       }
     },
@@ -5676,6 +5739,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6175,6 +6248,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -6916,6 +7046,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7247,6 +7392,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -7813,6 +7968,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "spark-dashboard-frontend",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
@@ -23,7 +23,9 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.1",
+        "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -39,6 +41,13 @@
         "vite": "^8.0.16",
         "vitest": "^4.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -2033,6 +2042,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -2059,6 +2098,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@ts-morph/common": {
@@ -2753,7 +2806,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3279,6 +3331,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3563,7 +3622,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4672,6 +4730,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5574,6 +5642,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6407,6 +6485,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -6987,6 +7079,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/symbol-tree": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "vitest run --project=unit",
+    "test:watch": "vitest --project=unit",
+    "test:browser": "vitest run --project=browser"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
@@ -40,11 +41,13 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/browser-playwright": "^4.1.10",
     "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
+    "playwright": "^1.62.0",
     "tailwindcss": "^4.3.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.61.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,9 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.1",
+    "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
+++ b/frontend/src/__tests__/Dashboard.multiGpu.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Dashboard } from '../components/views/Dashboard'
 import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '../types/metrics'
 import type { GpuEvent } from '../types/events'
@@ -109,31 +110,33 @@ function gpuSelector() {
 }
 
 describe('Dashboard multi-GPU selection', () => {
-  it('switches all GPU chart panels and gauges to the clicked GPU', () => {
+  it('switches all GPU chart panels and gauges to the clicked GPU', async () => {
+    const user = userEvent.setup()
     const history = stubHistory()
     render(<Dashboard metrics={makeSnapshot([gpu0, gpu1])} history={history} events={[]} requests={[]} />)
 
-    expect(gpuSelector()).not.toBeNull()
+    expect(gpuSelector()).toBeInTheDocument()
     // Primary GPU selected by default: per-GPU keys for GPU 0, gauge shows its util
     expect(history.calls).toContain('gpu:0:gpuUtil')
-    expect(screen.getByText('11')).toBeTruthy()
+    expect(screen.getByText('11')).toBeInTheDocument()
 
     history.calls.length = 0
-    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+    await user.click(screen.getByRole('button', { name: /GPU 1/ }))
 
     for (const key of ['gpu:1:gpuUtil', 'gpu:1:gpuTemp', 'gpu:1:gpuPower', 'gpu:1:gpuClockGraphics']) {
       expect(history.calls).toContain(key)
     }
     expect(history.calls.filter((c) => c.startsWith('gpu:0:'))).toEqual([])
     // Gauges now show GPU 1's utilization / temperature / power
-    expect(screen.getByText('77')).toBeTruthy()
-    expect(screen.getByText('61')).toBeTruthy()
-    expect(screen.getByText('220')).toBeTruthy()
-    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
-    expect(screen.getByRole('button', { name: /GPU 0/ }).getAttribute('aria-pressed')).toBe('false')
+    expect(screen.getByText('77')).toBeInTheDocument()
+    expect(screen.getByText('61')).toBeInTheDocument()
+    expect(screen.getByText('220')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /GPU 1/ })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /GPU 0/ })).toHaveAttribute('aria-pressed', 'false')
   })
 
-  it('chart event markers follow the selected GPU', () => {
+  it('chart event markers follow the selected GPU', async () => {
+    const user = userEvent.setup()
     const events: GpuEvent[] = [
       { timestamp_ms: 900, gpu_index: 0, event_type: 'thermal', detail: 'gpu0 thermal' },
       { timestamp_ms: 950, gpu_index: 1, event_type: 'throttle', detail: 'gpu1 throttle' },
@@ -146,7 +149,7 @@ describe('Dashboard multi-GPU selection', () => {
     expect(details).toContain('global xid')
     expect(details).not.toContain('gpu1 throttle')
 
-    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+    await user.click(screen.getByRole('button', { name: /GPU 1/ }))
 
     details = screen.getAllByTestId('chart-event').map((e) => e.textContent)
     expect(details).toContain('gpu1 throttle')
@@ -166,42 +169,45 @@ describe('Dashboard multi-GPU selection', () => {
         <Dashboard metrics={makeSnapshot([gpu0, gpu1])} history={history} events={[]} requests={[]} />,
       ),
     ).not.toThrow()
-    expect(gpuSelector()).not.toBeNull()
+    expect(gpuSelector()).toBeInTheDocument()
   })
 
-  it('keeps the selected GPU when a new snapshot arrives', () => {
+  it('keeps the selected GPU when a new snapshot arrives', async () => {
+    const user = userEvent.setup()
     const history = stubHistory()
     const snapshot = makeSnapshot([gpu0, gpu1])
     const { rerender } = render(<Dashboard metrics={snapshot} history={history} events={[]} requests={[]} />)
 
-    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+    await user.click(screen.getByRole('button', { name: /GPU 1/ }))
     history.calls.length = 0
 
     rerender(
       <Dashboard metrics={{ ...snapshot, timestamp_ms: 2000 }} history={history} events={[]} requests={[]} />,
     )
 
-    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: /GPU 1/ })).toHaveAttribute('aria-pressed', 'true')
     expect(history.calls).toContain('gpu:1:gpuUtil')
     expect(history.calls.filter((c) => c.startsWith('gpu:0:'))).toEqual([])
   })
 
-  it('falls back to the primary GPU when the selected GPU disappears', () => {
+  it('falls back to the primary GPU when the selected GPU disappears', async () => {
+    const user = userEvent.setup()
     const history = stubHistory()
     const { rerender } = render(
       <Dashboard metrics={makeSnapshot([gpu0, gpu1])} history={history} events={[]} requests={[]} />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
+    await user.click(screen.getByRole('button', { name: /GPU 1/ }))
 
     rerender(<Dashboard metrics={makeSnapshot([gpu0])} history={history} events={[]} requests={[]} />)
 
-    expect(gpuSelector()).toBeNull()
-    expect(screen.getByText('11')).toBeTruthy()
+    expect(gpuSelector()).not.toBeInTheDocument()
+    expect(screen.getByText('11')).toBeInTheDocument()
   })
 })
 
 describe('Dashboard engine GPU binding', () => {
-  it('automatically follows the selected engine GPU', () => {
+  it('automatically follows the selected engine GPU', async () => {
+    const user = userEvent.setup()
     const history = stubHistory()
     const engine0 = makeEngine([0])
     const engine1 = { ...makeEngine([1]), endpoint: 'http://localhost:8001', model: { ...makeEngine([1]).model!, name: 'second-model' } }
@@ -214,13 +220,14 @@ describe('Dashboard engine GPU binding', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('tab', { name: /second-model/ }))
+    await user.click(screen.getByRole('tab', { name: /second-model/ }))
 
-    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
-    expect(screen.getByText('77')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /GPU 1/ })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('77')).toBeInTheDocument()
   })
 
-  it('keeps the manual GPU when the selected engine spans it', () => {
+  it('keeps the manual GPU when the selected engine spans it', async () => {
+    const user = userEvent.setup()
     const history = stubHistory()
     const engine0 = makeEngine([0])
     const engineBoth = { ...makeEngine([0, 1]), endpoint: 'http://localhost:8001', model: { ...makeEngine([0, 1]).model!, name: 'parallel-model' } }
@@ -233,10 +240,10 @@ describe('Dashboard engine GPU binding', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /GPU 1/ }))
-    fireEvent.click(screen.getByRole('tab', { name: /parallel-model/ }))
+    await user.click(screen.getByRole('button', { name: /GPU 1/ }))
+    await user.click(screen.getByRole('tab', { name: /parallel-model/ }))
 
-    expect(screen.getByRole('button', { name: /GPU 1/ }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: /GPU 1/ })).toHaveAttribute('aria-pressed', 'true')
   })
 })
 
@@ -251,13 +258,13 @@ describe('Dashboard single-GPU regression', () => {
     )
 
     // No selector strip, no per-GPU chrome
-    expect(gpuSelector()).toBeNull()
-    expect(screen.queryByText('GPU 0')).toBeNull()
-    expect(container.querySelector('[aria-pressed]')).toBeNull()
+    expect(gpuSelector()).not.toBeInTheDocument()
+    expect(screen.queryByText('GPU 0')).not.toBeInTheDocument()
+    expect(container.querySelector('[aria-pressed]')).not.toBeInTheDocument()
 
     // Card subtitles carry the plain GPU name, not the multi-GPU "GPU n · name" form
     expect(screen.getAllByText('NVIDIA Alpha 0').length).toBeGreaterThan(0)
-    expect(screen.queryByText(/GPU 0 · /)).toBeNull()
+    expect(screen.queryByText(/GPU 0 · /)).not.toBeInTheDocument()
 
     // Charts read the legacy un-prefixed history keys
     for (const key of ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics']) {

--- a/frontend/src/__tests__/HBar.test.tsx
+++ b/frontend/src/__tests__/HBar.test.tsx
@@ -6,26 +6,25 @@ import type { GaugeSegment } from '../components/gauges/ArcGauge'
 describe('HBar', () => {
   it('renders a single value with label and unit', () => {
     render(<HBar value={42} label="GPU Util" unit="%" />)
-    expect(screen.getByText('GPU Util')).toBeTruthy()
-    expect(screen.getByText('42')).toBeTruthy()
-    expect(screen.getByText('%')).toBeTruthy()
+    expect(screen.getByText('GPU Util')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('%')).toBeInTheDocument()
   })
 
   it('fills the bar proportionally to value/max', () => {
     render(<HBar value={30} max={120} label="X" unit="W" />)
-    const fill = screen.getByTestId('hbar-fill') as HTMLElement
     // 30/120 = 25%
-    expect(fill.style.width).toBe('25%')
+    expect(screen.getByTestId('hbar-fill')).toHaveStyle({ width: '25%' })
   })
 
   it('clamps the fill width to [0, 100]%', () => {
     render(<HBar value={500} max={100} label="X" unit="%" />)
-    expect((screen.getByTestId('hbar-fill') as HTMLElement).style.width).toBe('100%')
+    expect(screen.getByTestId('hbar-fill')).toHaveStyle({ width: '100%' })
   })
 
   it('prefers displayValue over value for the readout', () => {
     render(<HBar value={75} displayValue={150} label="GPU Power" unit="W" />)
-    expect(screen.getByText('150')).toBeTruthy()
+    expect(screen.getByText('150')).toBeInTheDocument()
   })
 
   it('renders stacked segments with a legend and no single-value fill', () => {
@@ -38,11 +37,11 @@ describe('HBar', () => {
     ]
     render(<HBar value={50} label="" unit="%" segments={segments} />)
     // No single-value fill is rendered in segment mode.
-    expect(screen.queryByTestId('hbar-fill')).toBeNull()
+    expect(screen.queryByTestId('hbar-fill')).not.toBeInTheDocument()
     // Legend labels present.
-    expect(screen.getByText('GPU: 25')).toBeTruthy()
-    expect(screen.getByText('Free: 50')).toBeTruthy()
+    expect(screen.getByText('GPU: 25')).toBeInTheDocument()
+    expect(screen.getByText('Free: 50')).toBeInTheDocument()
     // Readout uses the explicit value (used %), matching ArcGauge precedence.
-    expect(screen.getByText('50')).toBeTruthy()
+    expect(screen.getByText('50')).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/browser/layout.browser.test.tsx
+++ b/frontend/src/__tests__/browser/layout.browser.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// The whole point of the browser project: a real layout engine. jsdom reports
+// every box as 0x0 and resolves no CSS, so the fit-to-viewport grid work in #68
+// cannot be tested there at all. This is the smoke test that proves the project
+// is wired — render a component, let the browser lay it out, measure it.
+function Box() {
+  return (
+    <div style={{ width: 320, padding: 16, boxSizing: 'border-box' }}>
+      <div data-testid="panel" style={{ height: 48, width: '50%' }} />
+    </div>
+  )
+}
+
+describe('browser mode', () => {
+  it('lays out and measures a rendered component', () => {
+    render(<Box />)
+
+    const panel = screen.getByTestId('panel')
+    expect(panel).toBeInTheDocument()
+
+    // 320 minus 2x16 padding, halved: a number jsdom can never produce.
+    const box = panel.getBoundingClientRect()
+    expect(box.width).toBe(144)
+    expect(box.height).toBe(48)
+  })
+})

--- a/frontend/src/__tests__/setup.test.ts
+++ b/frontend/src/__tests__/setup.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest'
-
-describe('test setup', () => {
-  it('vitest is configured correctly', () => {
-    expect(true).toBe(true)
-  })
-})

--- a/frontend/src/__tests__/toolkit.test.tsx
+++ b/frontend/src/__tests__/toolkit.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Guards the toolkit itself: if `src/test/setup.ts` stops being registered, or
+// user-event stops being installed, this fails loudly instead of every spec
+// failing obscurely.
+describe('test toolkit', () => {
+  it('registers the jest-dom matchers from the setup module', () => {
+    render(<button>ping</button>)
+
+    expect(screen.getByRole('button', { name: 'ping' })).toBeInTheDocument()
+  })
+
+  it('drives typing through user-event, one keystroke at a time', async () => {
+    const user = userEvent.setup()
+    const seen: string[] = []
+    render(<input aria-label="filter" onChange={(e) => seen.push(e.target.value)} />)
+
+    await user.type(screen.getByLabelText('filter'), 'ab')
+
+    // fireEvent.change would have produced a single 'ab'; real keystrokes don't.
+    expect(seen).toEqual(['a', 'ab'])
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,6 @@
+// Registered as `setupFiles` for both the jsdom and the browser project.
+//
+// `@testing-library/jest-dom/vitest` adds the DOM matchers (`toBeInTheDocument`,
+// `toHaveAttribute`, `toHaveStyle`, …) to vitest's `expect` and augments its
+// types, so specs assert on what the DOM says rather than on null-ness.
+import '@testing-library/jest-dom/vitest'

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: [],
+    setupFiles: ['./src/test/setup.ts'],
   },
 })

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,17 +1,57 @@
-import { defineConfig } from 'vitest/config'
+import { defaultExclude, defineConfig } from 'vitest/config'
+import { playwright } from '@vitest/browser-playwright'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-export default defineConfig({
+/** The vite pipeline a spec needs to load app code: JSX transform and `@` alias. */
+const appPipeline = {
   plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
   },
+}
+
+/** Applies to both projects: vitest's globals, and where the matchers come from. */
+const shared = {
+  globals: true,
+  setupFiles: ['./src/test/setup.ts'],
+}
+
+// Two projects, deliberately separated by test-file name:
+//
+//   unit    — `*.test.ts(x)` under jsdom. The default suite; no browser binaries.
+//   browser — `*.browser.test.ts(x)` in headless chromium. jsdom has no layout
+//             engine, so anything that measures an element can only be tested
+//             there. Kept small on purpose: it needs playwright's chromium
+//             download, which CI installs for that job alone.
+export default defineConfig({
   test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
+    projects: [
+      {
+        ...appPipeline,
+        test: {
+          ...shared,
+          name: 'unit',
+          environment: 'jsdom',
+          exclude: [...defaultExclude, '**/*.browser.test.{ts,tsx}'],
+        },
+      },
+      {
+        ...appPipeline,
+        test: {
+          ...shared,
+          name: 'browser',
+          include: ['src/**/*.browser.test.{ts,tsx}'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: 'chromium' }],
+          },
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
Closes #75.

The testing capabilities the rework in #68 needs, landed before there is anything to test with them — so the CI cost is visible now rather than discovered at the end.

## What's here

| Commit | |
| --- | --- |
| `a43e60c` | jest-dom 7 + user-event 14, `src/test/setup.ts`, `toolkit.test.tsx` |
| `e36908d` | HBar → matchers, Dashboard.multiGpu → user-event |
| `ce97aa5` | `unit`/`browser` vitest projects, `@vitest/browser-playwright` + playwright, layout smoke test |
| `0f42e91` | `frontend-browser` CI job |
| `b0804b7` | CLAUDE.md / CONTRIBUTING.md / README.md |

Vitest now runs two projects, split by test-file name. `unit` is the existing jsdom suite and stays the default `npm test`; `browser` picks up `*.browser.test.tsx` and runs them in headless chromium under `npm run test:browser`. The unit project excludes the browser pattern *on top of* vitest's `defaultExclude` rather than replacing it, so `node_modules` stays excluded.

The prototype finding on #75 held exactly: in vitest 4 the browser provider lives in its own package and is configured as an object, not a name string — `provider: playwright()` from `@vitest/browser-playwright`.

## Acceptance criteria

- [x] DOM matchers and the user-interaction library are available and registered from a setup module — `src/test/setup.ts`; user-event has nothing to register and is imported per spec, which is its intended usage
- [x] At least one existing spec is converted to the matchers as proof they are wired — two: HBar for the matchers, Dashboard.multiGpu for the interaction library
- [x] A browser-mode project runs a trivial smoke test in headless chromium, locally and in CI
- [x] CI installs browser binaries only for that job; the jsdom suite still runs without them
- [x] The spec for the deleted component is gone — **already satisfied on `main`** by 33d3eec, which deleted the `GpuCard.multiGpu`, `MemoryCard` and `ViewModeToggle` specs with their components. Every remaining spec resolves to a live module, so nothing on this branch addresses it. What this branch does delete is `setup.test.ts`, an `expect(true).toBe(true)` placeholder, replaced by a `toolkit.test.tsx` that fails when the setup module is unregistered or user-event goes missing
- [x] `npm run lint && npm run build && npm test -- --run` green, and the browser project green

## Dependency selection

All four are the current latest stable, checked against the registry rather than recalled: `@testing-library/jest-dom` 7.0.0, `@testing-library/user-event` 14.6.1, `@vitest/browser-playwright` 4.1.10 (matching the installed vitest, which it peer-pins exactly), `playwright` 1.62.0. `@vitest/browser` arrives as a dependency of the provider package, so it isn't listed separately.

## Verification

This Mac has no node, so everything ran in containers:

- **jsdom suite on a machine with no browser binary** — `npm ci && npm run lint && npm run build && npm test -- --run` in a plain `node:24` image: 221 tests green. This is the exact situation of the `frontend` CI job, and the reason the browser install lives in its own job.
- **Browser project** — `npm run test:browser` in `mcr.microsoft.com/playwright:v1.62.0-noble`: green.
- **The smoke test is not vacuous** — the same file re-run under jsdom fails with `expected +0 to be 144`. It renders a 320px box with 16px padding either side and a 50%-wide child, then measures the child; jsdom reports every box as 0×0.
- `npm ci` downloads no browser: playwright 1.62 has no install script, so the jsdom job stays binary-free by construction rather than by configuration.

## Notes for review

- **`frontend/package-lock.json`'s root `version` moves 0.12.0 → 0.13.0.** Not a hand-edit of a release-please field — `package.json` on `main` already says 0.13.0 and the lock was stale; `npm install` corrected it as a side effect.
- **A bare `npx vitest` (no `--project`) now runs both projects** and fails without chromium. That's vitest's normal behaviour for a multi-project config; the documented commands pin the project, and gating it would need a config hack CI has no reason to carry.
- CLAUDE.md's frontend pre-commit block gained the browser run explicitly. `npm test` alone no longer covers both projects, so the block on its own would have let a `*.browser.test.tsx` change through unrun.
