### PR TITLE
Metrics store with selector subscriptions and per-panel time window

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,14 @@ import { useCallback, useMemo, useState } from 'react'
 import { useDashboardConfiguration } from './hooks/useDashboardConfiguration'
 import { useMetrics } from './hooks/useMetrics'
 import { useMetricsHistory } from './hooks/useMetricsHistory'
+import { MetricsStoreProvider } from './hooks/MetricsStoreProvider'
 import { ConfigurationNotices } from './components/ConfigurationNotices'
 import { ConnectionBadge } from './components/ConnectionBadge'
 import { Dashboard } from './components/views/Dashboard'
 import { LogViewer } from './components/LogViewer'
 import type { GpuEvent, InferenceRequest } from './types/events'
 
-function App() {
+function AppContent() {
   const { metrics, connectionStatus, isStale } = useMetrics()
   // The configuration is loaded and saved from here, at the root, because it is
   // one document for the whole dashboard. Nothing renders from it yet — the
@@ -87,6 +88,16 @@ function App() {
         />
       </main>
     </div>
+  )
+}
+
+// The store provider sits above everything that reads metrics history, so the
+// coming grid pages and the current dashboard share one set of ring buffers.
+function App() {
+  return (
+    <MetricsStoreProvider>
+      <AppContent />
+    </MetricsStoreProvider>
   )
 }
 

--- a/frontend/src/__tests__/LogViewer.test.tsx
+++ b/frontend/src/__tests__/LogViewer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { LogViewer } from '../components/LogViewer'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
 import type { EngineSnapshot } from '../types/metrics'
 
 const engine = (
@@ -17,44 +18,7 @@ const engine = (
   gpu_indexes: [],
 })
 
-// Mock WebSocket
-class MockWebSocket {
-  static instances: MockWebSocket[] = []
-  url: string
-  onopen: ((ev: Event) => void) | null = null
-  onmessage: ((ev: MessageEvent) => void) | null = null
-  onclose: ((ev: CloseEvent) => void) | null = null
-  onerror: ((ev: Event) => void) | null = null
-  readyState = 0
-
-  constructor(url: string) {
-    this.url = url
-    MockWebSocket.instances.push(this)
-  }
-
-  close() {
-    this.readyState = 3
-    if (this.onclose) this.onclose(new CloseEvent('close'))
-  }
-
-  send() {}
-
-  // Helper to simulate server messages
-  receive(data: string) {
-    if (this.onmessage) this.onmessage(new MessageEvent('message', { data }))
-  }
-
-  // Helper to simulate connection
-  connect() {
-    this.readyState = 1
-    if (this.onopen) this.onopen(new Event('open'))
-  }
-}
-
-// Swap the global WebSocket for the mock. `globalThis` is typed without an
-// index signature, so widen it rather than reaching for `any`.
-;(globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
-  MockWebSocket as unknown as typeof WebSocket
+substituteWebSocket()
 
 /** Expand the console (which lazily opens the socket) and return the socket. */
 function expand(): MockWebSocket {

--- a/frontend/src/__tests__/metricsHistoryStore.test.ts
+++ b/frontend/src/__tests__/metricsHistoryStore.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MetricsHistoryStore } from '../lib/metricsHistoryStore'
+import type { EngineSnapshot, MetricsSnapshot } from '../types/metrics'
+
+/** A snapshot at `ts` whose per-series values can be nulled out selectively. */
+function makeSnapshot(
+  ts: number,
+  overrides: {
+    util?: number | null
+    temp?: number | null
+    engines?: EngineSnapshot[]
+    gpu_events?: MetricsSnapshot['gpu_events']
+  } = {},
+): MetricsSnapshot {
+  const { util = 11, temp = 40, engines = [], gpu_events = [] } = overrides
+  return {
+    timestamp_ms: ts,
+    gpu: {
+      index: 0,
+      name: 'GPU 0',
+      utilization_percent: util,
+      memory_total_bytes: 24,
+      memory_used_bytes: 6,
+      temperature_celsius: temp,
+      power_watts: 100,
+      power_limit_watts: 300,
+      clock_graphics_mhz: 1800,
+      clock_sm_mhz: 1800,
+      clock_memory_mhz: 9000,
+      fan_speed_percent: 30,
+    },
+    cpu: { name: 'CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128,
+      display_total_bytes: 128,
+      used_bytes: 64,
+      available_bytes: 64,
+      cached_bytes: 8,
+      gpu_estimated_bytes: null,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: false,
+    },
+    disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
+    network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
+    engines,
+    gpu_events,
+  }
+}
+
+/** An engine whose only live series is tokens/sec; everything else is null. */
+function makeEngine(tps: number | null): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint: 'http://localhost:8000',
+    status: { type: 'Running' },
+    model: null,
+    metrics: {
+      tokens_per_sec: tps,
+      avg_tokens_per_sec: null,
+      per_request_tps: null,
+      ttft_ms: null,
+      active_requests: null,
+      queued_requests: null,
+      kv_cache_percent: null,
+      kv_cache_is_estimated: false,
+      total_requests: null,
+      e2e_latency_ms: null,
+      prompt_tokens_per_sec: null,
+      avg_prompt_tokens_per_sec: null,
+      per_request_prompt_tps: null,
+      swapped_requests: null,
+      prefix_cache_hit_rate: null,
+      queue_time_ms: null,
+      inter_token_latency_ms: null,
+      preemptions_total: null,
+      total_prompt_tokens: null,
+      total_generation_tokens: null,
+      prefix_cache_queries_total: null,
+      avg_batch_size: null,
+      ttft_percentiles: null,
+      itl_percentiles: null,
+      e2e_percentiles: null,
+      ttft_goodput_pct: null,
+      itl_goodput_pct: null,
+      e2e_goodput_pct: null,
+      ttft_buckets: null,
+      itl_buckets: null,
+      e2e_buckets: null,
+      tpot_ms: null,
+      tpot_percentiles: null,
+      tpot_goodput_pct: null,
+      tpot_buckets: null,
+      spec_decode_draft_tokens_total: null,
+      spec_decode_accepted_tokens_total: null,
+      spec_decode_drafts_total: null,
+      spec_decode_acceptance_rate: null,
+      spec_decode_acceptance_rate_live: null,
+      spec_decode_mean_acceptance_length: null,
+    },
+    recent_requests: [],
+    deployment_mode: 'Native',
+    gpu_indexes: [],
+  }
+}
+
+describe('MetricsHistoryStore windowed reads', () => {
+  it('returns more retained samples for a fifteen-minute window than a five-minute one', () => {
+    const store = new MetricsHistoryStore()
+    // 601 samples one second apart; the buffers retain all of them.
+    for (let i = 1; i <= 601; i++) {
+      store.ingest(makeSnapshot(i * 1000))
+    }
+
+    const fiveMin = store.getChartData('gpuUtil', '5m')
+    const fifteenMin = store.getChartData('gpuUtil', '15m')
+    expect(fiveMin.length).toBe(301) // now − 300s, inclusive
+    expect(fifteenMin.length).toBe(601) // window exceeds retained history
+    expect(fifteenMin.length).toBeGreaterThan(fiveMin.length)
+
+    // The window applies to every series family the same way.
+    expect(store.getChartData('gpu:0:gpuUtil', '15m').length).toBeGreaterThan(
+      store.getChartData('gpu:0:gpuUtil', '5m').length,
+    )
+
+    // Omitting the window reads the default five minutes.
+    expect(store.getChartData('gpuUtil')).toEqual(fiveMin)
+  })
+
+  it('windows engine series and events the same way', () => {
+    const store = new MetricsHistoryStore()
+    for (let i = 1; i <= 601; i++) {
+      store.ingest(
+        makeSnapshot(i * 1000, {
+          engines: [makeEngine(i)],
+          gpu_events:
+            i % 60 === 0
+              ? [{ timestamp_ms: i * 1000, gpu_index: 0, event_type: 'thermal', detail: `t${i}` }]
+              : [],
+        }),
+      )
+    }
+
+    const engineSeries = 'Vllm-http://localhost:8000:tps'
+    expect(store.getChartData(engineSeries, '15m').length).toBeGreaterThan(
+      store.getChartData(engineSeries, '5m').length,
+    )
+    expect(store.getEvents('15m').length).toBeGreaterThan(store.getEvents('5m').length)
+  })
+})
+
+describe('MetricsHistoryStore per-series subscriptions', () => {
+  it('notifies only the series a snapshot changed', () => {
+    const store = new MetricsHistoryStore()
+    store.ingest(makeSnapshot(1000))
+
+    const utilListener = vi.fn()
+    const tempListener = vi.fn()
+    store.subscribe('gpuUtil', utilListener)
+    store.subscribe('gpuTemp', tempListener)
+    const tempVersion = store.seriesVersion('gpuTemp')
+
+    // Temperature is null: that series receives no sample this snapshot.
+    store.ingest(makeSnapshot(2000, { util: 12, temp: null }))
+
+    expect(utilListener).toHaveBeenCalledTimes(1)
+    expect(tempListener).not.toHaveBeenCalled()
+    expect(store.seriesVersion('gpuUtil')).toBeGreaterThan(0)
+    expect(store.seriesVersion('gpuTemp')).toBe(tempVersion)
+    expect(store.getChartData('gpuUtil').map((p) => p.value)).toEqual([11, 12])
+    expect(store.getChartData('gpuTemp').map((p) => p.value)).toEqual([40])
+  })
+
+  it('stops notifying after unsubscribe', () => {
+    const store = new MetricsHistoryStore()
+    const listener = vi.fn()
+    const unsubscribe = store.subscribe('gpuUtil', listener)
+    store.ingest(makeSnapshot(1000))
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    store.ingest(makeSnapshot(2000))
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a snapshot with an already-ingested timestamp', () => {
+    const store = new MetricsHistoryStore()
+    const listener = vi.fn()
+    store.subscribeAll(listener)
+    store.ingest(makeSnapshot(1000))
+    store.ingest(makeSnapshot(1000, { util: 99 }))
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(store.getChartData('gpuUtil').map((p) => p.value)).toEqual([11])
+  })
+
+  it('notifies whole-store subscribers on every ingested snapshot', () => {
+    const store = new MetricsHistoryStore()
+    const listener = vi.fn()
+    const unsubscribe = store.subscribeAll(listener)
+    const before = store.ingestVersion()
+
+    store.ingest(makeSnapshot(1000))
+    store.ingest(makeSnapshot(2000))
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(store.ingestVersion()).toBe(before + 2)
+
+    unsubscribe()
+    store.ingest(makeSnapshot(3000))
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/__tests__/metricsStore.socket.test.tsx
+++ b/frontend/src/__tests__/metricsStore.socket.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { useEffect } from 'react'
+import { MetricsStoreProvider } from '../hooks/MetricsStoreProvider'
+import { useMetricSeries } from '../hooks/useMetricsStore'
+import { useMetrics } from '../hooks/useMetrics'
+import { useMetricsHistory } from '../hooks/useMetricsHistory'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+import type { MetricsSnapshot } from '../types/metrics'
+
+// The store is deliberately tested through the substituted WebSocket — the
+// same seam the log viewer spec uses — so the real ingest and subscription
+// logic runs end to end instead of being mocked away.
+substituteWebSocket()
+
+function snapshot(ts: number, util: number, temp: number | null): MetricsSnapshot {
+  return {
+    timestamp_ms: ts,
+    gpu: {
+      index: 0,
+      name: 'GPU 0',
+      utilization_percent: util,
+      temperature_celsius: temp,
+      power_watts: null,
+      power_limit_watts: null,
+      clock_graphics_mhz: null,
+      clock_sm_mhz: null,
+      clock_memory_mhz: null,
+      fan_speed_percent: null,
+    },
+    cpu: { name: 'CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128,
+      used_bytes: 64,
+      available_bytes: 64,
+      cached_bytes: 8,
+      gpu_estimated_bytes: null,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: false,
+    },
+    disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
+    network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
+    engines: [],
+    gpu_events: [],
+  }
+}
+
+/** The app's real wiring: the socket hook feeding the store, as App does. */
+function Feed() {
+  const { metrics } = useMetrics()
+  useMetricsHistory(metrics)
+  return null
+}
+
+const renderCounts: Record<string, number> = {}
+
+/** A component subscribed to a single series, the way a panel will be. The
+ *  dependency-less effect runs once per committed render, which is the count
+ *  the spec asserts on — a skipped re-render leaves it untouched. */
+function Probe({ series }: { series: string }) {
+  const data = useMetricSeries(series)
+  useEffect(() => {
+    renderCounts[series] = (renderCounts[series] ?? 0) + 1
+  })
+  return <output data-testid={series}>{data.map((p) => p.value).join(',')}</output>
+}
+
+describe('metrics store through the substituted socket', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    for (const key of Object.keys(renderCounts)) delete renderCounts[key]
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('re-renders only the subscribers of the series a snapshot changed', () => {
+    render(
+      <MetricsStoreProvider>
+        <Feed />
+        <Probe series="gpuUtil" />
+        <Probe series="gpuTemp" />
+      </MetricsStoreProvider>,
+    )
+    const socket = MockWebSocket.instances[0]
+
+    // The very first frame flushes into the UI immediately.
+    act(() => socket.receive(JSON.stringify(snapshot(1000, 11, 40))))
+    expect(screen.getByTestId('gpuUtil')).toHaveTextContent('11')
+    expect(screen.getByTestId('gpuTemp')).toHaveTextContent('40')
+
+    const utilRenders = renderCounts['gpuUtil']
+    const tempRenders = renderCounts['gpuTemp']
+
+    // The next frame carries no temperature; later frames flush on the timer.
+    act(() => {
+      socket.receive(JSON.stringify(snapshot(2000, 12, null)))
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(screen.getByTestId('gpuUtil')).toHaveTextContent('11,12')
+    expect(renderCounts['gpuUtil']).toBeGreaterThan(utilRenders)
+    // The temperature series gained nothing, so its subscriber did not render.
+    expect(renderCounts['gpuTemp']).toBe(tempRenders)
+    expect(screen.getByTestId('gpuTemp')).toHaveTextContent('40')
+  })
+})

--- a/frontend/src/__tests__/useMetricsHistory.multiGpu.test.tsx
+++ b/frontend/src/__tests__/useMetricsHistory.multiGpu.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useMetricsHistory } from '../hooks/useMetricsHistory'
+import { MetricsStoreProvider } from '../hooks/MetricsStoreProvider'
 import type { MetricsSnapshot } from '../types/metrics'
 
 const baseSnapshot: MetricsSnapshot = {
@@ -71,7 +72,10 @@ describe('useMetricsHistory multi-GPU metrics', () => {
   it('keeps per-GPU chart series separate while preserving primary GPU keys', () => {
     const { result, rerender } = renderHook(
       ({ metrics }) => useMetricsHistory(metrics),
-      { initialProps: { metrics: null as MetricsSnapshot | null } },
+      {
+        initialProps: { metrics: null as MetricsSnapshot | null },
+        wrapper: MetricsStoreProvider,
+      },
     )
 
     act(() => rerender({ metrics: baseSnapshot }))

--- a/frontend/src/hooks/MetricsStoreProvider.tsx
+++ b/frontend/src/hooks/MetricsStoreProvider.tsx
@@ -1,0 +1,10 @@
+import { useState } from 'react'
+import { MetricsHistoryStore } from '@/lib/metricsHistoryStore'
+import { MetricsStoreContext } from './useMetricsStore'
+
+/** Owns one `MetricsHistoryStore` for the tree below it. The lazy initializer
+ *  runs once; the store is never replaced, so nothing re-renders for it. */
+export function MetricsStoreProvider({ children }: { children: React.ReactNode }) {
+  const [store] = useState(() => new MetricsHistoryStore())
+  return <MetricsStoreContext.Provider value={store}>{children}</MetricsStoreContext.Provider>
+}

--- a/frontend/src/hooks/useMetricsHistory.ts
+++ b/frontend/src/hooks/useMetricsHistory.ts
@@ -1,402 +1,64 @@
-import { useRef, useState, useCallback, useEffect } from 'react'
-import { CircularBuffer } from '../lib/circular-buffer'
-import { engineKey, gpuIndexOf, snapshotGpus } from '../lib/identity'
-import type { MetricsSnapshot, GpuEventData, InferenceRequestData } from '../types/metrics'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useMetricsStore } from './useMetricsStore'
+import type { TimeWindow } from '../types/events'
+import type { GpuEventData, InferenceRequestData, MetricsSnapshot } from '../types/metrics'
 
-interface DataPoint {
-  timestamp: number
-  value: number
-}
-
-const BUFFER_CAPACITY = 900 // 15 minutes at 1 sample/sec
-const EVENT_BUFFER_CAPACITY = 100
-const REQUEST_BUFFER_CAPACITY = 50
-
-type MetricKey =
-  | 'gpuUtil'
-  | 'gpuTemp'
-  | 'gpuPower'
-  | 'gpuClockGraphics'
-  | 'cpuAggregate'
-  | 'memoryUsedPercent'
-  | 'diskRead'
-  | 'diskWrite'
-  | 'networkRx'
-  | 'networkTx'
-
-const SYSTEM_METRIC_KEYS: MetricKey[] = [
-  'gpuUtil',
-  'gpuTemp',
-  'gpuPower',
-  'gpuClockGraphics',
-  'cpuAggregate',
-  'memoryUsedPercent',
-  'diskRead',
-  'diskWrite',
-  'networkRx',
-  'networkTx',
-]
-
-function createBuffers(): Record<MetricKey, CircularBuffer<DataPoint>> {
-  const buffers = {} as Record<MetricKey, CircularBuffer<DataPoint>>
-  for (const key of SYSTEM_METRIC_KEYS) {
-    buffers[key] = new CircularBuffer<DataPoint>(BUFFER_CAPACITY)
-  }
-  return buffers
-}
-
-function extractGpuValue(gpu: MetricsSnapshot['gpu'], key: MetricKey): number | null {
-  switch (key) {
-    case 'gpuUtil':
-      return gpu.utilization_percent
-    case 'gpuTemp':
-      return gpu.temperature_celsius
-    case 'gpuPower':
-      return gpu.power_watts
-    case 'gpuClockGraphics':
-      return gpu.clock_graphics_mhz
-    default:
-      return null
-  }
-}
-
-function extractValue(metrics: MetricsSnapshot, key: MetricKey): number | null {
-  switch (key) {
-    case 'gpuUtil':
-    case 'gpuTemp':
-    case 'gpuPower':
-    case 'gpuClockGraphics':
-      return extractGpuValue(metrics.gpu, key)
-    case 'cpuAggregate':
-      return metrics.cpu.aggregate_percent
-    case 'memoryUsedPercent':
-      return metrics.memory.total_bytes > 0
-        ? (metrics.memory.used_bytes / metrics.memory.total_bytes) * 100
-        : null
-    case 'diskRead':
-      return metrics.disk.read_bytes_per_sec
-    case 'diskWrite':
-      return metrics.disk.write_bytes_per_sec
-    case 'networkRx':
-      return metrics.network.rx_bytes_per_sec
-    case 'networkTx':
-      return metrics.network.tx_bytes_per_sec
-  }
-}
-
-const DEFAULT_WINDOW_SECONDS = 300 // 5 minutes
-
-export function useMetricsHistory(
-  metrics: MetricsSnapshot | null,
-) {
-  const buffersRef = useRef(createBuffers())
-  const gpuBuffersRef = useRef<
-    Record<string, Record<MetricKey, CircularBuffer<DataPoint>>>
-  >({})
-  const engineBuffersRef = useRef<
-    Record<string, Record<string, CircularBuffer<DataPoint>>>
-  >({})
-  const eventBufferRef = useRef(
-    new CircularBuffer<GpuEventData>(EVENT_BUFFER_CAPACITY),
-  )
-  const requestBuffersRef = useRef<
-    Record<string, CircularBuffer<InferenceRequestData>>
-  >({})
-  const lastTimestampRef = useRef<number>(0)
-  const [version, setVersion] = useState(0)
+/**
+ * Feeds incoming snapshots into the metrics store and exposes its read
+ * accessors to the pre-grid dashboard, which reads many series from one
+ * component and therefore subscribes to every ingested snapshot — exactly the
+ * granularity it had before the store existed. Panels that want one series
+ * subscribe through `useMetricSeries` instead.
+ */
+export function useMetricsHistory(metrics: MetricsSnapshot | null) {
+  const store = useMetricsStore()
 
   useEffect(() => {
-    if (!metrics || metrics.timestamp_ms === lastTimestampRef.current) return
-    lastTimestampRef.current = metrics.timestamp_ms
+    if (metrics) store.ingest(metrics)
+  }, [store, metrics])
 
-    const ts = metrics.timestamp_ms
-    const buffers = buffersRef.current
+  const subscribeAll = useCallback(
+    (listener: () => void) => store.subscribeAll(listener),
+    [store],
+  )
+  const getIngestVersion = useCallback(() => store.ingestVersion(), [store])
+  const version = useSyncExternalStore(subscribeAll, getIngestVersion)
 
-    for (const key of SYSTEM_METRIC_KEYS) {
-      const val = extractValue(metrics, key)
-      if (val !== null) {
-        buffers[key].push({ timestamp: ts, value: val })
-      }
-    }
-
-    for (const gpu of snapshotGpus(metrics)) {
-      const gpuKey = String(gpuIndexOf(gpu))
-      if (!gpuBuffersRef.current[gpuKey]) {
-        gpuBuffersRef.current[gpuKey] = createBuffers()
-      }
-      const gb = gpuBuffersRef.current[gpuKey]
-      for (const key of ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics'] as MetricKey[]) {
-        const val = extractGpuValue(gpu, key)
-        if (val !== null) {
-          gb[key].push({ timestamp: ts, value: val })
-        }
-      }
-    }
-
-    // Engine-specific metrics
-    for (const engine of metrics.engines) {
-      const key = engineKey(engine)
-      if (!engineBuffersRef.current[key]) {
-        engineBuffersRef.current[key] = {
-          tps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          avgTps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          perReqTps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          ttft: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          kvCache: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          prefixCacheHit: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          e2eLatency: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          promptTps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          avgPromptTps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          perReqPromptTps: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          queueTime: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          interTokenLatency: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          batchSize: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          ttftP50: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          ttftP95: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          ttftP99: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          itlP50: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          itlP95: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          itlP99: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          e2eP50: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          e2eP95: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          e2eP99: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          tpot: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          tpotP50: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          tpotP95: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          tpotP99: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          activeRequests: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          queuedRequests: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-          totalRequests: new CircularBuffer<DataPoint>(BUFFER_CAPACITY),
-        }
-      }
-      const eb = engineBuffersRef.current[key]
-      if (engine.metrics) {
-        if (engine.metrics.tokens_per_sec !== null) {
-          eb.tps.push({ timestamp: ts, value: engine.metrics.tokens_per_sec })
-        }
-        if (engine.metrics.avg_tokens_per_sec !== null) {
-          eb.avgTps.push({ timestamp: ts, value: engine.metrics.avg_tokens_per_sec })
-        }
-        if (engine.metrics.per_request_tps !== null) {
-          eb.perReqTps.push({ timestamp: ts, value: engine.metrics.per_request_tps })
-        }
-        if (engine.metrics.ttft_ms !== null) {
-          eb.ttft.push({ timestamp: ts, value: engine.metrics.ttft_ms })
-        }
-        if (engine.metrics.kv_cache_percent !== null) {
-          eb.kvCache.push({
-            timestamp: ts,
-            value: engine.metrics.kv_cache_percent,
-          })
-        }
-        if (engine.metrics.prefix_cache_hit_rate !== null) {
-          eb.prefixCacheHit.push({
-            timestamp: ts,
-            value: engine.metrics.prefix_cache_hit_rate,
-          })
-        }
-        if (engine.metrics.e2e_latency_ms !== null) {
-          eb.e2eLatency.push({ timestamp: ts, value: engine.metrics.e2e_latency_ms })
-        }
-        if (engine.metrics.prompt_tokens_per_sec !== null) {
-          eb.promptTps.push({ timestamp: ts, value: engine.metrics.prompt_tokens_per_sec })
-        }
-        if (engine.metrics.avg_prompt_tokens_per_sec !== null) {
-          eb.avgPromptTps.push({ timestamp: ts, value: engine.metrics.avg_prompt_tokens_per_sec })
-        }
-        if (engine.metrics.per_request_prompt_tps !== null) {
-          eb.perReqPromptTps.push({ timestamp: ts, value: engine.metrics.per_request_prompt_tps })
-        }
-        if (engine.metrics.queue_time_ms !== null) {
-          eb.queueTime.push({ timestamp: ts, value: engine.metrics.queue_time_ms })
-        }
-        if (engine.metrics.inter_token_latency_ms !== null) {
-          eb.interTokenLatency.push({ timestamp: ts, value: engine.metrics.inter_token_latency_ms })
-        }
-        if (engine.metrics.avg_batch_size !== null) {
-          eb.batchSize.push({ timestamp: ts, value: engine.metrics.avg_batch_size })
-        }
-        if (engine.metrics.tpot_ms !== null) {
-          eb.tpot.push({ timestamp: ts, value: engine.metrics.tpot_ms })
-        }
-        const tp = engine.metrics.ttft_percentiles
-        if (tp) {
-          if (tp.p50_ms !== null) eb.ttftP50.push({ timestamp: ts, value: tp.p50_ms })
-          if (tp.p95_ms !== null) eb.ttftP95.push({ timestamp: ts, value: tp.p95_ms })
-          if (tp.p99_ms !== null) eb.ttftP99.push({ timestamp: ts, value: tp.p99_ms })
-        }
-        const ip = engine.metrics.itl_percentiles
-        if (ip) {
-          if (ip.p50_ms !== null) eb.itlP50.push({ timestamp: ts, value: ip.p50_ms })
-          if (ip.p95_ms !== null) eb.itlP95.push({ timestamp: ts, value: ip.p95_ms })
-          if (ip.p99_ms !== null) eb.itlP99.push({ timestamp: ts, value: ip.p99_ms })
-        }
-        const ep = engine.metrics.e2e_percentiles
-        if (ep) {
-          if (ep.p50_ms !== null) eb.e2eP50.push({ timestamp: ts, value: ep.p50_ms })
-          if (ep.p95_ms !== null) eb.e2eP95.push({ timestamp: ts, value: ep.p95_ms })
-          if (ep.p99_ms !== null) eb.e2eP99.push({ timestamp: ts, value: ep.p99_ms })
-        }
-        const pp = engine.metrics.tpot_percentiles
-        if (pp) {
-          if (pp.p50_ms !== null) eb.tpotP50.push({ timestamp: ts, value: pp.p50_ms })
-          if (pp.p95_ms !== null) eb.tpotP95.push({ timestamp: ts, value: pp.p95_ms })
-          if (pp.p99_ms !== null) eb.tpotP99.push({ timestamp: ts, value: pp.p99_ms })
-        }
-        if (engine.metrics.active_requests !== null) {
-          eb.activeRequests.push({ timestamp: ts, value: engine.metrics.active_requests })
-        }
-        if (engine.metrics.queued_requests !== null) {
-          eb.queuedRequests.push({ timestamp: ts, value: engine.metrics.queued_requests })
-        }
-        if (engine.metrics.total_requests !== null) {
-          eb.totalRequests.push({ timestamp: ts, value: engine.metrics.total_requests })
-        }
-      }
-
-      // Accumulate per-engine inference requests
-      if (engine.recent_requests && engine.recent_requests.length > 0) {
-        if (!requestBuffersRef.current[key]) {
-          requestBuffersRef.current[key] =
-            new CircularBuffer<InferenceRequestData>(REQUEST_BUFFER_CAPACITY)
-        }
-        for (const req of engine.recent_requests) {
-          requestBuffersRef.current[key].push(req)
-        }
-      }
-    }
-
-    // Accumulate GPU events
-    if (metrics.gpu_events && metrics.gpu_events.length > 0) {
-      for (const event of metrics.gpu_events) {
-        eventBufferRef.current.push(event)
-      }
-    }
-
-    setVersion((v) => v + 1)
-  }, [metrics])
-
+  // The accessors change identity with every ingested snapshot, so memoized
+  // consumers (the event and request mappings in App) recompute exactly as
+  // often as they did under the old version counter.
   const getChartData = useCallback(
-    (metric: string): DataPoint[] => {
-      // Force dependency on version for reactivity
+    (metric: string, window?: TimeWindow) => {
       void version
-
-      const windowMs = DEFAULT_WINDOW_SECONDS * 1000
-      const now = lastTimestampRef.current
-      const cutoff = now - windowMs
-
-      // Check system metrics
-      const systemBuffer =
-        buffersRef.current[metric as MetricKey]
-      if (systemBuffer) {
-        return systemBuffer
-          .toArray()
-          .filter((dp) => dp.timestamp >= cutoff)
-      }
-
-      const gpuMatch = metric.match(/^gpu:(\d+):(gpuUtil|gpuTemp|gpuPower|gpuClockGraphics)$/)
-      if (gpuMatch) {
-        const gb = gpuBuffersRef.current[gpuMatch[1]]
-        const buffer = gb?.[gpuMatch[2] as MetricKey]
-        if (buffer) {
-          return buffer
-            .toArray()
-            .filter((dp) => dp.timestamp >= cutoff)
-        }
-      }
-
-      // Check engine metrics (format: "engineKey:metricName")
-      const colonIndex = metric.lastIndexOf(':')
-      if (colonIndex > 0) {
-        const key = metric.substring(0, colonIndex)
-        const metricName = metric.substring(colonIndex + 1)
-        const eb = engineBuffersRef.current[key]
-        if (eb && eb[metricName]) {
-          return eb[metricName]
-            .toArray()
-            .filter((dp) => dp.timestamp >= cutoff)
-        }
-      }
-
-      return []
+      return store.getChartData(metric, window)
     },
-    [version],
+    [store, version],
   )
 
   const getSparklineData = useCallback(
     (metric: string, count = 30): number[] => {
       void version
-
-      const systemBuffer =
-        buffersRef.current[metric as MetricKey]
-      if (systemBuffer) {
-        return systemBuffer.last(count).map((dp) => dp.value)
-      }
-
-      const gpuMatch = metric.match(/^gpu:(\d+):(gpuUtil|gpuTemp|gpuPower|gpuClockGraphics)$/)
-      if (gpuMatch) {
-        const gb = gpuBuffersRef.current[gpuMatch[1]]
-        const buffer = gb?.[gpuMatch[2] as MetricKey]
-        if (buffer) {
-          return buffer.last(count).map((dp) => dp.value)
-        }
-      }
-
-      const colonIndex = metric.lastIndexOf(':')
-      if (colonIndex > 0) {
-        const key = metric.substring(0, colonIndex)
-        const metricName = metric.substring(colonIndex + 1)
-        const eb = engineBuffersRef.current[key]
-        if (eb && eb[metricName]) {
-          return eb[metricName].last(count).map((dp) => dp.value)
-        }
-      }
-
-      return []
+      return store.getSparklineData(metric, count)
     },
-    [version],
+    [store, version],
   )
 
-  const getEvents = useCallback((): GpuEventData[] => {
-    void version
-
-    const windowMs = DEFAULT_WINDOW_SECONDS * 1000
-    const now = lastTimestampRef.current
-    const cutoff = now - windowMs
-
-    return eventBufferRef.current
-      .toArray()
-      .filter((e) => e.timestamp_ms >= cutoff)
-  }, [version])
+  const getEvents = useCallback(
+    (window?: TimeWindow): GpuEventData[] => {
+      void version
+      return store.getEvents(window)
+    },
+    [store, version],
+  )
 
   /** Recent requests, optionally narrowed to one engine. `key` is an engine
    *  key as produced by `engineKey()`; omit it for every engine's requests. */
   const getRequests = useCallback(
-    (key?: string): InferenceRequestData[] => {
+    (key?: string, window?: TimeWindow): InferenceRequestData[] => {
       void version
-
-      const windowMs = DEFAULT_WINDOW_SECONDS * 1000
-      const now = lastTimestampRef.current
-      const cutoff = now - windowMs
-
-      if (key) {
-        const buf = requestBuffersRef.current[key]
-        if (!buf) return []
-        return buf.toArray().filter((r) => r.end_ms >= cutoff)
-      }
-
-      // Return all engines' requests
-      const all: InferenceRequestData[] = []
-      for (const buf of Object.values(requestBuffersRef.current)) {
-        for (const r of buf.toArray()) {
-          if (r.end_ms >= cutoff) {
-            all.push(r)
-          }
-        }
-      }
-      return all
+      return store.getRequests(key, window)
     },
-    [version],
+    [store, version],
   )
 
   return { getChartData, getSparklineData, getEvents, getRequests }

--- a/frontend/src/hooks/useMetricsStore.ts
+++ b/frontend/src/hooks/useMetricsStore.ts
@@ -1,0 +1,45 @@
+import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from 'react'
+import { MetricsHistoryStore, type DataPoint } from '@/lib/metricsHistoryStore'
+import { DEFAULT_TIME_WINDOW } from '@/lib/dashboard/schema'
+import type { TimeWindow } from '@/types/events'
+
+/**
+ * The metrics history store, provided through context rather than a module
+ * singleton so every test (and any future second root) gets its own instance.
+ * The store itself lives outside React — see `MetricsHistoryStore`.
+ *
+ * Exported only for `MetricsStoreProvider`, which lives in its own file
+ * because a component and hooks cannot share one without breaking fast
+ * refresh; read the store through `useMetricsStore`.
+ */
+export const MetricsStoreContext = createContext<MetricsHistoryStore | null>(null)
+
+export function useMetricsStore(): MetricsHistoryStore {
+  const store = useContext(MetricsStoreContext)
+  if (!store) {
+    throw new Error('useMetricsStore requires a <MetricsStoreProvider> above it')
+  }
+  return store
+}
+
+/**
+ * One chart series over the given time window, re-rendering only when that
+ * series gains data. This is the subscription a panel uses: a snapshot that
+ * changes other series does not touch this component.
+ */
+export function useMetricSeries(
+  series: string,
+  window: TimeWindow = DEFAULT_TIME_WINDOW,
+): DataPoint[] {
+  const store = useMetricsStore()
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribe(series, listener),
+    [store, series],
+  )
+  const getVersion = useCallback(() => store.seriesVersion(series), [store, series])
+  const version = useSyncExternalStore(subscribe, getVersion)
+  return useMemo(() => {
+    void version // the series changed; re-read the window
+    return store.getChartData(series, window)
+  }, [store, series, window, version])
+}

--- a/frontend/src/lib/metricsHistoryStore.ts
+++ b/frontend/src/lib/metricsHistoryStore.ts
@@ -1,0 +1,353 @@
+import { CircularBuffer } from './circular-buffer'
+import { DEFAULT_TIME_WINDOW } from './dashboard/schema'
+import { engineKey, gpuIndexOf, snapshotGpus } from './identity'
+import { TIME_WINDOW_SECONDS, type TimeWindow } from '@/types/events'
+import type { GpuEventData, InferenceRequestData, MetricsSnapshot } from '@/types/metrics'
+
+export interface DataPoint {
+  timestamp: number
+  value: number
+}
+
+const BUFFER_CAPACITY = 900 // 15 minutes at 1 sample/sec
+const EVENT_BUFFER_CAPACITY = 100
+const REQUEST_BUFFER_CAPACITY = 50
+
+type MetricKey =
+  | 'gpuUtil'
+  | 'gpuTemp'
+  | 'gpuPower'
+  | 'gpuClockGraphics'
+  | 'cpuAggregate'
+  | 'memoryUsedPercent'
+  | 'diskRead'
+  | 'diskWrite'
+  | 'networkRx'
+  | 'networkTx'
+
+const SYSTEM_METRIC_KEYS: MetricKey[] = [
+  'gpuUtil',
+  'gpuTemp',
+  'gpuPower',
+  'gpuClockGraphics',
+  'cpuAggregate',
+  'memoryUsedPercent',
+  'diskRead',
+  'diskWrite',
+  'networkRx',
+  'networkTx',
+]
+
+const GPU_METRIC_KEYS: MetricKey[] = ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics']
+
+type EngineMetricsShape = NonNullable<MetricsSnapshot['engines'][number]['metrics']>
+
+/**
+ * Every engine series and where its sample comes from on a snapshot. The
+ * buffer set is created from this table too, so the series names and the
+ * field mapping cannot drift apart.
+ */
+const ENGINE_SERIES: ReadonlyArray<readonly [string, (m: EngineMetricsShape) => number | null]> = [
+  ['tps', (m) => m.tokens_per_sec],
+  ['avgTps', (m) => m.avg_tokens_per_sec],
+  ['perReqTps', (m) => m.per_request_tps],
+  ['ttft', (m) => m.ttft_ms],
+  ['kvCache', (m) => m.kv_cache_percent],
+  ['prefixCacheHit', (m) => m.prefix_cache_hit_rate],
+  ['e2eLatency', (m) => m.e2e_latency_ms],
+  ['promptTps', (m) => m.prompt_tokens_per_sec],
+  ['avgPromptTps', (m) => m.avg_prompt_tokens_per_sec],
+  ['perReqPromptTps', (m) => m.per_request_prompt_tps],
+  ['queueTime', (m) => m.queue_time_ms],
+  ['interTokenLatency', (m) => m.inter_token_latency_ms],
+  ['batchSize', (m) => m.avg_batch_size],
+  ['ttftP50', (m) => m.ttft_percentiles?.p50_ms ?? null],
+  ['ttftP95', (m) => m.ttft_percentiles?.p95_ms ?? null],
+  ['ttftP99', (m) => m.ttft_percentiles?.p99_ms ?? null],
+  ['itlP50', (m) => m.itl_percentiles?.p50_ms ?? null],
+  ['itlP95', (m) => m.itl_percentiles?.p95_ms ?? null],
+  ['itlP99', (m) => m.itl_percentiles?.p99_ms ?? null],
+  ['e2eP50', (m) => m.e2e_percentiles?.p50_ms ?? null],
+  ['e2eP95', (m) => m.e2e_percentiles?.p95_ms ?? null],
+  ['e2eP99', (m) => m.e2e_percentiles?.p99_ms ?? null],
+  ['tpot', (m) => m.tpot_ms],
+  ['tpotP50', (m) => m.tpot_percentiles?.p50_ms ?? null],
+  ['tpotP95', (m) => m.tpot_percentiles?.p95_ms ?? null],
+  ['tpotP99', (m) => m.tpot_percentiles?.p99_ms ?? null],
+  ['activeRequests', (m) => m.active_requests],
+  ['queuedRequests', (m) => m.queued_requests],
+  ['totalRequests', (m) => m.total_requests],
+]
+
+/** The series key of the event buffer, for subscriptions. */
+export const EVENTS_SERIES = 'events'
+
+/** The series key of one engine's request buffer (`requests` alone: all engines). */
+export function requestsSeries(key?: string): string {
+  return key ? `requests:${key}` : 'requests'
+}
+
+function createBuffers(): Record<MetricKey, CircularBuffer<DataPoint>> {
+  const buffers = {} as Record<MetricKey, CircularBuffer<DataPoint>>
+  for (const key of SYSTEM_METRIC_KEYS) {
+    buffers[key] = new CircularBuffer<DataPoint>(BUFFER_CAPACITY)
+  }
+  return buffers
+}
+
+function createEngineBuffers(): Record<string, CircularBuffer<DataPoint>> {
+  const buffers: Record<string, CircularBuffer<DataPoint>> = {}
+  for (const [name] of ENGINE_SERIES) {
+    buffers[name] = new CircularBuffer<DataPoint>(BUFFER_CAPACITY)
+  }
+  return buffers
+}
+
+function extractGpuValue(gpu: MetricsSnapshot['gpu'], key: MetricKey): number | null {
+  switch (key) {
+    case 'gpuUtil':
+      return gpu.utilization_percent
+    case 'gpuTemp':
+      return gpu.temperature_celsius
+    case 'gpuPower':
+      return gpu.power_watts
+    case 'gpuClockGraphics':
+      return gpu.clock_graphics_mhz
+    default:
+      return null
+  }
+}
+
+function extractValue(metrics: MetricsSnapshot, key: MetricKey): number | null {
+  switch (key) {
+    case 'gpuUtil':
+    case 'gpuTemp':
+    case 'gpuPower':
+    case 'gpuClockGraphics':
+      return extractGpuValue(metrics.gpu, key)
+    case 'cpuAggregate':
+      return metrics.cpu.aggregate_percent
+    case 'memoryUsedPercent':
+      return metrics.memory.total_bytes > 0
+        ? (metrics.memory.used_bytes / metrics.memory.total_bytes) * 100
+        : null
+    case 'diskRead':
+      return metrics.disk.read_bytes_per_sec
+    case 'diskWrite':
+      return metrics.disk.write_bytes_per_sec
+    case 'networkRx':
+      return metrics.network.rx_bytes_per_sec
+    case 'networkTx':
+      return metrics.network.tx_bytes_per_sec
+  }
+}
+
+/**
+ * The metrics history: every series the dashboard can chart, held in ring
+ * buffers outside React, with per-series subscriptions.
+ *
+ * This is the external store behind React's `useSyncExternalStore`. Ingesting
+ * a snapshot appends to whichever series carry a value and notifies only those
+ * series' subscribers, so a panel subscribed to one series does not re-render
+ * when a snapshot changes a different one. The previous shape — one global
+ * version counter inside a hook — invalidated every consumer on every flush.
+ *
+ * Series keys are the vocabulary `getChartData` always accepted:
+ * system series (`gpuUtil`), per-GPU series (`gpu:<index>:gpuUtil`), engine
+ * series (`<engineKey>:tps`), plus `events` and `requests[:<engineKey>]`.
+ *
+ * Reads take a `TimeWindow`. The buffers retain the largest window (15 min);
+ * the window is purely a read-side filter.
+ */
+export class MetricsHistoryStore {
+  private buffers = createBuffers()
+  private gpuBuffers: Record<string, Record<MetricKey, CircularBuffer<DataPoint>>> = {}
+  private engineBuffers: Record<string, Record<string, CircularBuffer<DataPoint>>> = {}
+  private eventBuffer = new CircularBuffer<GpuEventData>(EVENT_BUFFER_CAPACITY)
+  private requestBuffers: Record<string, CircularBuffer<InferenceRequestData>> = {}
+  private lastTimestamp = 0
+  private ingested = 0
+  private versions = new Map<string, number>()
+  private seriesListeners = new Map<string, Set<() => void>>()
+  private allListeners = new Set<() => void>()
+
+  /**
+   * Append one snapshot to every series it carries a value for, then notify
+   * the changed series' subscribers. A snapshot with an already-seen timestamp
+   * is a re-render artifact, not new data, and is ignored.
+   */
+  ingest(metrics: MetricsSnapshot): void {
+    if (metrics.timestamp_ms === this.lastTimestamp) return
+    this.lastTimestamp = metrics.timestamp_ms
+
+    const ts = metrics.timestamp_ms
+    const changed = new Set<string>()
+
+    for (const key of SYSTEM_METRIC_KEYS) {
+      const val = extractValue(metrics, key)
+      if (val !== null) {
+        this.buffers[key].push({ timestamp: ts, value: val })
+        changed.add(key)
+      }
+    }
+
+    for (const gpu of snapshotGpus(metrics)) {
+      const gpuKey = String(gpuIndexOf(gpu))
+      if (!this.gpuBuffers[gpuKey]) {
+        this.gpuBuffers[gpuKey] = createBuffers()
+      }
+      const gb = this.gpuBuffers[gpuKey]
+      for (const key of GPU_METRIC_KEYS) {
+        const val = extractGpuValue(gpu, key)
+        if (val !== null) {
+          gb[key].push({ timestamp: ts, value: val })
+          changed.add(`gpu:${gpuKey}:${key}`)
+        }
+      }
+    }
+
+    for (const engine of metrics.engines) {
+      const key = engineKey(engine)
+      if (!this.engineBuffers[key]) {
+        this.engineBuffers[key] = createEngineBuffers()
+      }
+      const eb = this.engineBuffers[key]
+      if (engine.metrics) {
+        for (const [name, sample] of ENGINE_SERIES) {
+          const val = sample(engine.metrics)
+          if (val !== null) {
+            eb[name].push({ timestamp: ts, value: val })
+            changed.add(`${key}:${name}`)
+          }
+        }
+      }
+
+      if (engine.recent_requests && engine.recent_requests.length > 0) {
+        if (!this.requestBuffers[key]) {
+          this.requestBuffers[key] = new CircularBuffer<InferenceRequestData>(
+            REQUEST_BUFFER_CAPACITY,
+          )
+        }
+        for (const req of engine.recent_requests) {
+          this.requestBuffers[key].push(req)
+        }
+        changed.add(requestsSeries(key))
+        changed.add(requestsSeries())
+      }
+    }
+
+    if (metrics.gpu_events && metrics.gpu_events.length > 0) {
+      for (const event of metrics.gpu_events) {
+        this.eventBuffer.push(event)
+      }
+      changed.add(EVENTS_SERIES)
+    }
+
+    this.ingested++
+    for (const series of changed) {
+      this.versions.set(series, (this.versions.get(series) ?? 0) + 1)
+    }
+    // Notify after all versions are bumped, so a listener that reads several
+    // series during its re-render sees one consistent snapshot.
+    for (const series of changed) {
+      const listeners = this.seriesListeners.get(series)
+      if (listeners) for (const listener of listeners) listener()
+    }
+    for (const listener of this.allListeners) listener()
+  }
+
+  /** Subscribe to one series. The listener fires when that series gains data. */
+  subscribe(series: string, listener: () => void): () => void {
+    let listeners = this.seriesListeners.get(series)
+    if (!listeners) {
+      listeners = new Set()
+      this.seriesListeners.set(series, listeners)
+    }
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  /** Subscribe to every ingested snapshot — the whole-dashboard equivalent of
+   *  the old global version counter, for consumers that read many series. */
+  subscribeAll(listener: () => void): () => void {
+    this.allListeners.add(listener)
+    return () => {
+      this.allListeners.delete(listener)
+    }
+  }
+
+  /** Monotonic per-series counter; the `getSnapshot` for a series subscription. */
+  seriesVersion(series: string): number {
+    return this.versions.get(series) ?? 0
+  }
+
+  /** Count of ingested snapshots; the `getSnapshot` for `subscribeAll`. */
+  ingestVersion(): number {
+    return this.ingested
+  }
+
+  private cutoff(window: TimeWindow): number {
+    return this.lastTimestamp - TIME_WINDOW_SECONDS[window] * 1000
+  }
+
+  /** The buffer a series key names: a system series (`gpuUtil`), a per-GPU
+   *  series (`gpu:<index>:gpuUtil`), or an engine series (`<engineKey>:tps`). */
+  private resolveBuffer(metric: string): CircularBuffer<DataPoint> | undefined {
+    const systemBuffer = this.buffers[metric as MetricKey]
+    if (systemBuffer) return systemBuffer
+
+    const gpuMatch = metric.match(/^gpu:(\d+):(gpuUtil|gpuTemp|gpuPower|gpuClockGraphics)$/)
+    if (gpuMatch) {
+      return this.gpuBuffers[gpuMatch[1]]?.[gpuMatch[2] as MetricKey]
+    }
+
+    const colonIndex = metric.lastIndexOf(':')
+    if (colonIndex > 0) {
+      return this.engineBuffers[metric.substring(0, colonIndex)]?.[
+        metric.substring(colonIndex + 1)
+      ]
+    }
+
+    return undefined
+  }
+
+  getChartData(metric: string, window: TimeWindow = DEFAULT_TIME_WINDOW): DataPoint[] {
+    const buffer = this.resolveBuffer(metric)
+    if (!buffer) return []
+    const cutoff = this.cutoff(window)
+    return buffer.toArray().filter((dp) => dp.timestamp >= cutoff)
+  }
+
+  getSparklineData(metric: string, count = 30): number[] {
+    return this.resolveBuffer(metric)?.last(count).map((dp) => dp.value) ?? []
+  }
+
+  getEvents(window: TimeWindow = DEFAULT_TIME_WINDOW): GpuEventData[] {
+    const cutoff = this.cutoff(window)
+    return this.eventBuffer.toArray().filter((e) => e.timestamp_ms >= cutoff)
+  }
+
+  /** Recent requests, optionally narrowed to one engine. `key` is an engine
+   *  key as produced by `engineKey()`; omit it for every engine's requests. */
+  getRequests(key?: string, window: TimeWindow = DEFAULT_TIME_WINDOW): InferenceRequestData[] {
+    const cutoff = this.cutoff(window)
+
+    if (key) {
+      const buf = this.requestBuffers[key]
+      if (!buf) return []
+      return buf.toArray().filter((r) => r.end_ms >= cutoff)
+    }
+
+    const all: InferenceRequestData[] = []
+    for (const buf of Object.values(this.requestBuffers)) {
+      for (const r of buf.toArray()) {
+        if (r.end_ms >= cutoff) {
+          all.push(r)
+        }
+      }
+    }
+    return all
+  }
+}

--- a/frontend/src/test/websocket.ts
+++ b/frontend/src/test/websocket.ts
@@ -1,0 +1,48 @@
+/**
+ * A stand-in for the browser WebSocket, shared by every spec that drives the
+ * application through the socket seam — the log viewer's log stream and the
+ * metrics feed both arrive this way.
+ *
+ * One copy, for the same reason `configurationServer.ts` is one copy: two
+ * substitutes of the same seam under the same name and different behavior is
+ * how the specs drift from the contract they encode.
+ */
+export class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  readyState = 0
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  close() {
+    this.readyState = 3
+    if (this.onclose) this.onclose(new CloseEvent('close'))
+  }
+
+  send() {}
+
+  /** Simulate a server message. */
+  receive(data: string) {
+    if (this.onmessage) this.onmessage(new MessageEvent('message', { data }))
+  }
+
+  /** Simulate the connection opening. */
+  connect() {
+    this.readyState = 1
+    if (this.onopen) this.onopen(new Event('open'))
+  }
+}
+
+/** Swap the global WebSocket for the mock. `globalThis` is typed without an
+ *  index signature, so widen it rather than reaching for `any`. */
+export function substituteWebSocket(): void {
+  ;(globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+    MockWebSocket as unknown as typeof WebSocket
+}


### PR DESCRIPTION
Closes #78. Spec: #70, decision record: #68.

## What this does

- **`MetricsHistoryStore`** (`frontend/src/lib/metricsHistoryStore.ts`): the ring buffers move out of `useMetricsHistory` into a framework-free external store. Ingest appends to whichever series carry a value and notifies only those series' subscribers — the single global version counter that invalidated every consumer on every flush is gone.
- **Windowed reads**: `getChartData`/`getEvents`/`getRequests` take a `TimeWindow`. The previously unused `TimeWindow`/`TIME_WINDOW_SECONDS` vocabulary from `types/events.ts` is now the one in use, defaulting to the schema's `DEFAULT_TIME_WINDOW` ('5m'); the hardcoded 300 s is deleted. The buffers already retain 15 minutes, so the window is purely a read-side filter. (Sparklines stay count-based by design.)
- **`useMetricSeries`** (via `useSyncExternalStore`, no new dependency): the per-panel subscription — one series over one window, re-rendering only when that series gains data. The store lives in a context provider owned by App so every test and the coming grid route (#79) share one instance per tree.
- **Behaviour preserved exactly**: `useMetricsHistory` becomes a thin adapter that ingests and subscribes to every snapshot, so the pre-grid dashboard keeps its exact rendering cadence. `Dashboard`/`EngineSection` and their specs are untouched.

## Acceptance criteria

- ✅ Per-series subscription proven end to end: the new spec substitutes the global `WebSocket` (the log viewer's seam) and asserts a snapshot that changes only `gpuUtil` does not re-render the `gpuTemp` subscriber — real ingest and subscription logic, nothing mocked away
- ✅ 15-minute reads return more retained samples than 5-minute reads (301 vs 601 in the store spec)
- ✅ One definition each: `TimeWindow`/`TIME_WINDOW_SECONDS` (`types/events.ts`), `DEFAULT_TIME_WINDOW` (`lib/dashboard/schema.ts`)
- ✅ Existing specs pass with mechanical edits only (provider wrapper in the history spec; the log viewer spec now imports the shared `MockWebSocket` from `src/test/websocket.ts` instead of its own copy)
- ✅ `npm run lint && npm run build && npm test -- --run` green locally (33 files, 388 tests)

## Review notes

- Two-axis review (standards + spec) ran before push; its duplication findings are folded in: one shared WebSocket substitute, one engine-series name/extractor table, one series resolver for chart+sparkline reads.
- `useMetricSeries`, `EVENTS_SERIES` and `requestsSeries()` have no production consumer yet, deliberately — the panels that subscribe per-series arrive with #79/#80; the current dashboard must keep its exact behaviour, which the `subscribeAll` path preserves.

Rebase-merge; both commits are valid Conventional Commits.