### PR TITLE
feat(frontend): configuration load/save client and failure banners

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from 'react'
+import { useDashboardConfiguration } from './hooks/useDashboardConfiguration'
 import { useMetrics } from './hooks/useMetrics'
 import { useMetricsHistory } from './hooks/useMetricsHistory'
+import { ConfigurationNotices } from './components/ConfigurationNotices'
 import { ConnectionBadge } from './components/ConnectionBadge'
 import { Dashboard } from './components/views/Dashboard'
 import { LogViewer } from './components/LogViewer'
@@ -8,6 +10,11 @@ import type { GpuEvent, InferenceRequest } from './types/events'
 
 function App() {
   const { metrics, connectionStatus, isStale } = useMetrics()
+  // The configuration is loaded and saved from here, at the root, because it is
+  // one document for the whole dashboard. Nothing renders from it yet — the
+  // panel grid that will is #79 — but the operator is told now when it could not
+  // be loaded or cannot be saved, rather than after a layout silently reverts.
+  const { notices: configurationNotices } = useDashboardConfiguration()
   const [consoleExpanded, setConsoleExpanded] = useState(false)
   // Endpoint of the engine tab selected in the engine section (null = Global
   // tab). The log viewer follows it so logs stay in sync with the selection.
@@ -49,6 +56,8 @@ function App() {
         </h1>
         <ConnectionBadge status={connectionStatus} isStale={isStale} />
       </header>
+
+      <ConfigurationNotices notices={configurationNotices} />
 
       <main className={`flex-1 min-h-0 flex flex-col p-3 lg:p-4 2xl:p-5 min-[1920px]:p-6 ${isStale ? 'opacity-50' : ''}`}>
         {!metrics && connectionStatus !== 'connected' && (

--- a/frontend/src/__tests__/App.configuration.test.tsx
+++ b/frontend/src/__tests__/App.configuration.test.tsx
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import App from '../App'
+import {
+  configurationResponse,
+  serveConfiguration,
+  serveNothing,
+  type FetchMock,
+} from '../test/configurationServer'
+import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+
+// The application root opens the metrics socket on mount. Nothing here is about
+// metrics, so the socket only has to exist and stay quiet. The log viewer's spec
+// keeps a richer substitute of its own, which drives frames and reconnection —
+// this needs none of that.
+class SilentWebSocket {
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  readyState = 0
+  close() {}
+  send() {}
+}
+
+/** A stored document at the version this build reads. */
+function document(pages: unknown[] = [{ id: 'watch', name: 'Watch', panels: [] }]): string {
+  return JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION, pages })
+}
+
+/** Waits for the configuration request to resolve and for React to render it. */
+async function configurationSettles(fetchMock: FetchMock) {
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+  await act(() => configurationResponse(fetchMock))
+}
+
+/** The dashboard itself, proving a banner never replaced it with a dead screen. */
+function dashboardIsRendered() {
+  expect(screen.getByText('Waiting for metrics')).toBeInTheDocument()
+}
+
+beforeEach(() => {
+  vi.stubGlobal('WebSocket', SilentWebSocket as unknown as typeof WebSocket)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  window.localStorage.clear()
+  window.sessionStorage.clear()
+})
+
+describe('the dashboard configuration at the application root', () => {
+  it('shows no banner when nothing is configured', async () => {
+    // A fresh install is not a fault: the preset renders and says nothing.
+    const fetchMock = serveConfiguration({ document: null })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    dashboardIsRendered()
+  })
+
+  it('shows no banner when the stored configuration loads', async () => {
+    const fetchMock = serveConfiguration({ document: document() })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    dashboardIsRendered()
+  })
+
+  it('names the problem when the stored configuration will not parse', async () => {
+    const fetchMock = serveConfiguration({ document: '{ not a dashboard }' })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /saved dashboard configuration could not be read/i,
+    )
+    dashboardIsRendered()
+  })
+
+  it('names the problem when the server could not read the stored document', async () => {
+    // The server has a document and failed to read it — to the operator, the
+    // same problem as one that will not parse, and the same banner.
+    const fetchMock = serveConfiguration({ getStatus: 500 })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /saved dashboard configuration could not be read/i,
+    )
+    dashboardIsRendered()
+  })
+
+  it('says so when the stored configuration is from a newer build', async () => {
+    const fetchMock = serveConfiguration({
+      document: JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION + 1, pages: [] }),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/from a newer version/i)
+    dashboardIsRendered()
+  })
+
+  it('says so when the stored configuration is too old to bring forward', async () => {
+    // No migration reaches this build from version 0, so there is nothing to
+    // render but the preset — and the operator has to know their pages are not
+    // lost, merely unreachable from here.
+    const fetchMock = serveConfiguration({
+      document: JSON.stringify({ version: 0, pages: [] }),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/too old to read/i)
+    dashboardIsRendered()
+  })
+
+  it('says so when the server could not be asked for the configuration', async () => {
+    const fetchMock = serveNothing()
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not be loaded/i)
+    dashboardIsRendered()
+  })
+
+  it('says so when the dashboard is read-only', async () => {
+    const fetchMock = serveConfiguration({ document: null, readOnly: true })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/read-only/i)
+    dashboardIsRendered()
+  })
+
+  it('writes nothing about the configuration to browser-local storage', async () => {
+    // A per-browser copy of a document shared by everyone on the instance would
+    // be an invisible second source of truth. The failing path is the tempting
+    // one, so that is the one asserted.
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+    const fetchMock = serveConfiguration({ document: '{ not a dashboard }' })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    // Targeted rather than "nothing was written at all": other features
+    // legitimately keep browser-local preferences, and this contract is about
+    // the shared configuration document only.
+    const configurationLike = /dashboard|panel|page|preset/i
+    expect(
+      setItem.mock.calls.filter(([key, value]) => configurationLike.test(`${key} ${value}`)),
+    ).toEqual([])
+    for (const storage of [window.localStorage, window.sessionStorage]) {
+      for (const key of Object.keys(storage)) {
+        expect(`${key} ${storage.getItem(key)}`).not.toMatch(configurationLike)
+      }
+    }
+  })
+})

--- a/frontend/src/__tests__/ConfigurationNotices.test.tsx
+++ b/frontend/src/__tests__/ConfigurationNotices.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ConfigurationNotices } from '../components/ConfigurationNotices'
+import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+import type { ConfigurationNotice } from '../lib/dashboard/notices'
+
+/**
+ * Every notice the dashboard can raise. The application-root spec drives the
+ * load-time ones through the fetch seam; the save-time ones cannot be reached
+ * from there until edit mode has a save control (#83), so their wording is
+ * covered here rather than shipping unrendered.
+ */
+const everyNotice: ConfigurationNotice[] = [
+  {
+    kind: 'newer-version',
+    documentVersion: DASHBOARD_SCHEMA_VERSION + 1,
+    supportedVersion: DASHBOARD_SCHEMA_VERSION,
+  },
+  { kind: 'unsupported-version', documentVersion: 0, supportedVersion: DASHBOARD_SCHEMA_VERSION },
+  { kind: 'unreadable' },
+  { kind: 'unavailable' },
+  { kind: 'read-only' },
+  { kind: 'save-failed' },
+  { kind: 'too-large' },
+]
+
+describe('ConfigurationNotices', () => {
+  it('renders nothing when there is nothing wrong', () => {
+    const { container } = render(<ConfigurationNotices notices={[]} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('gives every notice a banner of its own', () => {
+    render(<ConfigurationNotices notices={everyNotice} />)
+
+    expect(screen.getAllByRole('alert')).toHaveLength(everyNotice.length)
+  })
+
+  it('says something different for every notice', () => {
+    // A message shared between two kinds would leave an operator unable to tell
+    // "could not be saved" from "could not be loaded", which are opposite
+    // problems with opposite next steps.
+    render(<ConfigurationNotices notices={everyNotice} />)
+
+    const messages = screen.getAllByRole('alert').map((banner) => banner.textContent)
+
+    expect(new Set(messages).size).toBe(everyNotice.length)
+    for (const message of messages) expect(message?.trim()).not.toBe('')
+  })
+
+  it('tells the operator a save did not happen', () => {
+    render(<ConfigurationNotices notices={[{ kind: 'save-failed' }]} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/saving .* failed/i)
+    expect(screen.getByRole('alert')).toHaveTextContent(/not stored/i)
+  })
+
+  it('tells the operator a document too large will not fit, and what to do', () => {
+    render(<ConfigurationNotices notices={[{ kind: 'too-large' }]} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/too large/i)
+    expect(screen.getByRole('alert')).toHaveTextContent(/remove some panels or pages/i)
+  })
+
+  it('names the versions when the document came from another build', () => {
+    // The numbers are what turns "it does not work" into a report a maintainer
+    // can act on.
+    render(
+      <ConfigurationNotices
+        notices={[{ kind: 'newer-version', documentVersion: 7, supportedVersion: 3 }]}
+      />,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/7/)
+    expect(screen.getByRole('alert')).toHaveTextContent(/3/)
+  })
+})

--- a/frontend/src/__tests__/useDashboardConfiguration.test.tsx
+++ b/frontend/src/__tests__/useDashboardConfiguration.test.tsx
@@ -1,0 +1,291 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useDashboardConfiguration } from '../hooks/useDashboardConfiguration'
+import type { MigrationPath } from '../lib/dashboard/migrations'
+import { defaultDashboardDocument } from '../lib/dashboard/preset'
+import { DASHBOARD_SCHEMA_VERSION, type DashboardDocument } from '../lib/dashboard/schema'
+import {
+  configurationWrites as writes,
+  serveConfiguration,
+  serveNothing,
+} from '../test/configurationServer'
+
+/** A stored document with one page, at the version this build reads. */
+const stored = JSON.stringify({
+  version: DASHBOARD_SCHEMA_VERSION,
+  pages: [{ id: 'watch', name: 'Watch', panels: [] }],
+})
+
+/** Renders the hook and waits for the first response to resolve. */
+async function loaded(path?: MigrationPath) {
+  const view = renderHook(() => useDashboardConfiguration(path))
+  await waitFor(() => expect(view.result.current.document).not.toBeNull())
+  return view
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useDashboardConfiguration', () => {
+  it('has no document until the server has answered', async () => {
+    // The preset must not be rendered while the stored document is still in
+    // flight, or an operator with a saved layout watches it flash past.
+    serveConfiguration({ document: stored })
+
+    const { result } = renderHook(() => useDashboardConfiguration())
+
+    expect(result.current.document).toBeNull()
+
+    // Settle the in-flight load so its state update lands inside the test.
+    await waitFor(() => expect(result.current.document).not.toBeNull())
+  })
+
+  it('renders the preset with no notice when nothing is stored', async () => {
+    serveConfiguration({ document: null })
+
+    const { result } = await loaded()
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+    expect(result.current.notices).toEqual([])
+  })
+
+  it('renders the stored document', async () => {
+    serveConfiguration({ document: stored })
+
+    const { result } = await loaded()
+
+    expect(result.current.document?.pages.map((page) => page.name)).toEqual(['Watch'])
+    expect(result.current.notices).toEqual([])
+  })
+
+  it('renders the preset and says so when the document cannot be read', async () => {
+    serveConfiguration({ document: '{ this is not the document }' })
+
+    const { result } = await loaded()
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+    expect(result.current.notices).toEqual([{ kind: 'unreadable' }])
+  })
+
+  it('renders the preset and says so when the document is from a newer build', async () => {
+    serveConfiguration({
+      document: JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION + 1, pages: [] }),
+    })
+
+    const { result } = await loaded()
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+    expect(result.current.notices).toEqual([
+      {
+        kind: 'newer-version',
+        documentVersion: DASHBOARD_SCHEMA_VERSION + 1,
+        supportedVersion: DASHBOARD_SCHEMA_VERSION,
+      },
+    ])
+  })
+
+  it('renders the preset and says so when no migration reaches this build', async () => {
+    serveConfiguration({ document: JSON.stringify({ version: 0, pages: [] }) })
+
+    const { result } = await loaded()
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+    expect(result.current.notices).toEqual([
+      {
+        kind: 'unsupported-version',
+        documentVersion: 0,
+        supportedVersion: DASHBOARD_SCHEMA_VERSION,
+      },
+    ])
+  })
+
+  it('renders the preset and says so when the server could not be asked', async () => {
+    serveNothing()
+
+    const { result } = await loaded()
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+    expect(result.current.notices).toEqual([{ kind: 'unavailable' }])
+  })
+
+  it('renders the preset and says so when the server could not read the document', async () => {
+    // Distinct from an unreachable server: there is a document, and something
+    // on the machine is wrong with it rather than with the network.
+    serveConfiguration({ getStatus: 500 })
+
+    const { result } = await loaded()
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+    expect(result.current.notices).toEqual([{ kind: 'unreadable' }])
+  })
+
+  it('reports read-only storage', async () => {
+    serveConfiguration({ document: stored, readOnly: true })
+
+    const { result } = await loaded()
+
+    expect(result.current.readOnly).toBe(true)
+    expect(result.current.notices).toEqual([{ kind: 'read-only' }])
+  })
+
+  it('makes no request when asked to save on a read-only instance', async () => {
+    const fetchMock = serveConfiguration({ document: stored, readOnly: true })
+    const { result } = await loaded()
+
+    let outcome = ''
+    await act(async () => {
+      outcome = await result.current.save(defaultDashboardDocument())
+    })
+
+    expect(outcome).toBe('read-only')
+    expect(writes(fetchMock)).toEqual([])
+  })
+
+  it('writes the document on a save the operator asked for', async () => {
+    const fetchMock = serveConfiguration({ document: null })
+    const { result } = await loaded()
+    const edited: DashboardDocument = {
+      version: DASHBOARD_SCHEMA_VERSION,
+      pages: [{ id: 'wall', name: 'Wall', panels: [] }],
+    }
+
+    await act(async () => {
+      await result.current.save(edited)
+    })
+
+    expect(writes(fetchMock)).toHaveLength(1)
+    expect(JSON.parse(writes(fetchMock)[0])).toEqual(edited)
+    expect(result.current.document).toEqual(edited)
+  })
+
+  it('never autosaves — loading issues no write of any kind', async () => {
+    const fetchMock = serveConfiguration({ document: stored })
+
+    await loaded()
+
+    expect(writes(fetchMock)).toEqual([])
+  })
+
+  it('migrates in memory and persists only on the next save', async () => {
+    // A viewer who merely upgraded and opened the page must not rewrite a
+    // document shared with colleagues still on the previous build.
+    const path: MigrationPath = {
+      target: DASHBOARD_SCHEMA_VERSION,
+      migrations: [
+        {
+          from: DASHBOARD_SCHEMA_VERSION - 1,
+          migrate: (document) => ({ pages: document.sheets }),
+        },
+      ],
+    }
+    const fetchMock = serveConfiguration({
+      document: JSON.stringify({
+        version: DASHBOARD_SCHEMA_VERSION - 1,
+        sheets: [{ id: 'old', name: 'Old', panels: [] }],
+      }),
+    })
+
+    const { result } = await loaded(path)
+
+    expect(result.current.document?.pages.map((page) => page.name)).toEqual(['Old'])
+    expect(result.current.notices).toEqual([])
+    expect(writes(fetchMock)).toEqual([])
+
+    await act(async () => {
+      await result.current.save(result.current.document as DashboardDocument)
+    })
+
+    expect(JSON.parse(writes(fetchMock)[0])).toEqual({
+      version: DASHBOARD_SCHEMA_VERSION,
+      pages: [{ id: 'old', name: 'Old', panels: [] }],
+    })
+  })
+
+  it('clears the fallback notice once the operator has saved over it', async () => {
+    // The banner describes the stored document. Saving replaced it, so leaving
+    // the banner up would report a problem that no longer exists.
+    serveConfiguration({ document: '{ this is not the document }' })
+    const { result } = await loaded()
+
+    await act(async () => {
+      await result.current.save(defaultDashboardDocument())
+    })
+
+    expect(result.current.notices).toEqual([])
+  })
+
+  it('says so when a save failed', async () => {
+    serveConfiguration({ document: null, putStatus: 500 })
+    const { result } = await loaded()
+
+    let outcome = ''
+    await act(async () => {
+      outcome = await result.current.save(defaultDashboardDocument())
+    })
+
+    expect(outcome).toBe('failed')
+    expect(result.current.notices).toEqual([{ kind: 'save-failed' }])
+  })
+
+  it('says so when the document is too large to store', async () => {
+    serveConfiguration({ document: null, putStatus: 413 })
+    const { result } = await loaded()
+
+    await act(async () => {
+      await result.current.save(defaultDashboardDocument())
+    })
+
+    expect(result.current.notices).toEqual([{ kind: 'too-large' }])
+  })
+
+  it('turns read-only when a save is refused by storage that was writable', async () => {
+    // The directory lost its write permission after startup. The next save is
+    // the first thing that can notice.
+    serveConfiguration({ document: null, putStatus: 503 })
+    const { result } = await loaded()
+
+    expect(result.current.readOnly).toBe(false)
+
+    await act(async () => {
+      await result.current.save(defaultDashboardDocument())
+    })
+
+    expect(result.current.readOnly).toBe(true)
+    expect(result.current.notices).toEqual([{ kind: 'read-only' }])
+  })
+
+  it('keeps no copy of the configuration in browser-local storage', async () => {
+    // Not on load and not on save. The document is shared by everyone who opens
+    // the instance, so a per-browser copy would be a source of truth nobody can
+    // see — which is exactly what makes it worse than a visible failure.
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+    serveConfiguration({ document: stored })
+    const { result } = await loaded()
+
+    await act(async () => {
+      await result.current.save(defaultDashboardDocument())
+    })
+
+    expect(setItem).not.toHaveBeenCalled()
+    setItem.mockRestore()
+  })
+
+  it('does not adopt a document the server refused to store', async () => {
+    // What this reports is what is stored. The refused edit stays with the
+    // session that made it, which is what lets the operator retry the save
+    // rather than discover later that only the browser believed it landed.
+    serveConfiguration({ document: null, putStatus: 500 })
+    const { result } = await loaded()
+    const edited: DashboardDocument = {
+      version: DASHBOARD_SCHEMA_VERSION,
+      pages: [{ id: 'wall', name: 'Wall', panels: [] }],
+    }
+
+    await act(async () => {
+      await result.current.save(edited)
+    })
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+  })
+})

--- a/frontend/src/components/ConfigurationNotices.tsx
+++ b/frontend/src/components/ConfigurationNotices.tsx
@@ -1,0 +1,104 @@
+/**
+ * What the operator is told when the dashboard is not showing their saved
+ * configuration, or cannot save a new one.
+ *
+ * These exist because the alternative failure modes are all silent: a blank
+ * screen, a preset that looks like someone deleted the layout, or edits that
+ * vanish on the next reload. Each notice names the problem and says what is
+ * being shown instead, so the dashboard is still worth reading while it is
+ * degraded.
+ */
+
+import type { ConfigurationNotice } from '@/lib/dashboard/notices'
+
+export function ConfigurationNotices({ notices }: { notices: ConfigurationNotice[] }) {
+  if (notices.length === 0) return null
+
+  return (
+    <div className="shrink-0 flex flex-col gap-1 px-4 pt-2">
+      {notices.map((notice) => {
+        const { title, detail, tone } = describe(notice)
+        return (
+          <div
+            key={notice.kind}
+            role="alert"
+            className={`rounded-md border px-3 py-1.5 text-sm ${toneClass[tone]}`}
+          >
+            <span className="font-semibold">{title}</span>{' '}
+            <span className="opacity-80">{detail}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Amber for a degraded dashboard, red for an action that did not happen. */
+const toneClass = {
+  warning: 'border-amber-500/25 bg-amber-500/10 text-amber-200',
+  error: 'border-red-500/25 bg-red-500/10 text-red-200',
+} as const
+
+interface NoticeText {
+  title: string
+  detail: string
+  tone: keyof typeof toneClass
+}
+
+function describe(notice: ConfigurationNotice): NoticeText {
+  switch (notice.kind) {
+    case 'newer-version':
+      return {
+        title: 'Saved dashboard configuration is from a newer version.',
+        detail:
+          `It was written at configuration version ${notice.documentVersion}, and this build ` +
+          `reads version ${notice.supportedVersion}. The default dashboard is shown instead. ` +
+          'Saving replaces the stored configuration.',
+        tone: 'warning',
+      }
+    case 'unsupported-version':
+      return {
+        title: 'Saved dashboard configuration is too old to read.',
+        detail:
+          `It is at configuration version ${notice.documentVersion}, which this build ` +
+          `(version ${notice.supportedVersion}) can no longer bring forward. The default ` +
+          'dashboard is shown instead.',
+        tone: 'warning',
+      }
+    case 'unreadable':
+      return {
+        title: 'Saved dashboard configuration could not be read.',
+        detail:
+          'The server could not read the stored document, or it is damaged. The default ' +
+          'dashboard is shown instead, and saving replaces the stored configuration.',
+        tone: 'warning',
+      }
+    case 'unavailable':
+      return {
+        title: 'Saved dashboard configuration could not be loaded.',
+        detail:
+          'The server did not return it. The default dashboard is shown instead, so this is ' +
+          'not the layout that is stored.',
+        tone: 'warning',
+      }
+    case 'read-only':
+      return {
+        title: 'The dashboard is read-only.',
+        detail:
+          "The server's state directory is not writable, so layout changes cannot be saved.",
+        tone: 'warning',
+      }
+    case 'save-failed':
+      return {
+        title: 'Saving the dashboard configuration failed.',
+        detail: 'Your changes were not stored. Try saving again.',
+        tone: 'error',
+      }
+    case 'too-large':
+      return {
+        title: 'The dashboard configuration is too large to save.',
+        detail: 'The server refused it for its size. Remove some panels or pages and save again.',
+        tone: 'error',
+      }
+  }
+}

--- a/frontend/src/hooks/useDashboardConfiguration.ts
+++ b/frontend/src/hooks/useDashboardConfiguration.ts
@@ -1,0 +1,141 @@
+/**
+ * The configuration lifecycle: load it once at boot, save it when the operator
+ * asks, and keep whatever the operator needs telling about.
+ *
+ * Two rules shape everything here, both from the fact that the configuration is
+ * **instance-scoped** — one document shared by everyone who opens the dashboard:
+ *
+ * - **Nothing is written that the operator did not ask for.** No autosave, and
+ *   no write-back of a document that merely needed migrating on load. Otherwise
+ *   one upgraded viewer opening the page would rewrite the document and lock out
+ *   colleagues still on the previous build.
+ * - **Nothing is kept in browser-local storage.** Not as a cache, not as a
+ *   fallback. A per-browser copy of a shared document is an invisible second
+ *   source of truth, which is worse than the visible failure it would hide.
+ *
+ * Failures are states, not exceptions: there is always a renderable document,
+ * and the notices say why it might not be the stored one.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  fetchStoredConfiguration,
+  saveStoredConfiguration,
+  type SaveOutcome,
+} from '@/lib/dashboard/client'
+import { loadDashboardConfiguration, type ConfigurationFallbackReason } from '@/lib/dashboard/load'
+import type { MigrationPath } from '@/lib/dashboard/migrations'
+import type { ConfigurationNotice } from '@/lib/dashboard/notices'
+import type { DashboardDocument } from '@/lib/dashboard/schema'
+
+type SaveFailureNotice = 'save-failed' | 'too-large' | null
+
+/**
+ * How a save's outcome reads to the operator. Read-only is not here: it is a
+ * property of the instance rather than of the attempt, and it has its own
+ * standing notice as long as it holds.
+ */
+const SAVE_FAILURE_NOTICE: Record<SaveOutcome['status'], SaveFailureNotice> = {
+  saved: null,
+  'read-only': null,
+  'too-large': 'too-large',
+  failed: 'save-failed',
+}
+
+export interface DashboardConfigurationState {
+  /**
+   * The configuration to render: the stored document, or the default preset.
+   * Null until the first response resolves — rendering the preset in the
+   * meantime would flash a layout the operator did not save past them.
+   */
+  document: DashboardDocument | null
+  /** Everything the operator needs telling, most consequential first. */
+  notices: ConfigurationNotice[]
+  /** Whether saving is available at all. False also while the load is in flight. */
+  readOnly: boolean
+  /**
+   * Stores `document`, replacing what the server had. Returns how it went so an
+   * edit session can stay open on a failure rather than discarding work the
+   * server never accepted.
+   */
+  save: (document: DashboardDocument) => Promise<SaveOutcome['status']>
+}
+
+/**
+ * `path` exists for the same reason the loader takes one: the migrating branch
+ * is covered by stand-ins rather than waiting for the first real migration. It
+ * is read once, when the configuration is loaded — this is a boot-time concern,
+ * and latching it means a caller passing an inline object cannot set off a
+ * reload on every render.
+ */
+export function useDashboardConfiguration(path?: MigrationPath): DashboardConfigurationState {
+  const [document, setDocument] = useState<DashboardDocument | null>(null)
+  const [fallback, setFallback] = useState<ConfigurationFallbackReason | null>(null)
+  const [unavailable, setUnavailable] = useState(false)
+  const [readOnly, setReadOnly] = useState(false)
+  const [saveFailure, setSaveFailure] = useState<SaveFailureNotice>(null)
+  const pathRef = useRef(path)
+
+  useEffect(() => {
+    let live = true
+
+    void (async () => {
+      const stored = await fetchStoredConfiguration()
+      if (!live) return
+
+      setReadOnly(stored.readOnly)
+      // A server that was never reached is a different problem from a document
+      // that could not be read, and the operator's next move differs: check that
+      // the dashboard is up, versus look at what is on disk.
+      setUnavailable(stored.status === 'unavailable')
+
+      // Anything that is not a document reads as "nothing stored", which
+      // resolves to the preset. Whether that is a fault is decided above.
+      const loaded = loadDashboardConfiguration(
+        stored.status === 'stored' ? stored.body : null,
+        pathRef.current,
+      )
+      setDocument(loaded.document)
+      setFallback(stored.status === 'unreadable' ? { kind: 'unreadable' } : loaded.fallback)
+    })()
+
+    return () => {
+      live = false
+    }
+  }, [])
+
+  const save = useCallback(
+    async (next: DashboardDocument): Promise<SaveOutcome['status']> => {
+      // Storage that cannot be written is a permanent condition the operator
+      // already has a banner for; a request would only fail the same way.
+      if (readOnly) return 'read-only'
+
+      const outcome = await saveStoredConfiguration(next)
+      setReadOnly(outcome.readOnly)
+      setSaveFailure(SAVE_FAILURE_NOTICE[outcome.status])
+
+      if (outcome.status === 'saved') {
+        // What was stored is now what this build wrote, so any complaint about
+        // the previous document — unreadable, from a newer build, unreachable —
+        // describes something that no longer exists.
+        setDocument(next)
+        setFallback(null)
+        setUnavailable(false)
+      }
+
+      return outcome.status
+    },
+    [readOnly],
+  )
+
+  const notices = useMemo((): ConfigurationNotice[] => {
+    const list: ConfigurationNotice[] = []
+    if (fallback) list.push(fallback)
+    if (unavailable) list.push({ kind: 'unavailable' })
+    if (readOnly) list.push({ kind: 'read-only' })
+    if (saveFailure) list.push({ kind: saveFailure })
+    return list
+  }, [fallback, unavailable, readOnly, saveFailure])
+
+  return { document, notices, readOnly, save }
+}

--- a/frontend/src/lib/dashboard/client.test.ts
+++ b/frontend/src/lib/dashboard/client.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  CONFIGURATION_URL,
+  READ_ONLY_HEADER,
+  fetchStoredConfiguration,
+  saveStoredConfiguration,
+} from './client'
+import { defaultDashboardDocument } from './preset'
+import { serializeDashboardDocument } from './schema'
+
+/** Installs a fetch that answers with `response`, and hands back the spy. */
+function respondWith(response: Response | Promise<Response>) {
+  // Typed with fetch's own signature so the recorded calls can be read back as
+  // a URL and an init, rather than as the empty tuple a nullary stub records.
+  const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(() =>
+    Promise.resolve(response),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function body(text: string, init: ResponseInit = {}): Response {
+  return new Response(text, { status: 200, ...init })
+}
+
+const readOnly = { [READ_ONLY_HEADER]: 'true' }
+const writable = { [READ_ONLY_HEADER]: 'false' }
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('fetchStoredConfiguration', () => {
+  it('returns the stored document verbatim', async () => {
+    // Verbatim matters: the server stores opaque bytes, so anything this layer
+    // normalized would be a second reader of a schema only the loader knows.
+    respondWith(body('{"version":1,"pages":[]}', { headers: writable }))
+
+    expect(await fetchStoredConfiguration()).toEqual({
+      status: 'stored',
+      body: '{"version":1,"pages":[]}',
+      readOnly: false,
+    })
+  })
+
+  it('asks the configuration endpoint', async () => {
+    const fetchMock = respondWith(new Response(null, { status: 204 }))
+
+    await fetchStoredConfiguration()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe(CONFIGURATION_URL)
+  })
+
+  it('reports absence rather than failure when nothing is stored', async () => {
+    respondWith(new Response(null, { status: 204, headers: writable }))
+
+    expect(await fetchStoredConfiguration()).toEqual({ status: 'absent', readOnly: false })
+  })
+
+  it('reports read-only storage from the header', async () => {
+    respondWith(body('{"version":1,"pages":[]}', { headers: readOnly }))
+
+    expect(await fetchStoredConfiguration()).toMatchObject({ readOnly: true })
+  })
+
+  it('reports read-only storage even when nothing is stored', async () => {
+    // A fresh install on an unwritable volume: there is no document to read and
+    // there never will be one, which the operator has to be told.
+    respondWith(new Response(null, { status: 204, headers: readOnly }))
+
+    expect(await fetchStoredConfiguration()).toEqual({ status: 'absent', readOnly: true })
+  })
+
+  it('reports the document unreadable when the server could not read it', async () => {
+    // The server answers 500 when reading the file failed, so a document exists
+    // and cannot be read — which is the operator's problem, not the network's.
+    respondWith(new Response('Failed to read the dashboard configuration', { status: 500 }))
+
+    expect(await fetchStoredConfiguration()).toMatchObject({ status: 'unreadable' })
+  })
+
+  it('reports unavailable when the server cannot be reached', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))),
+    )
+
+    expect(await fetchStoredConfiguration()).toEqual({ status: 'unavailable', readOnly: false })
+  })
+
+  it('does not claim read-only when the response never said', async () => {
+    // The read-only banner promises a permanent condition. A dropped connection
+    // says nothing about the state directory, so it must not imply one.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))),
+    )
+
+    expect(await fetchStoredConfiguration()).toMatchObject({ readOnly: false })
+  })
+})
+
+describe('saveStoredConfiguration', () => {
+  it('puts the serialized document to the configuration endpoint', async () => {
+    const fetchMock = respondWith(new Response(null, { status: 204, headers: writable }))
+    const document = defaultDashboardDocument()
+
+    expect(await saveStoredConfiguration(document)).toEqual({ status: 'saved', readOnly: false })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(CONFIGURATION_URL)
+    expect(init?.method).toBe('PUT')
+    expect(init?.body).toBe(serializeDashboardDocument(document))
+  })
+
+  it('reports read-only when the instance cannot save at all', async () => {
+    respondWith(
+      new Response('Dashboard configuration storage is read-only', {
+        status: 503,
+        headers: readOnly,
+      }),
+    )
+
+    expect(await saveStoredConfiguration(defaultDashboardDocument())).toEqual({
+      status: 'read-only',
+      readOnly: true,
+    })
+  })
+
+  it('reports a document the server refuses to store for its size', async () => {
+    // Distinct from a plain failure because retrying will never help: the
+    // operator has to remove panels or pages.
+    respondWith(
+      new Response('Dashboard configuration exceeds the size limit', {
+        status: 413,
+        headers: writable,
+      }),
+    )
+
+    expect(await saveStoredConfiguration(defaultDashboardDocument())).toMatchObject({
+      status: 'too-large',
+    })
+  })
+
+  it('reports a failure when the write itself failed', async () => {
+    // A writable directory that could not be written to — a full disk, say. Not
+    // read-only: retrying is worth the operator's time here.
+    respondWith(
+      new Response('Failed to save the dashboard configuration', {
+        status: 500,
+        headers: writable,
+      }),
+    )
+
+    expect(await saveStoredConfiguration(defaultDashboardDocument())).toEqual({
+      status: 'failed',
+      readOnly: false,
+    })
+  })
+
+  it('reports a failure when the server cannot be reached', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))),
+    )
+
+    expect(await saveStoredConfiguration(defaultDashboardDocument())).toEqual({
+      status: 'failed',
+      readOnly: false,
+    })
+  })
+})

--- a/frontend/src/lib/dashboard/client.ts
+++ b/frontend/src/lib/dashboard/client.ts
@@ -1,0 +1,112 @@
+/**
+ * Talking to the server about the stored configuration document.
+ *
+ * The server stores opaque bytes and knows nothing about the schema, so this
+ * layer is deliberately thin: it moves text across the wire and turns HTTP
+ * outcomes into states the UI has a message for. Making sense of the bytes is
+ * the loader's job, and it is the only reader of the schema.
+ *
+ * Every response carries the read-only header, so whether this instance can save
+ * at all is answered by the same round trip that reads or writes — the client
+ * never has to ask separately, and a directory that became unwritable after
+ * startup surfaces on the next save rather than staying stale until a reload.
+ *
+ * Nothing here reads or writes browser-local storage. The configuration is
+ * shared by everyone who opens the instance, so a per-browser copy would be an
+ * invisible second source of truth — worse than a visible failure.
+ */
+
+import { serializeDashboardDocument, type DashboardDocument } from './schema'
+
+/** The instance-scoped configuration resource. */
+export const CONFIGURATION_URL = '/api/dashboard'
+
+/** Set on every configuration response: whether storage can be written at all. */
+export const READ_ONLY_HEADER = 'x-spark-dashboard-read-only'
+
+/** What the server had when asked. */
+export type StoredConfiguration =
+  /** A document exists; `body` is its bytes, untouched. */
+  | { status: 'stored'; body: string; readOnly: boolean }
+  /** Nothing is stored. A fresh install and a reset both look like this. */
+  | { status: 'absent'; readOnly: boolean }
+  /**
+   * The server answered and could not produce the document — it has one it
+   * failed to read. The same position a document that will not parse leaves the
+   * dashboard in, and it gets the same banner.
+   */
+  | { status: 'unreadable'; readOnly: boolean }
+  /** The server was never reached, so it is not known what is stored. */
+  | { status: 'unavailable'; readOnly: boolean }
+
+/** How a save ended. */
+export interface SaveOutcome {
+  status:
+    /** Stored. */
+    | 'saved'
+    /** This instance cannot save at all; no retry will change that. */
+    | 'read-only'
+    /** Over the server's size cap. Retrying will not help either. */
+    | 'too-large'
+    /** The write failed — a full disk, a dropped connection. Worth retrying. */
+    | 'failed'
+  readOnly: boolean
+}
+
+/** Reads the stored document. Never throws: every failure is a state above. */
+export async function fetchStoredConfiguration(): Promise<StoredConfiguration> {
+  let response: Response
+  try {
+    response = await fetch(CONFIGURATION_URL)
+  } catch {
+    return { status: 'unavailable', readOnly: false }
+  }
+
+  const readOnly = isReadOnly(response)
+
+  // 204 is absence, which is not a failure and gets no banner.
+  if (response.status === 204) return { status: 'absent', readOnly }
+  // The server answered and could not hand over the document, which is what it
+  // does when reading the file failed. That is a document the operator has that
+  // cannot be read — the same thing, to them, as one that will not parse.
+  if (!response.ok) return { status: 'unreadable', readOnly }
+
+  try {
+    return { status: 'stored', body: await response.text(), readOnly }
+  } catch {
+    return { status: 'unreadable', readOnly }
+  }
+}
+
+/** Replaces the stored document. Never throws. */
+export async function saveStoredConfiguration(document: DashboardDocument): Promise<SaveOutcome> {
+  let response: Response
+  try {
+    response = await fetch(CONFIGURATION_URL, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: serializeDashboardDocument(document),
+    })
+  } catch {
+    return { status: 'failed', readOnly: false }
+  }
+
+  const readOnly = isReadOnly(response)
+
+  if (response.ok) return { status: 'saved', readOnly }
+  // The server answers 503 only for storage it knows is unwritable, so trust it
+  // over the header if the two ever disagree.
+  if (response.status === 503) return { status: 'read-only', readOnly: true }
+  if (response.status === 413) return { status: 'too-large', readOnly }
+  return { status: 'failed', readOnly }
+}
+
+/**
+ * Read-only is claimed only when the server says so in as many words. A missing
+ * header — an old server, a proxy that stripped it, a connection that never
+ * arrived — is not evidence of a permanent condition, and the banner promises
+ * one.
+ */
+function isReadOnly(response: Response): boolean {
+  return response.headers.get(READ_ONLY_HEADER) === 'true'
+}

--- a/frontend/src/lib/dashboard/notices.ts
+++ b/frontend/src/lib/dashboard/notices.ts
@@ -1,0 +1,27 @@
+/**
+ * What the operator has to be told about their configuration.
+ *
+ * This is the vocabulary the loader, the HTTP client and the save path all
+ * report into, and the only thing the banner component needs to know about any
+ * of them. It lives here rather than beside the hook that assembles it so the
+ * component depends on the domain rather than on a hook, and so the reasons the
+ * loader already speaks (`ConfigurationFallbackReason`) extend naturally.
+ */
+
+import type { ConfigurationFallbackReason } from './load'
+
+export type ConfigurationNotice =
+  /**
+   * The stored document is not the one being rendered, and why: written by a
+   * newer build, too old for any migration to reach, or unreadable — including
+   * when it was the server that could not read it.
+   */
+  | ConfigurationFallbackReason
+  /** The server was never reached, so what is stored is unknown. */
+  | { kind: 'unavailable' }
+  /** Storage is unwritable, so nothing can be saved on this instance. */
+  | { kind: 'read-only' }
+  /** The last save failed and is worth retrying. */
+  | { kind: 'save-failed' }
+  /** The last save was refused for the document's size; retrying will not help. */
+  | { kind: 'too-large' }

--- a/frontend/src/test/configurationServer.ts
+++ b/frontend/src/test/configurationServer.ts
@@ -1,0 +1,79 @@
+/**
+ * A stand-in for the dashboard-configuration endpoint, shared by every spec
+ * that drives the application through the fetch seam.
+ *
+ * It answers the way `src/server.rs` does — 204 for nothing stored, the bytes
+ * verbatim otherwise, and the read-only header on every response — so a spec
+ * describes what the server said rather than how `fetch` is shaped. One copy,
+ * because two stubs of the same endpoint under the same name and different
+ * signatures is how the specs drift from the contract they encode.
+ */
+
+import { vi } from 'vitest'
+import { READ_ONLY_HEADER } from '@/lib/dashboard/client'
+
+/** Typed with fetch's own signature, so recorded calls read as URL plus init. */
+export type FetchMock = ReturnType<
+  typeof vi.fn<(url: string, init?: RequestInit) => Promise<Response>>
+>
+
+export interface ConfigurationServerOptions {
+  /** The stored document's bytes, or null for "nothing stored" (204). */
+  document?: string | null
+  /** What the state directory reports; sets the header on every response. */
+  readOnly?: boolean
+  /** Overrides the read's status — 500 for a document the server cannot read. */
+  getStatus?: number
+  /** The write's status: 204 stored, 503 read-only, 413 too large, 500 failed. */
+  putStatus?: number
+}
+
+/** Installs the stub as the global `fetch` and hands it back for assertions. */
+export function serveConfiguration(options: ConfigurationServerOptions = {}): FetchMock {
+  const { document = null, readOnly = false, getStatus, putStatus = 204 } = options
+  const headers = { [READ_ONLY_HEADER]: String(readOnly) }
+
+  const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+    if (init?.method === 'PUT') {
+      return Promise.resolve(new Response(null, { status: putStatus, headers }))
+    }
+    if (getStatus !== undefined && getStatus !== 200) {
+      return Promise.resolve(
+        new Response('the server could not read it', { status: getStatus, headers }),
+      )
+    }
+    return Promise.resolve(
+      document === null
+        ? new Response(null, { status: 204, headers })
+        : new Response(document, { status: 200, headers }),
+    )
+  })
+
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+/** Installs a `fetch` that never reaches the server at all. */
+export function serveNothing(): FetchMock {
+  const fetchMock = vi.fn(() => Promise.reject(new TypeError('Failed to fetch')))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+/** The bodies of every write the code under test issued, in order. */
+export function configurationWrites(fetchMock: FetchMock): string[] {
+  return fetchMock.mock.calls
+    .filter(([, init]) => init?.method === 'PUT')
+    .map(([, init]) => String(init?.body))
+}
+
+/**
+ * Settles the configuration request and the render of whatever came back.
+ *
+ * Specs that expect no banner settle exactly the way the ones that expect a
+ * banner do, so a silent case cannot pass merely by asserting before the answer
+ * arrived.
+ */
+export async function configurationResponse(fetchMock: FetchMock): Promise<void> {
+  await (fetchMock.mock.results[0]?.value as Promise<Response> | undefined)?.catch(() => undefined)
+}


### PR DESCRIPTION
Closes #77. Part of the frontend rework (#70, decision record #68).

The dashboard now boots by asking the server for its configuration, and says plainly when what it is showing is not what is stored. The existing dashboard still renders throughout — the panel grid that will render the document is #79, and the save is reached by edit mode in #83.

## What it does

Every failure is a state with a banner rather than an exception. A document that cannot be read, one written by a newer build, one too old for any migration to reach, and a server that could not be asked at all each resolve to the default preset and name the problem. A fresh install is none of those: nothing stored is not a fault, so it gets the preset and silence.

"Cannot be read" deliberately covers both the document that will not parse and the read the server itself failed (`500`), because they leave the operator in one position and point at one place to look. A server that was never reached is kept separate — a different problem with a different next move.

Read-only storage is reported by the server on every response rather than asked about separately, so a state directory that lost its write permission after startup surfaces on the next save instead of staying stale until a reload. Saving on a read-only instance issues no request: the condition is permanent and already has a banner.

## What it deliberately does not do

- **No autosave**, here or in any later ticket.
- **No write-back on load.** A document that needed migrating is migrated in memory and waits for a save the operator asked for. The configuration is global, so an auto-write would let one upgraded viewer lock out everyone still on the previous build.
- **No browser-local storage**, not as a cache and not as a fallback. Both the load and the save path assert against it.
- A save the server refuses is **not adopted** — what the hook reports is what is stored, so an edit session can retry rather than discover later that only the browser believed it landed.

## Acceptance criteria

All of #77's criteria are covered, with one deviation worth flagging: *"saving is unavailable"* and the migrate-then-save criterion are asserted at the **hook** seam rather than the application root, because `App.tsx` has no save affordance to click yet. Adding one would pull edit mode (#83) into this PR.

## Testing

Four specs against the fetch seam: the client, the hook, the banner component, and the application root. The specs that expect no banner settle on the same response promise as the ones that expect one, so a silent case cannot pass merely by asserting before the answer arrived. One shared stand-in for the endpoint serves every spec, because two stubs of one endpoint drift from the contract they encode.

`npm run lint`, `npm run build` and the unit suite all pass — 381 tests across 31 files, up from 335. No `*.browser.test.tsx` changed, so the browser project does not apply.

## Metrics contract

N/A: no wire-format type, formatter or component changed.