### PR TITLE
feat(frontend): dashboard configuration schema, migrations and default preset

### DIFF
--- a/frontend/src/lib/dashboard/bindings.test.ts
+++ b/frontend/src/lib/dashboard/bindings.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FOLLOW,
+  UNREADABLE,
+  readBinding,
+  resolveEngineBinding,
+  resolveGpuBinding,
+} from './bindings'
+import type { EngineSnapshot, GpuMetrics } from '@/types/metrics'
+
+function gpu(index: number | null | undefined): GpuMetrics {
+  return {
+    index,
+    name: 'NVIDIA GB10',
+    utilization_percent: 10,
+    memory_total_bytes: null,
+    memory_used_bytes: null,
+    temperature_celsius: 40,
+    power_watts: 50,
+    power_limit_watts: null,
+    clock_graphics_mhz: null,
+    clock_sm_mhz: null,
+    clock_memory_mhz: null,
+    fan_speed_percent: null,
+  }
+}
+
+function engine(endpoint: string): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status: { type: 'Running' },
+    model: null,
+    metrics: null,
+    recent_requests: [],
+    deployment_mode: 'Docker',
+  }
+}
+
+describe('readBinding', () => {
+  it('reads the follow sentinel', () => {
+    expect(readBinding({ kind: 'follow' })).toEqual(FOLLOW)
+  })
+
+  it('reads a GPU pinned by index', () => {
+    expect(readBinding({ kind: 'gpu', index: 2 })).toEqual({ kind: 'gpu', index: 2 })
+    expect(readBinding({ kind: 'gpu', index: 0 })).toEqual({ kind: 'gpu', index: 0 })
+  })
+
+  it('reads an engine pinned by endpoint', () => {
+    expect(readBinding({ kind: 'engine', endpoint: 'http://localhost:8000' })).toEqual({
+      kind: 'engine',
+      endpoint: 'http://localhost:8000',
+    })
+  })
+
+  it('defaults an absent binding to follow', () => {
+    // Nothing was ever pinned, so following the page is the default rather than
+    // a substitution for something the operator chose.
+    expect(readBinding(undefined)).toEqual(FOLLOW)
+    expect(readBinding(null)).toEqual(FOLLOW)
+  })
+
+  it('refuses to guess at a pin it cannot read', () => {
+    // Reverting these to follow would show the page selection under a title the
+    // operator may have written to name the target that was pinned here.
+    expect(readBinding({ kind: 'gpu' })).toEqual(UNREADABLE)
+    expect(readBinding({ kind: 'gpu', index: '2' })).toEqual(UNREADABLE)
+    expect(readBinding({ kind: 'engine' })).toEqual(UNREADABLE)
+    expect(readBinding({ kind: 'engine', endpoint: '' })).toEqual(UNREADABLE)
+    expect(readBinding({ kind: 'display' })).toEqual(UNREADABLE)
+    expect(readBinding('gpu:2')).toEqual(UNREADABLE)
+    expect(readBinding(7)).toEqual(UNREADABLE)
+  })
+
+  it('rejects a GPU index that is not a real index', () => {
+    expect(readBinding({ kind: 'gpu', index: -1 })).toEqual(UNREADABLE)
+    expect(readBinding({ kind: 'gpu', index: 1.5 })).toEqual(UNREADABLE)
+    expect(readBinding({ kind: 'gpu', index: NaN })).toEqual(UNREADABLE)
+  })
+})
+
+describe('resolveGpuBinding', () => {
+  const gpus = [gpu(0), gpu(1)]
+
+  it('follows the page selection', () => {
+    expect(resolveGpuBinding(FOLLOW, gpus, 1)).toEqual({ status: 'resolved', target: gpus[1] })
+  })
+
+  it('resolves a pinned GPU that is present', () => {
+    expect(resolveGpuBinding({ kind: 'gpu', index: 0 }, gpus, 1)).toEqual({
+      status: 'resolved',
+      target: gpus[0],
+    })
+  })
+
+  it('resolves a pin against the normalized index of a legacy GPU', () => {
+    const legacy = [gpu(null)]
+    expect(resolveGpuBinding({ kind: 'gpu', index: 0 }, legacy, 0)).toEqual({
+      status: 'resolved',
+      target: legacy[0],
+    })
+  })
+
+  it('reports a pinned GPU that is not on the host as missing', () => {
+    // Restricting the dashboard to one GPU has to make the panels pinned to the
+    // others fail visibly, not quietly show GPU 0's numbers.
+    expect(resolveGpuBinding({ kind: 'gpu', index: 3 }, gpus, 0)).toEqual({
+      status: 'missing',
+      requested: 'GPU 3',
+    })
+  })
+
+  it('reports a followed selection that is not on the host as missing', () => {
+    expect(resolveGpuBinding(FOLLOW, gpus, 3)).toEqual({ status: 'missing', requested: 'GPU 3' })
+  })
+
+  it('reports an empty host as having nothing selected', () => {
+    expect(resolveGpuBinding(FOLLOW, [], 0)).toEqual({ status: 'unselected' })
+  })
+
+  it('still reports a pin against an empty host as missing', () => {
+    // A pin named something specific, so it is missing rather than unselected —
+    // "nothing to follow" is only a state a following panel can be in.
+    expect(resolveGpuBinding({ kind: 'gpu', index: 3 }, [], 0)).toEqual({
+      status: 'missing',
+      requested: 'GPU 3',
+    })
+  })
+
+  it('shows no GPU at all for a binding it could not read', () => {
+    expect(resolveGpuBinding(UNREADABLE, gpus, 0)).toEqual({ status: 'unreadable' })
+  })
+
+  it('never substitutes a GPU for a binding that names an engine', () => {
+    // On a GPU panel that is a corrupt document, and picking a GPU to show
+    // anyway is the worst way to report it.
+    expect(
+      resolveGpuBinding({ kind: 'engine', endpoint: 'http://localhost:8000' }, gpus, 0),
+    ).toEqual({ status: 'unreadable' })
+  })
+})
+
+describe('resolveEngineBinding', () => {
+  const engines = [engine('http://localhost:8000'), engine('http://localhost:8001')]
+
+  it('follows the page selection', () => {
+    expect(resolveEngineBinding(FOLLOW, engines, 'http://localhost:8001')).toEqual({
+      status: 'resolved',
+      target: engines[1],
+    })
+  })
+
+  it('resolves a pinned engine that is running', () => {
+    expect(
+      resolveEngineBinding({ kind: 'engine', endpoint: 'http://localhost:8000' }, engines, null),
+    ).toEqual({ status: 'resolved', target: engines[0] })
+  })
+
+  it('reports a pinned engine that is gone as missing', () => {
+    // Changing an engine's port must show immediately which panels now point at
+    // nothing, so they can be repointed.
+    expect(
+      resolveEngineBinding({ kind: 'engine', endpoint: 'http://localhost:9999' }, engines, null),
+    ).toEqual({ status: 'missing', requested: 'http://localhost:9999' })
+  })
+
+  it('reports a followed selection that is gone as missing', () => {
+    expect(resolveEngineBinding(FOLLOW, engines, 'http://localhost:9999')).toEqual({
+      status: 'missing',
+      requested: 'http://localhost:9999',
+    })
+  })
+
+  it('reports a host running no engines as having nothing selected', () => {
+    // Hardware monitoring stays useful on a host with no engines, so this is a
+    // graceful state rather than a failure.
+    expect(resolveEngineBinding(FOLLOW, [], null)).toEqual({ status: 'unselected' })
+    expect(resolveEngineBinding(FOLLOW, engines, null)).toEqual({ status: 'unselected' })
+  })
+
+  it('shows no engine at all for a binding it could not read', () => {
+    expect(resolveEngineBinding(UNREADABLE, engines, null)).toEqual({ status: 'unreadable' })
+  })
+
+  it('never substitutes an engine for a binding that names a GPU', () => {
+    expect(resolveEngineBinding({ kind: 'gpu', index: 1 }, engines, null)).toEqual({
+      status: 'unreadable',
+    })
+  })
+})

--- a/frontend/src/lib/dashboard/bindings.ts
+++ b/frontend/src/lib/dashboard/bindings.ts
@@ -1,0 +1,152 @@
+/**
+ * What a panel points at, and what it resolves to on this particular host.
+ *
+ * A binding is either a concrete target — a GPU by integer index, an engine by
+ * endpoint, the same identity keys the rest of the dashboard uses — or the
+ * sentinel `follow`, which defers to the page-level selection. Follow is what
+ * lets the shipped default preset be one static document that is right on a
+ * one-GPU laptop and on a four-GPU server, instead of a layout generated at
+ * runtime that would need testing across every permutation.
+ *
+ * **Silent substitution is prohibited.** Every way of not having a target
+ * resolves to something the UI renders as a placeholder keeping its grid slot —
+ * never to a different target. Quietly showing one engine's numbers under the
+ * label the operator pinned is the worst available failure on a metrics tool,
+ * because it cannot be noticed. That is also why a pin that cannot be read does
+ * not quietly revert to following: the operator may well have retitled the panel
+ * after the target it named.
+ */
+
+import { findEngineByEndpoint, findGpuByIndex, type GpuIdentity } from '@/lib/identity'
+import type { EngineSnapshot } from '@/types/metrics'
+import { isRecord } from './json'
+
+/**
+ * Where a panel gets its target.
+ *
+ * Deeply readonly: bindings are values, replaced rather than edited. Without it
+ * the shared `FOLLOW` and `UNREADABLE` constants would be aliased by every
+ * panel that has one, and editing a single panel would reach all of them.
+ */
+export type PanelBinding =
+  /** Whatever the page-level selector currently points at. */
+  | { readonly kind: 'follow' }
+  /** One GPU, pinned by its integer index. */
+  | { readonly kind: 'gpu'; readonly index: number }
+  /** One inference engine, pinned by its endpoint. */
+  | { readonly kind: 'engine'; readonly endpoint: string }
+  /**
+   * Something was pinned here and it could not be read — a hand-edited file, a
+   * truncated write. Kept as a state of its own rather than folded into
+   * `follow`, so the panel says it needs repointing instead of showing the page
+   * selection under a title that may name the target it lost.
+   */
+  | { readonly kind: 'unreadable' }
+
+/** The follow sentinel. Every panel in the default preset carries this. */
+export const FOLLOW: PanelBinding = { kind: 'follow' }
+
+/** A binding that was present and could not be read. */
+export const UNREADABLE: PanelBinding = { kind: 'unreadable' }
+
+/** What a binding turned into on this host. */
+export type BindingResolution<T> =
+  /** The target exists; render it. */
+  | { status: 'resolved'; target: T }
+  /**
+   * A target was asked for and is not here — a pin to a GPU index the host no
+   * longer exposes, an engine whose port changed. `requested` names it so the
+   * placeholder can say which panel to repoint.
+   */
+  | { status: 'missing'; requested: string }
+  /**
+   * Nothing is selected to follow, because there is nothing to select: a host
+   * running no inference engines. Distinct from `missing` because it is not a
+   * misconfiguration and reads differently to an operator.
+   */
+  | { status: 'unselected' }
+  /**
+   * The binding itself could not be understood — unreadable as stored, or naming
+   * a kind of target this panel does not take. There is nothing to name in the
+   * placeholder beyond "repoint this panel".
+   */
+  | { status: 'unreadable' }
+
+/**
+ * Reads a persisted binding.
+ *
+ * An **absent** binding becomes `follow`: nothing was ever pinned, so following
+ * the page is the default rather than a substitution. A binding that is
+ * **present but malformed** becomes `unreadable` — it did name a target, and
+ * guessing which would risk showing the wrong numbers under the operator's own
+ * label.
+ */
+export function readBinding(raw: unknown): PanelBinding {
+  if (raw === undefined || raw === null) return FOLLOW
+  if (!isRecord(raw)) return UNREADABLE
+
+  switch (raw.kind) {
+    case 'follow':
+      return FOLLOW
+    case 'gpu':
+      return isGpuIndex(raw.index) ? { kind: 'gpu', index: raw.index } : UNREADABLE
+    case 'engine':
+      return typeof raw.endpoint === 'string' && raw.endpoint.length > 0
+        ? { kind: 'engine', endpoint: raw.endpoint }
+        : UNREADABLE
+    default:
+      return UNREADABLE
+  }
+}
+
+/**
+ * Resolves a GPU panel's binding against the GPUs on this host.
+ *
+ * `pageGpuIndex` is the page-level selection a following panel defers to. A
+ * selection that is not on the host is reported as missing rather than nudged to
+ * the primary GPU — the page label and the panel's data have to agree.
+ */
+export function resolveGpuBinding<T extends GpuIdentity>(
+  binding: PanelBinding,
+  gpus: readonly T[],
+  pageGpuIndex: number,
+): BindingResolution<T> {
+  // Including a binding that names an engine: on a GPU panel that is a corrupt
+  // document, and picking some GPU to show anyway is the prohibited failure.
+  if (binding.kind !== 'follow' && binding.kind !== 'gpu') return { status: 'unreadable' }
+
+  // Only a following panel can have nothing to follow. A pin names a GPU, so an
+  // empty host makes it missing rather than unselected — the operator asked for
+  // something specific and it is not here.
+  if (binding.kind === 'follow' && gpus.length === 0) return { status: 'unselected' }
+
+  const index = binding.kind === 'gpu' ? binding.index : pageGpuIndex
+  const target = findGpuByIndex(gpus, index)
+  return target ? { status: 'resolved', target } : { status: 'missing', requested: `GPU ${index}` }
+}
+
+/**
+ * Resolves an engine panel's binding against the engines detected on this host.
+ *
+ * `pageEngineEndpoint` is the page-level selection. A host with no engines, or a
+ * page with no engine selected, is `unselected` — hardware monitoring is still
+ * useful there, so it is a graceful state rather than a failure.
+ */
+export function resolveEngineBinding<T extends Pick<EngineSnapshot, 'endpoint'>>(
+  binding: PanelBinding,
+  engines: readonly T[],
+  pageEngineEndpoint: string | null | undefined,
+): BindingResolution<T> {
+  if (binding.kind !== 'follow' && binding.kind !== 'engine') return { status: 'unreadable' }
+
+  const endpoint = binding.kind === 'engine' ? binding.endpoint : pageEngineEndpoint
+  if (!endpoint) return { status: 'unselected' }
+
+  const target = findEngineByEndpoint(engines, endpoint)
+  return target ? { status: 'resolved', target } : { status: 'missing', requested: endpoint }
+}
+
+/** A GPU index as the backend reports them: a non-negative whole number. */
+function isGpuIndex(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}

--- a/frontend/src/lib/dashboard/grid.test.ts
+++ b/frontend/src/lib/dashboard/grid.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import {
+  GRID_COLUMNS,
+  GRID_MAX_ROWS,
+  firstFreeSlot,
+  isOutOfRoom,
+  readGeometry,
+  type PanelGeometry,
+} from './grid'
+
+/** A geometry literal, so the specs below read as coordinates rather than objects. */
+function at(x: number, y: number, w: number, h: number): PanelGeometry {
+  return { x, y, w, h }
+}
+
+describe('readGeometry', () => {
+  it('reads a complete geometry unchanged', () => {
+    expect(readGeometry({ x: 3, y: 2, w: 4, h: 5 })).toEqual(at(3, 2, 4, 5))
+  })
+
+  it('treats a missing width or height as one', () => {
+    // gridstack's save() omits values equal to its defaults, so a 1x1 widget
+    // serializes without w/h at all. Guessing anything else here silently
+    // resizes every small panel on the next read.
+    expect(readGeometry({ x: 5, y: 6 })).toEqual(at(5, 6, 1, 1))
+    expect(readGeometry({ x: 5, y: 6, w: 2 })).toEqual(at(5, 6, 2, 1))
+    expect(readGeometry({ x: 5, y: 6, h: 2 })).toEqual(at(5, 6, 1, 2))
+  })
+
+  it('treats a missing position as the grid origin', () => {
+    expect(readGeometry({ w: 2, h: 2 })).toEqual(at(0, 0, 2, 2))
+  })
+
+  it('reads a wholly absent geometry as a single cell at the origin', () => {
+    expect(readGeometry(undefined)).toEqual(at(0, 0, 1, 1))
+    expect(readGeometry(null)).toEqual(at(0, 0, 1, 1))
+    expect(readGeometry('nonsense')).toEqual(at(0, 0, 1, 1))
+  })
+
+  it('discards values that are not finite numbers', () => {
+    expect(readGeometry({ x: '2', y: NaN, w: null, h: Infinity })).toEqual(at(0, 0, 1, 1))
+  })
+
+  it('truncates fractional coordinates to whole cells', () => {
+    expect(readGeometry({ x: 1.7, y: 2.9, w: 3.4, h: 4.6 })).toEqual(at(1, 2, 3, 4))
+  })
+
+  it('clamps a size larger than the grid down to the grid', () => {
+    expect(readGeometry({ x: 0, y: 0, w: 99, h: 99 })).toEqual(
+      at(0, 0, GRID_COLUMNS, GRID_MAX_ROWS),
+    )
+  })
+
+  it('raises a zero or negative size to one cell', () => {
+    expect(readGeometry({ x: 0, y: 0, w: 0, h: -4 })).toEqual(at(0, 0, 1, 1))
+  })
+
+  it('pulls a panel that overhangs the right edge back inside', () => {
+    // A 4-wide panel can start no further right than column 8 of 12.
+    expect(readGeometry({ x: 11, y: 0, w: 4, h: 1 })).toEqual(at(8, 0, 4, 1))
+  })
+
+  it('pulls a panel that overhangs the bottom edge back inside', () => {
+    // A 4-tall panel can start no lower than row 4 of 8.
+    expect(readGeometry({ x: 0, y: 7, w: 1, h: 4 })).toEqual(at(0, 4, 1, 4))
+  })
+
+  it('pulls a negative position back to the origin', () => {
+    expect(readGeometry({ x: -3, y: -1, w: 2, h: 2 })).toEqual(at(0, 0, 2, 2))
+  })
+})
+
+describe('firstFreeSlot', () => {
+  it('places the first panel at the origin', () => {
+    expect(firstFreeSlot([], { w: 1, h: 1 })).toEqual(at(0, 0, 1, 1))
+  })
+
+  it('places a panel beside an occupied block on the same row', () => {
+    expect(firstFreeSlot([at(0, 0, 3, 3)], { w: 1, h: 1 })).toEqual(at(3, 0, 1, 1))
+  })
+
+  it('drops to the next row when the first is full', () => {
+    expect(firstFreeSlot([at(0, 0, GRID_COLUMNS, 1)], { w: 1, h: 1 })).toEqual(at(0, 1, 1, 1))
+  })
+
+  it('fills a gap between two panels when the panel is narrow enough', () => {
+    const occupied = [at(0, 0, 4, 1), at(8, 0, 4, 1)]
+    expect(firstFreeSlot(occupied, { w: 4, h: 1 })).toEqual(at(4, 0, 4, 1))
+  })
+
+  it('skips a gap the panel does not fit and takes the next row', () => {
+    const occupied = [at(0, 0, 4, 1), at(8, 0, 4, 1)]
+    expect(firstFreeSlot(occupied, { w: 5, h: 1 })).toEqual(at(0, 1, 5, 1))
+  })
+
+  it('requires the whole height to be free, not just the top row', () => {
+    // Column 0 is free on row 0 but taken on row 1, so a 2-tall panel has to
+    // start at column 1 — a scan that only checked the first row would put it
+    // on top of the existing panel.
+    const occupied = [at(0, 1, 1, 1)]
+    expect(firstFreeSlot(occupied, { w: 1, h: 2 })).toEqual(at(1, 0, 1, 2))
+  })
+
+  it('scans row by row rather than column by column', () => {
+    // With column 0 blocked on row 0 only, reading order puts the next panel
+    // at (1,0) — not at (0,1) further down the same column.
+    expect(firstFreeSlot([at(0, 0, 1, 1)], { w: 1, h: 1 })).toEqual(at(1, 0, 1, 1))
+  })
+
+  it('has nowhere to put a panel wider than the grid', () => {
+    expect(firstFreeSlot([], { w: GRID_COLUMNS + 1, h: 1 })).toBeNull()
+  })
+
+  it('has nowhere to put a panel taller than the row cap', () => {
+    expect(firstFreeSlot([], { w: 1, h: GRID_MAX_ROWS + 1 })).toBeNull()
+  })
+
+  it('has nowhere to put a panel on a full grid', () => {
+    expect(firstFreeSlot([at(0, 0, GRID_COLUMNS, GRID_MAX_ROWS)], { w: 1, h: 1 })).toBeNull()
+  })
+
+  it('finds the single remaining cell of an almost-full grid', () => {
+    const occupied = [
+      at(0, 0, GRID_COLUMNS, GRID_MAX_ROWS - 1),
+      at(0, GRID_MAX_ROWS - 1, GRID_COLUMNS - 1, 1),
+    ]
+    expect(firstFreeSlot(occupied, { w: 1, h: 1 })).toEqual(
+      at(GRID_COLUMNS - 1, GRID_MAX_ROWS - 1, 1, 1),
+    )
+  })
+})
+
+describe('isOutOfRoom', () => {
+  it('is false while a slot remains', () => {
+    expect(isOutOfRoom([], { w: 1, h: 1 })).toBe(false)
+  })
+
+  it('is true once the grid is full', () => {
+    expect(isOutOfRoom([at(0, 0, GRID_COLUMNS, GRID_MAX_ROWS)], { w: 1, h: 1 })).toBe(true)
+  })
+
+  it('is true for a panel that fits nowhere even on an empty grid', () => {
+    expect(isOutOfRoom([], { w: GRID_COLUMNS, h: GRID_MAX_ROWS + 1 })).toBe(true)
+  })
+
+  it('answers per requested size on the same page', () => {
+    // Half a row left: a single cell fits, a full-width panel does not. The
+    // predicate has to be asked about the panel being added, not the page.
+    const occupied = [
+      at(0, 0, GRID_COLUMNS, GRID_MAX_ROWS - 1),
+      at(0, GRID_MAX_ROWS - 1, 6, 1),
+    ]
+    expect(isOutOfRoom(occupied, { w: 1, h: 1 })).toBe(false)
+    expect(isOutOfRoom(occupied, { w: GRID_COLUMNS, h: 1 })).toBe(true)
+  })
+})

--- a/frontend/src/lib/dashboard/grid.ts
+++ b/frontend/src/lib/dashboard/grid.ts
@@ -1,0 +1,150 @@
+/**
+ * The dashboard grid's coordinate system: where a panel sits, and whether one
+ * more will fit.
+ *
+ * The grid is a fixed number of columns by a hard-capped number of rows. The
+ * cap is what makes "out of room" a real state the operator can be told about
+ * rather than a page that silently grows a scrollbar — the dashboard's defining
+ * property is that a desktop layout fits the viewport. Row *height* is a
+ * rendering concern derived from the measured container; nothing here knows
+ * about pixels.
+ *
+ * Everything in this module is pure, so the interesting cases (a sparse
+ * geometry, a full page) are covered without a browser.
+ *
+ * These constants are the **single source** for the grid's dimensions. Whoever
+ * mounts the grid library must configure its own column count and row cap from
+ * them, rather than restating the numbers: the library answers the same
+ * "will it fit" question during a drag, and two independent answers would
+ * disagree the moment either changed.
+ */
+
+import { isRecord } from './json'
+
+/** A panel's placement in grid cells. Origin is the top-left cell. */
+export interface PanelGeometry {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/** Just the size half of a geometry — what a not-yet-placed panel knows. */
+export type PanelSize = Pick<PanelGeometry, 'w' | 'h'>
+
+/**
+ * Columns in the authored desktop layout. Twelve divides by 2, 3, 4 and 6, so
+ * the common row arrangements land on whole columns.
+ *
+ * Narrow viewports collapse to fewer columns at render time; that is derived,
+ * never persisted, so the authored layout survives a resize round trip.
+ */
+export const GRID_COLUMNS = 12
+
+/**
+ * Hard cap on rows. Doubles as the panel-count limit — there is no separate
+ * one, because a page that cannot fit another cell cannot fit another panel.
+ */
+export const GRID_MAX_ROWS = 8
+
+/**
+ * Reads a persisted geometry into one guaranteed to be inside the grid.
+ *
+ * This is the single place sparse and hostile input is dealt with, and the
+ * contract is **normalize on read**: gridstack's `save()` omits values equal to
+ * its own defaults, so a panel at width and height of one is persisted with
+ * neither key. Missing width or height therefore means one. Writing is
+ * deliberately dense as well (see `serializeDashboardDocument`), but reading is
+ * the side that has to be tolerant, because the sparse objects also arrive
+ * straight from the library at runtime.
+ *
+ * Out-of-bounds values are clamped rather than rejected: a clamped panel is
+ * still visible and still recognizable, whereas discarding it — or the page
+ * holding it — loses work the operator did. A clamp can put two panels on the
+ * same cells; the grid reflows them on mount, which is visible and recoverable.
+ */
+export function readGeometry(raw: unknown): PanelGeometry {
+  const source = isRecord(raw) ? raw : {}
+
+  const w = clamp(cell(source.w, 1), 1, GRID_COLUMNS)
+  const h = clamp(cell(source.h, 1), 1, GRID_MAX_ROWS)
+
+  return {
+    x: clamp(cell(source.x, 0), 0, GRID_COLUMNS - w),
+    y: clamp(cell(source.y, 0), 0, GRID_MAX_ROWS - h),
+    w,
+    h,
+  }
+}
+
+/**
+ * The first cell, in reading order, where a panel of `size` fits without
+ * overlapping any of `occupied`. Null when it fits nowhere.
+ *
+ * Reading order — left to right, then top to bottom — is what makes an added
+ * panel appear where the operator's eye already is, so click-to-add needs no
+ * aiming. The whole rectangle must be free, not just its first row.
+ */
+export function firstFreeSlot(
+  occupied: readonly PanelGeometry[],
+  size: PanelSize,
+): PanelGeometry | null {
+  const { w, h } = size
+  if (w < 1 || h < 1 || w > GRID_COLUMNS || h > GRID_MAX_ROWS) return null
+
+  const taken = occupancy(occupied)
+
+  for (let y = 0; y <= GRID_MAX_ROWS - h; y++) {
+    for (let x = 0; x <= GRID_COLUMNS - w; x++) {
+      if (isFree(taken, x, y, w, h)) return { x, y, w, h }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Whether a panel of `size` has nowhere to go on a page holding `occupied`.
+ *
+ * The question is asked per panel rather than per page: a page with half a row
+ * left has room for a small panel and none for a wide one. A drop that would be
+ * out of room is rejected visibly, so a failed drag reads as "the page is full"
+ * instead of as a bug.
+ */
+export function isOutOfRoom(occupied: readonly PanelGeometry[], size: PanelSize): boolean {
+  return firstFreeSlot(occupied, size) === null
+}
+
+/** Row-major occupancy bitmap of the whole grid. */
+function occupancy(panels: readonly PanelGeometry[]): boolean[] {
+  const taken = new Array<boolean>(GRID_COLUMNS * GRID_MAX_ROWS).fill(false)
+
+  for (const panel of panels) {
+    const { x, y, w, h } = readGeometry(panel)
+    for (let row = y; row < y + h; row++) {
+      for (let col = x; col < x + w; col++) {
+        taken[row * GRID_COLUMNS + col] = true
+      }
+    }
+  }
+
+  return taken
+}
+
+function isFree(taken: readonly boolean[], x: number, y: number, w: number, h: number): boolean {
+  for (let row = y; row < y + h; row++) {
+    for (let col = x; col < x + w; col++) {
+      if (taken[row * GRID_COLUMNS + col]) return false
+    }
+  }
+  return true
+}
+
+/** A whole number of cells, or `fallback` when the value is not a usable number. */
+function cell(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : fallback
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.min(Math.max(value, lo), hi)
+}

--- a/frontend/src/lib/dashboard/json.ts
+++ b/frontend/src/lib/dashboard/json.ts
@@ -1,0 +1,19 @@
+/**
+ * The one narrowing every reader in this module starts from.
+ *
+ * A stored document is arbitrary JSON until proven otherwise — it may have been
+ * written by a newer build, hand-edited on disk, or truncated. Each reader here
+ * begins by asking whether it has an object to read at all, so that question has
+ * one answer rather than five subtly different ones.
+ */
+
+/**
+ * Whether the value is a plain JSON object, so its keys can be read.
+ *
+ * Arrays are excluded on purpose: they are objects to `typeof`, but nothing in
+ * the schema is ever legitimately an array where a record is expected, and
+ * treating one as a record would read `length` as a field.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/frontend/src/lib/dashboard/load.test.ts
+++ b/frontend/src/lib/dashboard/load.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import { loadDashboardConfiguration } from './load'
+import { defaultDashboardDocument } from './preset'
+import { DASHBOARD_SCHEMA_VERSION, serializeDashboardDocument } from './schema'
+import type { MigrationPath } from './migrations'
+
+/** A document the current build reads, as it would come back from the server. */
+function storedDocument(): string {
+  return serializeDashboardDocument({
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [
+      {
+        id: 'mine',
+        name: 'Mine',
+        panels: [
+          {
+            id: 'a',
+            type: 'gpu-power',
+            title: 'Trainer',
+            geometry: { x: 0, y: 0, w: 6, h: 4 },
+            binding: { kind: 'gpu', index: 1 },
+            window: '15m',
+          },
+        ],
+      },
+    ],
+  })
+}
+
+describe('loadDashboardConfiguration with nothing stored', () => {
+  it('renders the preset with no banner', () => {
+    // Nothing is configured out of the box, and a fresh install is not a fault.
+    const loaded = loadDashboardConfiguration(null)
+
+    expect(loaded.document).toEqual(defaultDashboardDocument())
+    expect(loaded.isDefault).toBe(true)
+    expect(loaded.fallback).toBeNull()
+    expect(loaded.migrated).toBe(false)
+  })
+
+  it('treats an absent body the same way', () => {
+    expect(loadDashboardConfiguration(undefined).fallback).toBeNull()
+  })
+})
+
+describe('loadDashboardConfiguration with a readable document', () => {
+  it('renders what the operator saved', () => {
+    const loaded = loadDashboardConfiguration(storedDocument())
+
+    expect(loaded.isDefault).toBe(false)
+    expect(loaded.fallback).toBeNull()
+    expect(loaded.migrated).toBe(false)
+    expect(loaded.document.pages[0].name).toBe('Mine')
+    expect(loaded.document.pages[0].panels[0].title).toBe('Trainer')
+    expect(loaded.document.pages[0].panels[0].binding).toEqual({ kind: 'gpu', index: 1 })
+    expect(loaded.document.pages[0].panels[0].window).toBe('15m')
+  })
+})
+
+describe('loadDashboardConfiguration with an unreadable document', () => {
+  it('renders the preset and reports why, rather than a blank screen', () => {
+    const loaded = loadDashboardConfiguration('{ "pages": [')
+
+    expect(loaded.document).toEqual(defaultDashboardDocument())
+    expect(loaded.isDefault).toBe(true)
+    expect(loaded.fallback).toEqual({ kind: 'unreadable' })
+  })
+
+  it('reports valid JSON that is not a dashboard document', () => {
+    expect(loadDashboardConfiguration('[]').fallback).toEqual({ kind: 'unreadable' })
+    expect(loadDashboardConfiguration('"overview"').fallback).toEqual({ kind: 'unreadable' })
+    expect(loadDashboardConfiguration('{"pages":[]}').fallback).toEqual({ kind: 'unreadable' })
+  })
+
+  it('renders the preset without a banner for a document with no pages', () => {
+    // Nothing to render is the position a fresh install is in, and nothing
+    // failed — so no banner claims the configuration could not be read.
+    const loaded = loadDashboardConfiguration(
+      JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION, pages: [] }),
+    )
+
+    expect(loaded.document).toEqual(defaultDashboardDocument())
+    expect(loaded.isDefault).toBe(true)
+    expect(loaded.fallback).toBeNull()
+  })
+
+  it('reports a document with no version at all', () => {
+    // Without the version field there is no way to tell which build wrote it,
+    // which is exactly why the field ships from the first release.
+    expect(loadDashboardConfiguration('{"pages":[{"id":"p","panels":[]}]}').fallback).toEqual({
+      kind: 'unreadable',
+    })
+    expect(loadDashboardConfiguration('{"version":"1","pages":[]}').fallback).toEqual({
+      kind: 'unreadable',
+    })
+  })
+
+  it('reports a stored document that says nothing', () => {
+    // A file that exists but is empty means a write went wrong. Writes are
+    // atomic, so this should not happen — and if it does the operator is told.
+    expect(loadDashboardConfiguration('').fallback).toEqual({ kind: 'unreadable' })
+    expect(loadDashboardConfiguration('   \n').fallback).toEqual({ kind: 'unreadable' })
+  })
+
+  it('reports a document whose pages are unreadable', () => {
+    const loaded = loadDashboardConfiguration(
+      JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION, pages: 'overview' }),
+    )
+
+    expect(loaded.fallback).toEqual({ kind: 'unreadable' })
+    expect(loaded.isDefault).toBe(true)
+  })
+})
+
+describe('loadDashboardConfiguration with a document from another version', () => {
+  it('falls back with the versions named when the document is newer', () => {
+    // Rolling the dashboard back has to be recoverable, and there is no
+    // down-migration, so the preset renders and the banner explains it.
+    const loaded = loadDashboardConfiguration(
+      JSON.stringify({
+        version: DASHBOARD_SCHEMA_VERSION + 1,
+        pages: [{ id: 'p', name: 'P', panels: [] }],
+      }),
+    )
+
+    expect(loaded.document).toEqual(defaultDashboardDocument())
+    expect(loaded.isDefault).toBe(true)
+    expect(loaded.fallback).toEqual({
+      kind: 'newer-version',
+      documentVersion: DASHBOARD_SCHEMA_VERSION + 1,
+      supportedVersion: DASHBOARD_SCHEMA_VERSION,
+    })
+  })
+
+  it('falls back when the document is too old to bring forward', () => {
+    const loaded = loadDashboardConfiguration(
+      JSON.stringify({ version: 0, pages: [{ id: 'p', name: 'P', panels: [] }] }),
+    )
+
+    expect(loaded.isDefault).toBe(true)
+    expect(loaded.fallback).toEqual({
+      kind: 'unsupported-version',
+      documentVersion: 0,
+      supportedVersion: DASHBOARD_SCHEMA_VERSION,
+    })
+  })
+
+  it('never throws, whatever it is handed', () => {
+    const inputs = ['', '{', 'null', 'true', '[1,2]', '{"version":-1}', '{"version":1e309}']
+    for (const input of inputs) {
+      expect(() => loadDashboardConfiguration(input), input).not.toThrow()
+      expect(loadDashboardConfiguration(input).document.pages.length, input).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('loadDashboardConfiguration with a document that needed migrating', () => {
+  /** A stand-in path from an imagined earlier version up to the current one. */
+  const path: MigrationPath = {
+    migrations: [
+      {
+        from: DASHBOARD_SCHEMA_VERSION - 1,
+        migrate: (document) => ({
+          ...document,
+          pages: [{ id: 'brought-forward', name: 'Brought forward', panels: [] }],
+        }),
+      },
+    ],
+    target: DASHBOARD_SCHEMA_VERSION,
+  }
+
+  const stored = JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION - 1, legacyPages: [] })
+
+  it('renders the migrated document', () => {
+    const loaded = loadDashboardConfiguration(stored, path)
+
+    expect(loaded.isDefault).toBe(false)
+    expect(loaded.fallback).toBeNull()
+    expect(loaded.document.pages[0].id).toBe('brought-forward')
+  })
+
+  it('says it migrated, so the caller knows not to write it back', () => {
+    // The configuration is shared by everyone on the instance. Writing back on
+    // load would let one upgraded viewer lock out colleagues still on the
+    // previous build merely by opening the page.
+    expect(loadDashboardConfiguration(stored, path).migrated).toBe(true)
+  })
+})

--- a/frontend/src/lib/dashboard/load.ts
+++ b/frontend/src/lib/dashboard/load.ts
@@ -1,0 +1,130 @@
+/**
+ * Turning whatever the server had into a document the dashboard can render.
+ *
+ * This is the only entry point that boot needs, and it **never throws and never
+ * returns nothing**. Every failure resolves to the default preset plus a reason
+ * the UI renders as a banner, because a working dashboard with an explanation
+ * beats a blank screen with a console error — and because the operator has to
+ * know their layout is not the one being shown.
+ *
+ * Two things this does not do, both deliberately:
+ *
+ * - It does not write. A document that needed migrating is migrated in memory
+ *   and reported as such; persisting it waits for a save the operator asked for.
+ * - It does not consider browser-local storage, here or as a fallback. An
+ *   invisible second source of truth for a configuration that is shared by
+ *   everyone on the instance is worse than a visible failure.
+ */
+
+import { isRecord } from './json'
+import { runMigrations, type MigrationPath } from './migrations'
+import { defaultDashboardDocument } from './preset'
+import { DASHBOARD_SCHEMA_VERSION, parseDashboardDocument, type DashboardDocument } from './schema'
+
+/** Why the stored document is not the one being rendered. */
+export type ConfigurationFallbackReason =
+  /**
+   * Written by a newer build. There is no down-migration, so this is what makes
+   * rolling the dashboard back recoverable instead of fatal.
+   */
+  | { kind: 'newer-version'; documentVersion: number; supportedVersion: number }
+  /** Too old to bring forward — no migration path reaches this build. */
+  | { kind: 'unsupported-version'; documentVersion: number; supportedVersion: number }
+  /** Not readable as a dashboard document at all. */
+  | { kind: 'unreadable' }
+
+/** The configuration to render, and what the operator needs telling about it. */
+export interface LoadedConfiguration {
+  /** Always renderable: the stored document, or the default preset. */
+  document: DashboardDocument
+  /** True when `document` is the preset rather than what was stored. */
+  isDefault: boolean
+  /**
+   * Null when the stored document loaded, and when there was nothing stored —
+   * a fresh install is not a fault and gets no banner.
+   */
+  fallback: ConfigurationFallbackReason | null
+  /**
+   * True when migrations ran. The caller must not persist the result: writing
+   * back on load would let one upgraded viewer lock out everyone still on the
+   * previous build.
+   */
+  migrated: boolean
+}
+
+/**
+ * Reads the stored document.
+ *
+ * `stored` is the raw response body, or null/undefined when the server reported
+ * that nothing has been stored. `path` is injectable so the migrating branch is
+ * covered with a stand-in rather than waiting for the first real migration.
+ */
+export function loadDashboardConfiguration(
+  stored: string | null | undefined,
+  path?: MigrationPath,
+): LoadedConfiguration {
+  if (stored === null || stored === undefined) return fresh()
+
+  const raw = tryParseJson(stored)
+  if (raw === FAILED) return fallback({ kind: 'unreadable' })
+
+  const version = documentVersion(raw)
+  if (version === null) return fallback({ kind: 'unreadable' })
+
+  if (version > DASHBOARD_SCHEMA_VERSION) {
+    return fallback({
+      kind: 'newer-version',
+      documentVersion: version,
+      supportedVersion: DASHBOARD_SCHEMA_VERSION,
+    })
+  }
+
+  const outcome = runMigrations(raw, version, path)
+  if (outcome.status === 'unmigratable') {
+    return fallback({
+      kind: 'unsupported-version',
+      documentVersion: version,
+      supportedVersion: DASHBOARD_SCHEMA_VERSION,
+    })
+  }
+
+  const document = parseDashboardDocument(outcome.document)
+  if (!document) return fallback({ kind: 'unreadable' })
+
+  // A document with no pages has nothing to render, which is the same position a
+  // fresh install is in — so it gets the preset, and no banner, because nothing
+  // failed and there is no layout to have lost.
+  if (document.pages.length === 0) return fresh()
+
+  return { document, isDefault: false, fallback: null, migrated: outcome.status === 'migrated' }
+}
+
+/** Nothing stored: the preset, and nothing to tell the operator. */
+function fresh(): LoadedConfiguration {
+  return { document: defaultDashboardDocument(), isDefault: true, fallback: null, migrated: false }
+}
+
+function fallback(reason: ConfigurationFallbackReason): LoadedConfiguration {
+  return { document: defaultDashboardDocument(), isDefault: true, fallback: reason, migrated: false }
+}
+
+/** Sentinel for JSON that would not parse, so `null` stays a legitimate value. */
+const FAILED = Symbol('failed')
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return FAILED
+  }
+}
+
+/**
+ * The version the document declares, or null when it declares none. A document
+ * without it cannot be placed at all — which is why the field ships from the
+ * first release rather than being inferred later from the document's shape.
+ */
+function documentVersion(raw: unknown): number | null {
+  if (!isRecord(raw)) return null
+  return typeof raw.version === 'number' && Number.isInteger(raw.version) ? raw.version : null
+}

--- a/frontend/src/lib/dashboard/migrations.test.ts
+++ b/frontend/src/lib/dashboard/migrations.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DASHBOARD_MIGRATION_PATH,
+  runMigrations,
+  type DashboardMigration,
+  type MigrationPath,
+} from './migrations'
+import { DASHBOARD_SCHEMA_VERSION, parseDashboardDocument } from './schema'
+
+/**
+ * One real document in a superseded format, and what it has to become.
+ *
+ * Every registered migration needs an entry here — the coverage spec below
+ * fails otherwise. Adding the first migration means appending a case, not
+ * building a harness: paste the document as it was actually written by the
+ * older build, and assert the panels the operator should still see.
+ */
+interface MigrationFixture {
+  name: string
+  /** The document exactly as the older build persisted it. */
+  stored: unknown
+  /** The version `stored` declares — the same number as the migration's `from`. */
+  from: number
+  /** What the migrated document must contain, checked after a full parse. */
+  expect: (document: NonNullable<ReturnType<typeof parseDashboardDocument>>) => void
+}
+
+const MIGRATION_FIXTURES: MigrationFixture[] = []
+
+/** A stand-in migration, so the runner's chaining is covered before there is a real one. */
+function stub(from: number, mark: string): DashboardMigration {
+  return {
+    from,
+    migrate: (document) => ({ ...document, marks: [...asMarks(document.marks), mark] }),
+  }
+}
+
+function asMarks(value: unknown): string[] {
+  return Array.isArray(value) ? (value as string[]) : []
+}
+
+function path(migrations: DashboardMigration[], target: number): MigrationPath {
+  return { migrations, target }
+}
+
+describe('runMigrations against the real migration path', () => {
+  it('runs nothing against a document already at the current version', () => {
+    const stored = { version: DASHBOARD_SCHEMA_VERSION, pages: [] }
+    const outcome = runMigrations(stored, DASHBOARD_SCHEMA_VERSION)
+
+    expect(outcome).toEqual({ status: 'current', document: stored })
+  })
+
+  it('has a fixture for every registered migration', () => {
+    // Kept in step deliberately: a migration without a real document to prove
+    // it against is a migration nobody has run.
+    expect(MIGRATION_FIXTURES.map((fixture) => fixture.from).sort()).toEqual(
+      DASHBOARD_MIGRATION_PATH.migrations.map((migration) => migration.from).sort(),
+    )
+  })
+
+  it('targets the version this build reads', () => {
+    expect(DASHBOARD_MIGRATION_PATH.target).toBe(DASHBOARD_SCHEMA_VERSION)
+  })
+
+  it('leaves no gap in the chain of registered migrations', () => {
+    const froms = DASHBOARD_MIGRATION_PATH.migrations.map((migration) => migration.from)
+    expect(froms).toEqual([...froms].sort((a, b) => a - b))
+    froms.forEach((from, position) => {
+      if (position > 0) expect(from).toBe(froms[position - 1] + 1)
+    })
+  })
+
+  // Empty until the first migration exists; each fixture then becomes a spec.
+  for (const fixture of MIGRATION_FIXTURES) {
+    it(`migrates ${fixture.name} into a document that still parses`, () => {
+      const outcome = runMigrations(fixture.stored, fixture.from)
+      expect(outcome.status).toBe('migrated')
+
+      const document = parseDashboardDocument(
+        outcome.status === 'migrated' ? outcome.document : null,
+      )
+      expect(document).not.toBeNull()
+      fixture.expect(document!)
+    })
+  }
+})
+
+describe('runMigrations chaining', () => {
+  it('applies every step in order and stamps the version it reached', () => {
+    const outcome = runMigrations({ version: 1 }, 1, path([stub(1, 'a'), stub(2, 'b')], 3))
+
+    expect(outcome).toEqual({
+      status: 'migrated',
+      ran: 2,
+      document: { version: 3, marks: ['a', 'b'] },
+    })
+  })
+
+  it("starts from the document's own version rather than the beginning", () => {
+    const outcome = runMigrations({ version: 2 }, 2, path([stub(1, 'a'), stub(2, 'b')], 3))
+
+    expect(outcome).toEqual({
+      status: 'migrated',
+      ran: 1,
+      document: { version: 3, marks: ['b'] },
+    })
+  })
+
+  it('leaves the stored document untouched', () => {
+    // A read path that mutated its input would be a step towards writing back
+    // on load, which is exactly what must not happen to a shared document.
+    const stored = { version: 1, marks: ['original'] }
+    runMigrations(stored, 1, path([stub(1, 'a')], 2))
+
+    expect(stored).toEqual({ version: 1, marks: ['original'] })
+  })
+
+  it('refuses a version with no migration to run', () => {
+    // A document older than the oldest migration cannot be brought forward.
+    expect(runMigrations({ version: 0 }, 0, path([stub(1, 'a')], 2))).toEqual({
+      status: 'unmigratable',
+      from: 0,
+    })
+  })
+
+  it('refuses a version from the future rather than looping', () => {
+    expect(runMigrations({ version: 9 }, 9, path([stub(1, 'a')], 2))).toEqual({
+      status: 'unmigratable',
+      from: 9,
+    })
+  })
+
+  it('refuses a chain that stops short of the target', () => {
+    // Registering 1→2 while the build reads version 3 is a programming error,
+    // and silently handing back a half-migrated document would hide it.
+    expect(runMigrations({ version: 1 }, 1, path([stub(1, 'a')], 3))).toEqual({
+      status: 'unmigratable',
+      from: 1,
+    })
+  })
+})

--- a/frontend/src/lib/dashboard/migrations.ts
+++ b/frontend/src/lib/dashboard/migrations.ts
@@ -1,0 +1,100 @@
+/**
+ * Bringing an older document forward to the version this build reads.
+ *
+ * There are no migrations yet, and there will not be one until a change is not
+ * additive — this is the lazy half of the versioning decision. The eager half is
+ * that the version field ships from day one, because it cannot be added later
+ * without sniffing at a document's shape and guessing what wrote it.
+ *
+ * Two rules hold whatever the migrations end up doing:
+ *
+ * - **Migrations run in memory only.** Nothing here writes, and the loader does
+ *   not write back either. The configuration is shared by everyone who opens the
+ *   instance, so a viewer who merely upgraded and opened the page must not
+ *   rewrite the document and lock out colleagues still on the previous build.
+ *   A migrated document is persisted on the next save the operator asks for.
+ * - **No down-migration.** A document from a newer version is refused here and
+ *   falls back to the default preset with a banner, which is what makes rolling
+ *   the dashboard back a recoverable operation.
+ */
+
+import { DASHBOARD_SCHEMA_VERSION } from './schema'
+import { isRecord } from './json'
+
+/** One step forward, from `from` to `from + 1`. */
+export interface DashboardMigration {
+  /** The version this migration reads. */
+  from: number
+  /**
+   * Returns the document one version newer. Must not mutate its argument, and
+   * need not set `version` — the runner stamps that.
+   */
+  migrate: (document: Record<string, unknown>) => Record<string, unknown>
+}
+
+/** The migrations available, and the version they lead to. */
+export interface MigrationPath {
+  /** Ordered by `from`, with no gaps, ending one below `target`. */
+  migrations: readonly DashboardMigration[]
+  target: number
+}
+
+/**
+ * The real path: empty, targeting the current version.
+ *
+ * Adding a migration means appending it here, bumping
+ * `DASHBOARD_SCHEMA_VERSION`, and adding a fixture to `migrations.test.ts`.
+ */
+export const DASHBOARD_MIGRATION_PATH: MigrationPath = {
+  migrations: [],
+  target: DASHBOARD_SCHEMA_VERSION,
+}
+
+/** What happened when the document was brought forward. */
+export type MigrationOutcome =
+  /** Already at the target version; nothing ran and nothing changed. */
+  | { status: 'current'; document: unknown }
+  /**
+   * Brought forward in memory. `ran` is how many steps applied. The caller must
+   * treat this as read-only state and persist it only on a user-initiated save.
+   */
+  | { status: 'migrated'; document: unknown; ran: number }
+  /**
+   * There is no path from that version — older than the oldest migration, newer
+   * than this build, or a chain with a hole in it. The caller falls back to the
+   * default preset and says so.
+   */
+  | { status: 'unmigratable'; from: number }
+
+/**
+ * Brings `raw` forward from `from` to the path's target.
+ *
+ * `path` is injectable so the chaining is covered by stand-in migrations rather
+ * than waiting for the first real one — the alternative is a runner whose only
+ * tested behaviour is doing nothing.
+ */
+export function runMigrations(
+  raw: unknown,
+  from: number,
+  path: MigrationPath = DASHBOARD_MIGRATION_PATH,
+): MigrationOutcome {
+  if (from === path.target) return { status: 'current', document: raw }
+  if (from > path.target || !isRecord(raw)) return { status: 'unmigratable', from }
+
+  let document = raw
+  let version = from
+  let ran = 0
+
+  while (version < path.target) {
+    const migration = path.migrations.find((candidate) => candidate.from === version)
+    // A hole in the chain is a programming error. Handing back a half-migrated
+    // document would hide it behind a fallback that looks like data corruption.
+    if (!migration) return { status: 'unmigratable', from }
+
+    version += 1
+    document = { ...migration.migrate(document), version }
+    ran += 1
+  }
+
+  return { status: 'migrated', document, ran }
+}

--- a/frontend/src/lib/dashboard/panels.test.ts
+++ b/frontend/src/lib/dashboard/panels.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PANEL_TYPES,
+  PANEL_TYPE_IDS,
+  defaultPanelTitle,
+  isKnownPanelType,
+  panelBindingKind,
+} from './panels'
+
+describe('the panel type vocabulary', () => {
+  it('is the exact set of ids that may appear in a saved document', () => {
+    // These strings are persisted, so renaming one breaks every saved
+    // dashboard that used it. This spec exists to make that a deliberate
+    // decision with a migration rather than a silent rename.
+    expect(PANEL_TYPE_IDS).toEqual([
+      'gpu-utilization',
+      'gpu-temperature',
+      'gpu-power',
+      'gpu-clock',
+      'gpu-memory',
+      'gpu-fan',
+      'gpu-events',
+      'cpu-utilization',
+      'cpu-cores',
+      'memory',
+      'disk-io',
+      'network-io',
+      'engines-overview',
+      'engine-status',
+      'engine-prefill-throughput',
+      'engine-decode-throughput',
+      'engine-latency',
+      'engine-slo-goodput',
+      'engine-requests',
+      'engine-cache',
+      'engine-spec-decode',
+      'inference-timeline',
+      'logs',
+    ])
+  })
+
+  it('gives every panel type a non-empty default title', () => {
+    for (const id of PANEL_TYPE_IDS) {
+      expect(PANEL_TYPES[id].title, id).toBeTruthy()
+    }
+  })
+})
+
+describe('isKnownPanelType', () => {
+  it('accepts every declared type', () => {
+    for (const id of PANEL_TYPE_IDS) {
+      expect(isKnownPanelType(id), id).toBe(true)
+    }
+  })
+
+  it('rejects a type this build does not implement', () => {
+    expect(isKnownPanelType('gpu-voltage')).toBe(false)
+  })
+
+  it('rejects a type that only looks like an object key', () => {
+    expect(isKnownPanelType('constructor')).toBe(false)
+    expect(isKnownPanelType('toString')).toBe(false)
+  })
+})
+
+describe('panelBindingKind', () => {
+  it('reports the per-GPU panels as binding to a GPU', () => {
+    expect(panelBindingKind('gpu-utilization')).toBe('gpu')
+    expect(panelBindingKind('gpu-events')).toBe('gpu')
+  })
+
+  it('reports the per-engine panels as binding to an engine', () => {
+    expect(panelBindingKind('engine-latency')).toBe('engine')
+    // The log socket addresses an engine by endpoint, so a log panel is bound
+    // like any other engine panel rather than being a special case.
+    expect(panelBindingKind('logs')).toBe('engine')
+  })
+
+  it('reports host-wide panels as binding to nothing', () => {
+    expect(panelBindingKind('memory')).toBe('none')
+    expect(panelBindingKind('disk-io')).toBe('none')
+    // The overview covers every engine at once, so there is nothing to pin.
+    expect(panelBindingKind('engines-overview')).toBe('none')
+  })
+
+  it('reports an unimplemented type as binding to nothing', () => {
+    // Nothing can be bound for a panel this build cannot render at all; it
+    // shows an unsupported-panel placeholder instead.
+    expect(panelBindingKind('gpu-voltage')).toBe('none')
+  })
+})
+
+describe('defaultPanelTitle', () => {
+  it('names a known panel in the operator-facing wording', () => {
+    expect(defaultPanelTitle('gpu-utilization')).toBe('GPU Utilization')
+  })
+
+  it('falls back to the raw type for an unimplemented panel', () => {
+    // The placeholder can then say which panel type it could not render,
+    // which is what tells an operator they rolled the dashboard back.
+    expect(defaultPanelTitle('gpu-voltage')).toBe('gpu-voltage')
+  })
+})

--- a/frontend/src/lib/dashboard/panels.ts
+++ b/frontend/src/lib/dashboard/panels.ts
@@ -1,0 +1,105 @@
+/**
+ * Every panel the dashboard can put on a page, and what each one binds to.
+ *
+ * The granularity is deliberate: one panel per metric rather than a handful of
+ * fixed composite cards, so an operator watching a training run can give GPU
+ * temperature and power the whole screen and drop the network and disk panels
+ * entirely. It is the reason the configuration is a versioned schema with a
+ * migration obligation — a closed panel set with opaque geometry was considered
+ * and rejected.
+ *
+ * **The ids are persisted.** They appear verbatim in saved documents, so
+ * renaming one is a breaking change that needs a migration, not a refactor.
+ * Adding one is additive and needs none.
+ */
+
+/** What a panel needs pointed at it before it can show anything. */
+export type PanelBindingKind =
+  /** One GPU, identified by its integer index. */
+  | 'gpu'
+  /** One inference engine, identified by its endpoint. */
+  | 'engine'
+  /** Nothing — the panel covers the whole host, or every engine at once. */
+  | 'none'
+
+/** What the dashboard knows about a panel type before any document is read. */
+export interface PanelTypeSpec {
+  /** What has to be bound for the panel to render data. */
+  binds: PanelBindingKind
+  /** Title shown when the operator has not renamed the panel. */
+  title: string
+}
+
+/**
+ * The vocabulary. Declaration order is palette order, so related panels sit
+ * together where an operator goes looking for them.
+ */
+export const PANEL_TYPES = {
+  // ── Per-GPU hardware ────────────────────────────────────────────────────
+  'gpu-utilization': { binds: 'gpu', title: 'GPU Utilization' },
+  'gpu-temperature': { binds: 'gpu', title: 'GPU Temp' },
+  'gpu-power': { binds: 'gpu', title: 'GPU Power' },
+  'gpu-clock': { binds: 'gpu', title: 'GPU Clock' },
+  'gpu-memory': { binds: 'gpu', title: 'GPU Memory' },
+  'gpu-fan': { binds: 'gpu', title: 'GPU Fan' },
+  'gpu-events': { binds: 'gpu', title: 'GPU Events' },
+
+  // ── Host-wide hardware ──────────────────────────────────────────────────
+  'cpu-utilization': { binds: 'none', title: 'CPU' },
+  'cpu-cores': { binds: 'none', title: 'CPU Cores' },
+  // Unified-memory hosts report one pool shared with the GPU, so this is a
+  // host-wide panel rather than a per-GPU one.
+  memory: { binds: 'none', title: 'Memory' },
+  'disk-io': { binds: 'none', title: 'Disk I/O' },
+  'network-io': { binds: 'none', title: 'Network' },
+
+  // ── Engines ─────────────────────────────────────────────────────────────
+  'engines-overview': { binds: 'none', title: 'All Engines' },
+  'engine-status': { binds: 'engine', title: 'Engine' },
+  'engine-prefill-throughput': { binds: 'engine', title: 'Prefill Throughput' },
+  'engine-decode-throughput': { binds: 'engine', title: 'Decode Throughput' },
+  'engine-latency': { binds: 'engine', title: 'Latency' },
+  'engine-slo-goodput': { binds: 'engine', title: 'SLO Goodput' },
+  'engine-requests': { binds: 'engine', title: 'Requests' },
+  'engine-cache': { binds: 'engine', title: 'Cache' },
+  'engine-spec-decode': { binds: 'engine', title: 'Speculative Decoding' },
+  'inference-timeline': { binds: 'engine', title: 'Inference Requests' },
+  // The log socket addresses an engine by endpoint, so logs bind like any
+  // other engine panel instead of being a fixed drawer.
+  logs: { binds: 'engine', title: 'Logs' },
+} as const satisfies Record<string, PanelTypeSpec>
+
+/** A panel type this build implements. */
+export type PanelType = keyof typeof PANEL_TYPES
+
+/** Every panel type, in palette order. */
+export const PANEL_TYPE_IDS = Object.keys(PANEL_TYPES) as PanelType[]
+
+/**
+ * Whether this build implements the panel type.
+ *
+ * A saved document can name a type this build has never heard of — a newer
+ * version added one, and the dashboard was rolled back. That panel keeps its
+ * slot and renders as an unsupported-panel placeholder, because dropping it
+ * would silently reflow an arrangement the operator authored.
+ */
+export function isKnownPanelType(type: string): type is PanelType {
+  return Object.hasOwn(PANEL_TYPES, type)
+}
+
+/**
+ * What the panel binds to. An unimplemented type binds to nothing: there is no
+ * data to point at something that cannot be rendered.
+ */
+export function panelBindingKind(type: string): PanelBindingKind {
+  return isKnownPanelType(type) ? PANEL_TYPES[type].binds : 'none'
+}
+
+/**
+ * The title to show when the operator has not renamed the panel. An
+ * unimplemented type falls back to its raw id so the placeholder can name what
+ * it could not render.
+ */
+export function defaultPanelTitle(type: string): string {
+  return isKnownPanelType(type) ? PANEL_TYPES[type].title : type
+}

--- a/frontend/src/lib/dashboard/preset.test.ts
+++ b/frontend/src/lib/dashboard/preset.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { defaultDashboardDocument } from './preset'
+import { GRID_COLUMNS, GRID_MAX_ROWS, isOutOfRoom } from './grid'
+import { isKnownPanelType } from './panels'
+import { DASHBOARD_SCHEMA_VERSION, parseDashboardDocument, serializeDashboardDocument } from './schema'
+
+describe('the default preset', () => {
+  it('parses as a document of the current version', () => {
+    const preset = defaultDashboardDocument()
+
+    expect(preset.version).toBe(DASHBOARD_SCHEMA_VERSION)
+    expect(parseDashboardDocument(JSON.parse(serializeDashboardDocument(preset)))).toEqual(preset)
+  })
+
+  it('has at least one page, each with a name and panels', () => {
+    const preset = defaultDashboardDocument()
+
+    expect(preset.pages.length).toBeGreaterThan(0)
+    for (const page of preset.pages) {
+      expect(page.id).toBeTruthy()
+      expect(page.name).toBeTruthy()
+      expect(page.panels.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('contains no concrete bindings', () => {
+    // This is what makes one static document correct on a one-GPU laptop and on
+    // a four-GPU server: nothing in it names a GPU index or an endpoint, so
+    // there is nothing to be wrong about the host it lands on.
+    for (const page of defaultDashboardDocument().pages) {
+      for (const panel of page.panels) {
+        expect(panel.binding, panel.id).toEqual({ kind: 'follow' })
+      }
+    }
+  })
+
+  it('only uses panel types this build implements', () => {
+    for (const page of defaultDashboardDocument().pages) {
+      for (const panel of page.panels) {
+        expect(isKnownPanelType(panel.type), panel.type).toBe(true)
+      }
+    }
+  })
+
+  it('gives every panel on a page a distinct identifier', () => {
+    for (const page of defaultDashboardDocument().pages) {
+      const ids = page.panels.map((panel) => panel.id)
+      expect(new Set(ids).size, page.id).toBe(ids.length)
+    }
+  })
+
+  it('tiles each page exactly, with no overlap and no empty cells', () => {
+    // The dashboard's defining property is that the desktop layout fits the
+    // viewport. A preset that covers every cell exactly once both fills the
+    // screen and proves no two panels were placed on top of each other.
+    const cells = GRID_COLUMNS * GRID_MAX_ROWS
+
+    for (const page of defaultDashboardDocument().pages) {
+      const geometries = page.panels.map((panel) => panel.geometry)
+      const covered = geometries.reduce((sum, { w, h }) => sum + w * h, 0)
+
+      expect(covered, page.id).toBe(cells)
+      expect(isOutOfRoom(geometries, { w: 1, h: 1 }), page.id).toBe(true)
+    }
+  })
+
+  it('stays inside the grid', () => {
+    for (const page of defaultDashboardDocument().pages) {
+      for (const { x, y, w, h } of page.panels.map((panel) => panel.geometry)) {
+        expect(x + w, page.id).toBeLessThanOrEqual(GRID_COLUMNS)
+        expect(y + h, page.id).toBeLessThanOrEqual(GRID_MAX_ROWS)
+      }
+    }
+  })
+
+  it('hands out a fresh document each time', () => {
+    // Edit mode works on the preset when nothing is saved, so a shared instance
+    // would let one session's dragging leak into the next reset.
+    const first = defaultDashboardDocument()
+    first.pages[0].panels[0].title = 'Edited'
+    first.pages[0].panels[0].binding = { kind: 'gpu', index: 3 }
+
+    const second = defaultDashboardDocument()
+    expect(second.pages[0].panels[0].title).toBeUndefined()
+    expect(second.pages[0].panels[0].binding).toEqual({ kind: 'follow' })
+  })
+})

--- a/frontend/src/lib/dashboard/preset.ts
+++ b/frontend/src/lib/dashboard/preset.ts
@@ -1,0 +1,74 @@
+/**
+ * The dashboard an operator gets before configuring anything.
+ *
+ * It is a **static document**, not a layout generated from the host it lands on.
+ * Every panel binds with the `follow` sentinel, which resolves to the page-level
+ * selection, so the same document is right on a one-GPU laptop and on a four-GPU
+ * server — the alternative would be runtime generation that needs testing across
+ * every GPU and engine permutation.
+ *
+ * "Nothing configured" and "reset" are the same state: the document does not
+ * exist on the server, and this is what renders instead.
+ *
+ * The arrangement below is a working default, not the final design. The preset
+ * redesign — including the second page for logs and the cutover from the current
+ * fixed layout — is its own change (#86). What is settled here is the shape: one
+ * page that tiles the grid exactly, so the desktop layout fits the viewport.
+ */
+
+import { FOLLOW } from './bindings'
+import type { PanelGeometry } from './grid'
+import type { PanelType } from './panels'
+import {
+  DASHBOARD_SCHEMA_VERSION,
+  DEFAULT_TIME_WINDOW,
+  type DashboardDocument,
+  type DashboardPanel,
+} from './schema'
+
+/**
+ * A fresh copy of the default preset.
+ *
+ * Fresh on every call, deliberately: edit mode operates on this document when
+ * nothing is saved, so a shared instance would let one session's dragging leak
+ * into the next reset.
+ */
+export function defaultDashboardDocument(): DashboardDocument {
+  return {
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [
+      {
+        id: 'overview',
+        name: 'Overview',
+        panels: [
+          // Engines across the top — the numbers an operator watches while a
+          // model is serving. They degrade to a placeholder on a host running
+          // no engines, leaving the hardware rows below still useful.
+          panel('decode', 'engine-decode-throughput', { x: 0, y: 0, w: 4, h: 3 }),
+          panel('latency', 'engine-latency', { x: 4, y: 0, w: 4, h: 3 }),
+          panel('requests', 'engine-requests', { x: 8, y: 0, w: 4, h: 3 }),
+
+          // The GPU band, following the page's GPU selection.
+          panel('gpu-util', 'gpu-utilization', { x: 0, y: 3, w: 3, h: 3 }),
+          panel('gpu-temp', 'gpu-temperature', { x: 3, y: 3, w: 3, h: 3 }),
+          panel('gpu-power', 'gpu-power', { x: 6, y: 3, w: 3, h: 3 }),
+          panel('gpu-clock', 'gpu-clock', { x: 9, y: 3, w: 3, h: 3 }),
+
+          // Host-wide hardware, shorter because it is glanced at rather than read.
+          panel('cpu', 'cpu-utilization', { x: 0, y: 6, w: 3, h: 2 }),
+          panel('memory', 'memory', { x: 3, y: 6, w: 3, h: 2 }),
+          panel('disk', 'disk-io', { x: 6, y: 6, w: 3, h: 2 }),
+          panel('network', 'network-io', { x: 9, y: 6, w: 3, h: 2 }),
+        ],
+      },
+    ],
+  }
+}
+
+/**
+ * One preset panel. No title — the panel type's own default is used, so
+ * renaming a default later reaches operators who never customized it.
+ */
+function panel(id: string, type: PanelType, geometry: PanelGeometry): DashboardPanel {
+  return { id, type, geometry, binding: FOLLOW, window: DEFAULT_TIME_WINDOW }
+}

--- a/frontend/src/lib/dashboard/schema.test.ts
+++ b/frontend/src/lib/dashboard/schema.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DASHBOARD_SCHEMA_VERSION,
+  DEFAULT_TIME_WINDOW,
+  panelTitle,
+  parseDashboardDocument,
+  serializeDashboardDocument,
+} from './schema'
+import { FOLLOW } from './bindings'
+
+/** A minimal well-formed raw document, as it would sit on disk. */
+function rawDocument(overrides: Record<string, unknown> = {}) {
+  return {
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [
+      {
+        id: 'overview',
+        name: 'Overview',
+        panels: [
+          {
+            id: 'util',
+            type: 'gpu-utilization',
+            geometry: { x: 0, y: 0, w: 3, h: 2 },
+            binding: { kind: 'follow' },
+            window: '5m',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('parseDashboardDocument', () => {
+  it('yields typed pages and panels', () => {
+    const document = parseDashboardDocument(rawDocument())
+
+    expect(document).not.toBeNull()
+    expect(document!.version).toBe(DASHBOARD_SCHEMA_VERSION)
+    expect(document!.pages).toHaveLength(1)
+
+    const page = document!.pages[0]
+    expect(page.id).toBe('overview')
+    expect(page.name).toBe('Overview')
+    expect(page.panels).toEqual([
+      {
+        id: 'util',
+        type: 'gpu-utilization',
+        geometry: { x: 0, y: 0, w: 3, h: 2 },
+        binding: FOLLOW,
+        window: '5m',
+      },
+    ])
+  })
+
+  it('keeps a pinned binding and a per-panel window', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          {
+            id: 'compare',
+            name: 'Compare',
+            panels: [
+              {
+                id: 'a',
+                type: 'gpu-power',
+                geometry: { x: 0, y: 0, w: 6, h: 4 },
+                binding: { kind: 'gpu', index: 1 },
+                window: '15m',
+              },
+              {
+                id: 'b',
+                type: 'engine-latency',
+                geometry: { x: 6, y: 0, w: 6, h: 4 },
+                binding: { kind: 'engine', endpoint: 'http://localhost:8000' },
+                window: '10m',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(document!.pages[0].panels[0].binding).toEqual({ kind: 'gpu', index: 1 })
+    expect(document!.pages[0].panels[0].window).toBe('15m')
+    expect(document!.pages[0].panels[1].binding).toEqual({
+      kind: 'engine',
+      endpoint: 'http://localhost:8000',
+    })
+    expect(document!.pages[0].panels[1].window).toBe('10m')
+  })
+
+  it('keeps a panel type this build does not implement', () => {
+    // Dropping it would silently reflow an arrangement the operator authored.
+    // The panel keeps its slot; rendering it is the placeholder's problem.
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          {
+            id: 'p',
+            name: 'P',
+            panels: [{ id: 'x', type: 'gpu-voltage', geometry: { x: 0, y: 0, w: 1, h: 1 } }],
+          },
+        ],
+      }),
+    )
+
+    expect(document!.pages[0].panels[0].type).toBe('gpu-voltage')
+  })
+
+  it('resolves a sparse geometry to single cells', () => {
+    // The grid serializer omits values equal to its defaults, so a 1x1 panel
+    // arrives with no width or height at all.
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          {
+            id: 'p',
+            name: 'P',
+            panels: [{ id: 'x', type: 'memory', geometry: { x: 4, y: 3 } }],
+          },
+        ],
+      }),
+    )
+
+    expect(document!.pages[0].panels[0].geometry).toEqual({ x: 4, y: 3, w: 1, h: 1 })
+  })
+
+  it('defaults an absent binding and window', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          {
+            id: 'p',
+            name: 'P',
+            panels: [{ id: 'x', type: 'gpu-temperature', geometry: { x: 0, y: 0, w: 2, h: 2 } }],
+          },
+        ],
+      }),
+    )
+
+    expect(document!.pages[0].panels[0].binding).toEqual(FOLLOW)
+    expect(document!.pages[0].panels[0].window).toBe(DEFAULT_TIME_WINDOW)
+  })
+
+  it('falls back to the default window for one it does not recognize', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          {
+            id: 'p',
+            name: 'P',
+            panels: [
+              { id: 'x', type: 'memory', geometry: { x: 0, y: 0, w: 1, h: 1 }, window: '4h' },
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(document!.pages[0].panels[0].window).toBe(DEFAULT_TIME_WINDOW)
+  })
+
+  it('names a page and its panels when the identifiers are missing', () => {
+    // Identifiers key the grid and the page URLs, so one has to exist; deriving
+    // it from position keeps every panel the operator arranged.
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [{ panels: [{ type: 'memory' }, { type: 'disk-io' }] }],
+      }),
+    )
+
+    expect(document!.pages[0].id).toBe('page-1')
+    expect(document!.pages[0].name).toBe('Page 1')
+    expect(document!.pages[0].panels.map((panel) => panel.id)).toEqual(['panel-1', 'panel-2'])
+  })
+
+  it('makes duplicated identifiers unique instead of losing a panel', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          { id: 'dup', name: 'One', panels: [{ id: 'same', type: 'memory' }] },
+          { id: 'dup', name: 'Two', panels: [{ id: 'same', type: 'memory' }, { id: 'same', type: 'disk-io' }] },
+        ],
+      }),
+    )
+
+    expect(document!.pages.map((page) => page.id)).toEqual(['dup', 'dup-2'])
+    expect(document!.pages[1].panels.map((panel) => panel.id)).toEqual(['same', 'same-2'])
+  })
+
+  it('keeps an operator-authored panel title and drops a blank one', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          {
+            id: 'p',
+            name: 'P',
+            panels: [
+              { id: 'a', type: 'memory', title: '  Host RAM  ' },
+              { id: 'b', type: 'disk-io', title: '   ' },
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(document!.pages[0].panels[0].title).toBe('Host RAM')
+    expect(document!.pages[0].panels[1].title).toBeUndefined()
+  })
+
+  it('drops a panel that is not an object at all', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [{ id: 'p', name: 'P', panels: ['gpu-utilization', null, { id: 'a', type: 'memory' }] }],
+      }),
+    )
+
+    expect(document!.pages[0].panels.map((panel) => panel.type)).toEqual(['memory'])
+  })
+
+  it('accepts a page with no panels', () => {
+    // An operator can empty a page while rearranging; that is not corruption.
+    const document = parseDashboardDocument(
+      rawDocument({ pages: [{ id: 'p', name: 'P', panels: [] }] }),
+    )
+
+    expect(document!.pages[0].panels).toEqual([])
+  })
+
+  it('accepts a document with no pages', () => {
+    // Deleting the last page is something an operator can do, so it must not be
+    // reported as a configuration that cannot be read.
+    expect(parseDashboardDocument(rawDocument({ pages: [] }))?.pages).toEqual([])
+  })
+
+  it('rejects a document that is not a document', () => {
+    expect(parseDashboardDocument(null)).toBeNull()
+    expect(parseDashboardDocument(undefined)).toBeNull()
+    expect(parseDashboardDocument('{}')).toBeNull()
+    expect(parseDashboardDocument(42)).toBeNull()
+    expect(parseDashboardDocument([])).toBeNull()
+    expect(parseDashboardDocument({})).toBeNull()
+  })
+
+  it('rejects a document whose pages could not be read', () => {
+    // Distinct from an empty list: entries were stored here and none of them
+    // survived, which is corruption the operator has to be told about rather
+    // than a configuration they emptied themselves.
+    expect(parseDashboardDocument(rawDocument({ pages: 'overview' }))).toBeNull()
+    expect(parseDashboardDocument(rawDocument({ pages: [7, null] }))).toBeNull()
+  })
+
+  it('rejects a version other than the one this build reads', () => {
+    // Choosing a fallback is the loader's job, which knows whether the document
+    // is from the future or merely unmigrated.
+    expect(parseDashboardDocument(rawDocument({ version: DASHBOARD_SCHEMA_VERSION + 1 }))).toBeNull()
+    expect(parseDashboardDocument(rawDocument({ version: undefined }))).toBeNull()
+    expect(parseDashboardDocument(rawDocument({ version: '1' }))).toBeNull()
+  })
+})
+
+describe('serializeDashboardDocument', () => {
+  it('round-trips a document unchanged', () => {
+    const document = parseDashboardDocument(rawDocument())!
+    expect(parseDashboardDocument(JSON.parse(serializeDashboardDocument(document)))).toEqual(document)
+  })
+
+  it('round-trips a document that arrived sparse', () => {
+    const sparse = rawDocument({
+      pages: [{ id: 'p', name: 'P', panels: [{ id: 'x', type: 'memory', geometry: { x: 2, y: 1 } }] }],
+    })
+    const once = parseDashboardDocument(sparse)!
+    const twice = parseDashboardDocument(JSON.parse(serializeDashboardDocument(once)))!
+
+    expect(twice).toEqual(once)
+    expect(twice.pages[0].panels[0].geometry).toEqual({ x: 2, y: 1, w: 1, h: 1 })
+  })
+
+  it('writes geometry in full so what lands on disk is never sparse', () => {
+    // Reading tolerates sparse geometry because the grid library hands it to us
+    // that way; writing is dense so a future migration reading the file has
+    // every value in front of it rather than having to know the defaults.
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [{ id: 'p', name: 'P', panels: [{ id: 'x', type: 'memory', geometry: { x: 2, y: 1 } }] }],
+      }),
+    )!
+    const written = JSON.parse(serializeDashboardDocument(document))
+
+    expect(written.pages[0].panels[0].geometry).toEqual({ x: 2, y: 1, w: 1, h: 1 })
+  })
+
+  it('stamps the schema version it wrote', () => {
+    const document = parseDashboardDocument(rawDocument())!
+    expect(JSON.parse(serializeDashboardDocument(document)).version).toBe(DASHBOARD_SCHEMA_VERSION)
+  })
+
+  it('omits a title the operator never set', () => {
+    const document = parseDashboardDocument(rawDocument())!
+    expect(JSON.parse(serializeDashboardDocument(document)).pages[0].panels[0]).not.toHaveProperty(
+      'title',
+    )
+  })
+})
+
+describe('panelTitle', () => {
+  it('prefers the operator-authored title', () => {
+    expect(panelTitle({ type: 'gpu-utilization', title: 'Trainer GPU' })).toBe('Trainer GPU')
+  })
+
+  it('falls back to the panel type default', () => {
+    expect(panelTitle({ type: 'gpu-utilization' })).toBe('GPU Utilization')
+  })
+})

--- a/frontend/src/lib/dashboard/schema.ts
+++ b/frontend/src/lib/dashboard/schema.ts
@@ -1,0 +1,206 @@
+/**
+ * The shape of the dashboard configuration document, and how it is read and
+ * written.
+ *
+ * One instance-scoped document holds N pages; each page holds panels; each panel
+ * carries a type, an optional operator-authored title, its grid geometry, a
+ * binding and a time window. The server stores it as opaque bytes and knows none
+ * of this — all schema knowledge lives here, deliberately, so the project has
+ * one cross-language contract (the metrics wire format) rather than two.
+ *
+ * **The version ships from day one.** Migration functions are written lazily,
+ * because an additive change needs none, but the version field cannot be
+ * retrofitted later without sniffing at the document's shape and guessing.
+ *
+ * Reading is tolerant and never throws: a document that cannot be read at all
+ * returns null, and the caller falls back to the default preset with a reason
+ * the operator can see. Reading is also **lossy for unknown keys** — anything
+ * this build does not recognize is dropped on the next save. That is safe
+ * precisely because a build that adds a field bumps the version, and a
+ * newer-versioned document is never parsed here.
+ */
+
+import { readBinding, type PanelBinding } from './bindings'
+import { readGeometry, type PanelGeometry } from './grid'
+import { isRecord } from './json'
+import { defaultPanelTitle } from './panels'
+import { TIME_WINDOW_SECONDS, type TimeWindow } from '@/types/events'
+
+/**
+ * The schema version this build reads and writes.
+ *
+ * Bump it when a change is not additive, and add the migration that goes with
+ * it. There is no down-migration: a document from a newer version falls back to
+ * the preset with a banner, which is what makes rolling the dashboard back
+ * recoverable.
+ */
+export const DASHBOARD_SCHEMA_VERSION = 1
+
+/** Time window a panel's chart covers when the operator has not chosen one. */
+export const DEFAULT_TIME_WINDOW: TimeWindow = '5m'
+
+/** The whole configuration: a versioned list of pages. */
+export interface DashboardDocument {
+  version: number
+  pages: DashboardPage[]
+}
+
+/** One named arrangement of panels, addressable by its own URL. */
+export interface DashboardPage {
+  /**
+   * Stable identifier, used in the page's URL. Independent of the name so a
+   * rename does not break a kiosk display's bookmark.
+   */
+  id: string
+  name: string
+  panels: DashboardPanel[]
+}
+
+/** One panel on a page. */
+export interface DashboardPanel {
+  /** Unique within its page. */
+  id: string
+  /**
+   * A `PanelType` when this build implements it. Typed as a plain string
+   * because a rolled-back build must still be able to hold a panel it cannot
+   * render rather than discard it.
+   */
+  type: string
+  /** Absent when the operator has not renamed the panel. */
+  title?: string
+  geometry: PanelGeometry
+  binding: PanelBinding
+  window: TimeWindow
+}
+
+/**
+ * Reads a document at the current schema version. Null when there is nothing
+ * readable here, including when the version is not this build's — deciding what
+ * to show instead is the loader's job, because only it knows whether the
+ * document came from the future or merely needs migrating.
+ */
+export function parseDashboardDocument(raw: unknown): DashboardDocument | null {
+  if (!isRecord(raw)) return null
+  if (raw.version !== DASHBOARD_SCHEMA_VERSION) return null
+  if (!Array.isArray(raw.pages)) return null
+
+  const pages = raw.pages.filter(isRecord).map(readPage)
+  // A list that held entries and yielded no readable page is corruption. An
+  // empty list is not: a configuration can legitimately have no pages, and
+  // calling that unreadable would put a "cannot be read" banner in front of an
+  // operator who had simply deleted their last one.
+  if (pages.length === 0 && raw.pages.length > 0) return null
+
+  return { version: DASHBOARD_SCHEMA_VERSION, pages: withUniqueIds(pages, 'page') }
+}
+
+/**
+ * Writes the document for the server to store.
+ *
+ * Only known keys are written, and geometry is written in full rather than
+ * relying on the grid library's habit of omitting its own defaults — so the file
+ * on disk describes itself, and a future migration reading it does not have to
+ * know which values were elided.
+ */
+export function serializeDashboardDocument(document: DashboardDocument): string {
+  return JSON.stringify({
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: document.pages.map((page) => ({
+      id: page.id,
+      name: page.name,
+      panels: page.panels.map((panel) => ({
+        id: panel.id,
+        type: panel.type,
+        // Omitted rather than written as null, so "never renamed" stays
+        // distinguishable from "renamed to nothing".
+        ...(panel.title === undefined ? {} : { title: panel.title }),
+        geometry: {
+          x: panel.geometry.x,
+          y: panel.geometry.y,
+          w: panel.geometry.w,
+          h: panel.geometry.h,
+        },
+        binding: panel.binding,
+        window: panel.window,
+      })),
+    })),
+  })
+}
+
+/** What the panel's header reads: the operator's title, or the type's default. */
+export function panelTitle(panel: Pick<DashboardPanel, 'type' | 'title'>): string {
+  return panel.title ?? defaultPanelTitle(panel.type)
+}
+
+function readPage(raw: Record<string, unknown>): DashboardPage {
+  const panels = Array.isArray(raw.panels) ? raw.panels.filter(isRecord).map(readPanel) : []
+
+  return {
+    id: readId(raw.id),
+    name: readText(raw.name) ?? '',
+    panels: withUniqueIds(panels, 'panel'),
+  }
+}
+
+function readPanel(raw: Record<string, unknown>): DashboardPanel {
+  const title = readText(raw.title)
+
+  return {
+    id: readId(raw.id),
+    type: readText(raw.type) ?? '',
+    ...(title === undefined ? {} : { title }),
+    geometry: readGeometry(raw.geometry),
+    binding: readBinding(raw.binding),
+    window: readWindow(raw.window),
+  }
+}
+
+/**
+ * A trimmed, non-empty string, or undefined. Whitespace-only is treated as
+ * absent so a title cleared in the UI reverts to the panel type's default
+ * rather than rendering as a blank header.
+ */
+function readText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/** Empty marks "no usable id"; `withUniqueIds` fills it from the position. */
+function readId(value: unknown): string {
+  return readText(value) ?? ''
+}
+
+function readWindow(value: unknown): TimeWindow {
+  return typeof value === 'string' && Object.hasOwn(TIME_WINDOW_SECONDS, value)
+    ? (value as TimeWindow)
+    : DEFAULT_TIME_WINDOW
+}
+
+/**
+ * Gives everything a unique, non-empty id, derived from its position when the
+ * document had none or repeated one.
+ *
+ * Repairing rather than rejecting is the point: an id collision would break the
+ * grid's keys and a page's URL, but discarding the offender loses an
+ * arrangement the operator built by hand. Pages get a display name here too,
+ * for the same reason.
+ */
+function withUniqueIds<T extends { id: string }>(items: T[], kind: 'page' | 'panel'): T[] {
+  const taken = new Set<string>()
+
+  return items.map((item, position) => {
+    let id = item.id || `${kind}-${position + 1}`
+    for (let suffix = 2; taken.has(id); suffix++) {
+      id = `${item.id || `${kind}-${position + 1}`}-${suffix}`
+    }
+    taken.add(id)
+
+    const named =
+      kind === 'page' && 'name' in item && !item.name
+        ? { ...item, name: `Page ${position + 1}` }
+        : item
+
+    return { ...named, id }
+  })
+}


### PR DESCRIPTION
Closes #76. Spec: #70. Decision record: #68.

The whole configuration schema layer as pure functions — no React, no fetch, no UI. Nothing imports it yet; #77 is the first consumer.

## What's here

| Module | Job |
| --- | --- |
| `grid.ts` | 12×8 grid, sparse-geometry normalization, `firstFreeSlot` / `isOutOfRoom` |
| `panels.ts` | 23 persisted panel type ids and what each binds to |
| `bindings.ts` | `follow` / GPU / engine bindings and their resolution |
| `schema.ts` | The versioned document: tolerant parse, dense serialize |
| `migrations.ts` | Migration runner + the fixture harness the first migration extends |
| `preset.ts` | The default preset — all `follow`, tiles the grid exactly |
| `load.ts` | Boot entry point: never throws, always returns something renderable |
| `json.ts` | The one narrowing every reader starts from |

113 new tests (221 → 334).

## Decisions the ticket left open

- **Sparse geometry: normalize on read** is the contract, because gridstack hands us sparse objects at runtime and not only on disk. Writes are dense as reinforcement, so the file describes itself. Both directions tested.
- **Unknown panel types are retained, not dropped.** Discarding one silently reflows an arrangement the operator authored; it keeps its slot and #79 renders a placeholder. This is why `DashboardPanel.type` is `string` rather than the `PanelType` union.
- **An absent binding defaults to `follow`; a malformed one is `unreadable`.** Nothing pinned means following is the default, not a substitution. But a binding that *did* name a target must not quietly revert to following — an operator who pinned GPU 3 may have retitled the panel to say so, and showing the page selection under that title is precisely the prohibited failure.
- **An empty page list is an empty configuration, not corruption** — deleting your last page renders the preset with no banner. A list that held entries and yielded no readable page *is* corruption, and says so.
- **The preset has no room for another panel**, because a fit-to-viewport default tiles the grid exactly. That is the "out of room" state the spec wants to be real, not an oversight. The arrangement is a working default; the redesign and cutover are #86.
- **The migration path and grid dimensions are injectable / exported** so the runner's chaining is tested with stand-ins now, rather than being debugged by whoever writes the first real migration.

## Notes for the tickets downstream

`GRID_COLUMNS` / `GRID_MAX_ROWS` are the single source for the grid's dimensions. #79/#83 must configure gridstack's own column count and row cap **from them** — the library answers the same "will it fit" question during a drag, and two independent answers would disagree the moment either changed. Recorded in `grid.ts`.

`CONTEXT.md` and ADRs for the new *panel* / *page* / *binding* / *preset* vocabulary belong to #88.

The metrics contract is untouched: no wire-format type, formatter or component changed, so that checklist is N/A here.

## Test plan

- `npm run lint` — clean
- `npm run build` (`tsc -b && vite build`) — clean
- `npm test -- --run` — 27 files, 334 tests green
- `npm run test:browser` — not required, no `*.browser.test.tsx` changed
- No Rust touched