### PR TITLE
feat(frontend): grid page shell and routing, built at a second route

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@base-ui/react": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "gridstack": "13.2.0",
         "lucide-react": "^1.21.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -4639,6 +4640,22 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gridstack": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-13.2.0.tgz",
+      "integrity": "sha512-+ImmOx6qd1wiF0EagY7e/pPdngh/6s0FM+r9hh4d8AsXslO51iHEuoAF7CMrXCFr0Xqd0X4WS/bqRLXtEUThug==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.me/alaind831"
+        },
+        {
+          "type": "venmo",
+          "url": "https://www.venmo.com/adumesny"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@base-ui/react": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "gridstack": "13.2.0",
     "lucide-react": "^1.21.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,10 +2,13 @@ import { useCallback, useMemo, useState } from 'react'
 import { useDashboardConfiguration } from './hooks/useDashboardConfiguration'
 import { useMetrics } from './hooks/useMetrics'
 import { useMetricsHistory } from './hooks/useMetricsHistory'
+import { useMetricsIngest } from './hooks/useMetricsIngest'
+import { useRoute } from './hooks/useRoute'
 import { MetricsStoreProvider } from './hooks/MetricsStoreProvider'
+import { AppHeader } from './components/AppHeader'
 import { ConfigurationNotices } from './components/ConfigurationNotices'
-import { ConnectionBadge } from './components/ConnectionBadge'
 import { Dashboard } from './components/views/Dashboard'
+import { GridPage } from './components/grid/GridPage'
 import { LogViewer } from './components/LogViewer'
 import type { GpuEvent, InferenceRequest } from './types/events'
 
@@ -50,13 +53,7 @@ function AppContent() {
 
   return (
     <div className="h-dvh flex flex-col bg-[#08080a] overflow-hidden">
-      <header className="shrink-0 border-b border-white/[0.04] px-4 py-1.5 flex justify-between items-center">
-        <h1 className="text-xl font-semibold text-zinc-100 tracking-tight" style={{ fontFamily: 'Inter, sans-serif' }}>
-          <span className="text-[#76B900]">Spark</span>{' '}
-          <span className="text-zinc-500 font-normal">Dashboard</span>
-        </h1>
-        <ConnectionBadge status={connectionStatus} isStale={isStale} />
-      </header>
+      <AppHeader status={connectionStatus} isStale={isStale} />
 
       <ConfigurationNotices notices={configurationNotices} />
 
@@ -91,12 +88,57 @@ function AppContent() {
   )
 }
 
+// A grid page at its own URL (#79): the same masthead and notices as the root,
+// with the panels rendered from the stored configuration. Snapshots are only
+// ingested here — each panel subscribes to its own series, so this shell does
+// not re-render per snapshot the way the pre-grid dashboard does.
+function GridPageContent({ pageId }: { pageId: string }) {
+  const { metrics, connectionStatus, isStale } = useMetrics()
+  useMetricsIngest(metrics)
+  const { document, notices: configurationNotices } = useDashboardConfiguration()
+
+  // Null document means the load has not resolved; rendering nothing beats
+  // flashing the preset past an operator whose real page is milliseconds away.
+  const page = document?.pages.find((candidate) => candidate.id === pageId)
+
+  return (
+    <div className="h-dvh flex flex-col bg-[#08080a] overflow-hidden">
+      <AppHeader status={connectionStatus} isStale={isStale} />
+
+      <ConfigurationNotices notices={configurationNotices} />
+
+      <main className="flex-1 min-h-0 p-3 lg:p-4 2xl:p-5 min-[1920px]:p-6">
+        {document &&
+          (page ? (
+            <GridPage key={page.id} page={page} />
+          ) : (
+            <div className="h-full flex items-center justify-center">
+              <div className="text-center">
+                <h2 className="text-xl font-bold text-zinc-50 mb-2">No page at this address</h2>
+                <p className="text-zinc-400 mb-4">
+                  The dashboard configuration has no page “{pageId}”. It may have been deleted.
+                </p>
+                <a href="/" className="text-[#76B900] hover:underline">
+                  Back to the dashboard
+                </a>
+              </div>
+            </div>
+          ))}
+      </main>
+    </div>
+  )
+}
+
 // The store provider sits above everything that reads metrics history, so the
-// coming grid pages and the current dashboard share one set of ring buffers.
+// grid pages and the current dashboard share one set of ring buffers. The root
+// URL keeps serving the pre-grid dashboard untouched until the #86 cutover;
+// grid pages are only reachable at their own URLs.
 function App() {
+  const route = useRoute()
+
   return (
     <MetricsStoreProvider>
-      <AppContent />
+      {route.kind === 'page' ? <GridPageContent pageId={route.pageId} /> : <AppContent />}
     </MetricsStoreProvider>
   )
 }

--- a/frontend/src/__tests__/App.gridPage.test.tsx
+++ b/frontend/src/__tests__/App.gridPage.test.tsx
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import App from '../App'
+import {
+  configurationResponse,
+  serveConfiguration,
+  type FetchMock,
+} from '../test/configurationServer'
+import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+
+// The grid page through the application seam: real routing, real configuration
+// loading, real registry and store subscriptions — with the grid library
+// swapped for the shared document-order substitute (see src/test/gridstack.tsx)
+// and the metrics socket quiet, since nothing here is about metrics values.
+class SilentWebSocket {
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  readyState = 0
+  close() {}
+  send() {}
+}
+
+/** A stored one-page document; panels default to a readable tracer panel. */
+function storedDocument(panels: unknown[], pageId = 'watch', pageName = 'Watch'): string {
+  return JSON.stringify({
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [{ id: pageId, name: pageName, panels }],
+  })
+}
+
+function visit(pathname: string) {
+  window.history.replaceState(null, '', pathname)
+}
+
+async function configurationSettles(fetchMock: FetchMock) {
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+  await act(() => configurationResponse(fetchMock))
+}
+
+beforeEach(() => {
+  vi.stubGlobal('WebSocket', SilentWebSocket as unknown as typeof WebSocket)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  visit('/')
+})
+
+describe('the grid page route', () => {
+  it('renders a stored page’s panels at that page’s URL', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'a', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+        { id: 'b', type: 'memory', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+    visit('/pages/watch')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+    // The root dashboard did not render underneath the grid page.
+    expect(screen.queryByText('Waiting for metrics')).not.toBeInTheDocument()
+  })
+
+  it('matches the page by id alone, so a stale slug from before a rename still lands', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument(
+        [{ id: 'a', type: 'memory', geometry: { x: 0, y: 0, w: 6, h: 4 } }],
+        'wall',
+        'Wall Display',
+      ),
+    })
+    visit('/pages/wall/old-name-from-before-the-rename')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+  })
+
+  it('renders the default preset’s page when nothing is configured', async () => {
+    const fetchMock = serveConfiguration({ document: null })
+    visit('/pages/overview')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    // The tracer panels render for real; the preset panels no component
+    // implements yet keep their slots as placeholders (#80–#82).
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'GPU Utilization' })).toBeInTheDocument()
+    expect(screen.getAllByText('This panel is not available yet.')).not.toHaveLength(0)
+  })
+
+  it('keeps an unknown panel type’s slot with a placeholder naming the type', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'a', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+        { id: 'b', type: 'quantum-flux', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+        { id: 'c', type: 'memory', geometry: { x: 0, y: 4, w: 6, h: 4 } },
+      ]),
+    })
+    visit('/pages/watch')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    // The unknown panel says what it is and why it cannot render…
+    const unknown = screen.getByRole('region', { name: 'quantum-flux' })
+    expect(
+      within(unknown).getByText(/cannot render a “quantum-flux” panel/),
+    ).toBeInTheDocument()
+    // …and its neighbors on both sides still rendered — the page did not break.
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+  })
+
+  it('renders panels in document order, which the grid substitute preserves', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'first', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+        { id: 'second', type: 'memory', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+    visit('/pages/watch')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    const regions = screen.getAllByRole('region')
+    expect(regions.map((region) => region.getAttribute('aria-label'))).toEqual(['CPU', 'Memory'])
+  })
+
+  it('uses the operator’s panel title when one was saved', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'a', type: 'memory', title: 'RAM, big', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+    visit('/pages/watch')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('region', { name: 'RAM, big' })).toBeInTheDocument()
+  })
+
+  it('says when the URL names a page the configuration does not have', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument([]) })
+    visit('/pages/deleted-page')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByText('No page at this address')).toBeInTheDocument()
+    expect(screen.getByText(/no page “deleted-page”/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to the dashboard/i })).toHaveAttribute(
+      'href',
+      '/',
+    )
+  })
+
+  it('still shows configuration notices, so a fallback is not silent on a kiosk URL', async () => {
+    const fetchMock = serveConfiguration({ document: '{ not a dashboard }' })
+    visit('/pages/overview')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /saved dashboard configuration could not be read/i,
+    )
+    // The preset took over, so its page renders under the banner.
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+  })
+
+  it('leaves the root URL exactly as it was — the existing dashboard, no grid', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument([]) })
+    visit('/')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getByText('Waiting for metrics')).toBeInTheDocument()
+    expect(screen.queryByTestId('grid-stack')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/browser/gridPage.browser.test.tsx
+++ b/frontend/src/__tests__/browser/gridPage.browser.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { GridPage } from '@/components/grid/GridPage'
+import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
+import { FOLLOW } from '@/lib/dashboard/bindings'
+import type { PanelGeometry } from '@/lib/dashboard/grid'
+import { DEFAULT_TIME_WINDOW, type DashboardPage } from '@/lib/dashboard/schema'
+import type { PanelType } from '@/lib/dashboard/panels'
+
+// The real grid engine, which only a real layout engine can drive: the #79
+// acceptance criteria that depend on measurement. Fit-to-viewport (row height
+// divided out of a measured container) and the responsive collapse both run on
+// ResizeObserver paths that jsdom never fires. Drag, resize and the row cap
+// are edit-mode behavior and belong to the #87 suite.
+//
+// Tailwind classes do not apply here (the browser project runs no Tailwind
+// build), so assertions read the engine's own geometry — element rects and the
+// gs-* attributes — never the product styling.
+
+function page(panels: Array<[string, PanelType, PanelGeometry]>): DashboardPage {
+  return {
+    id: 'p',
+    name: 'P',
+    panels: panels.map(([id, type, geometry]) => ({
+      id,
+      type,
+      geometry,
+      binding: FOLLOW,
+      window: DEFAULT_TIME_WINDOW,
+    })),
+  }
+}
+
+function Harness({ width, height, content }: { width: number; height: number; content: DashboardPage }) {
+  return (
+    <MetricsStoreProvider>
+      <div style={{ width, height }}>
+        <GridPage page={content} />
+      </div>
+    </MetricsStoreProvider>
+  )
+}
+
+/** The engine's geometry for each item, with gridstack's sparse defaults filled in. */
+function itemGeometry(container: HTMLElement): Map<string, PanelGeometry> {
+  const found = new Map<string, PanelGeometry>()
+  for (const el of container.querySelectorAll('.grid-stack-item')) {
+    const id = el.getAttribute('gs-id')
+    if (!id) continue
+    found.set(id, {
+      x: Number(el.getAttribute('gs-x') ?? 0),
+      y: Number(el.getAttribute('gs-y') ?? 0),
+      // The library omits values equal to its defaults — missing means 1.
+      w: Number(el.getAttribute('gs-w') ?? 1),
+      h: Number(el.getAttribute('gs-h') ?? 1),
+    })
+  }
+  return found
+}
+
+describe('the grid page in a real layout engine', () => {
+  it('fits the viewport: the measured container height is divided into rows, and a full page does not overflow', async () => {
+    const content = page([
+      ['top', 'cpu-utilization', { x: 0, y: 0, w: 12, h: 4 }],
+      ['bottom', 'memory', { x: 0, y: 4, w: 12, h: 4 }],
+    ])
+    const { container } = render(<Harness width={800} height={480} content={content} />)
+
+    await waitFor(() => {
+      const items = [...container.querySelectorAll('.grid-stack-item')]
+      expect(items).toHaveLength(2)
+      const outer = container.querySelector('.grid-stack')!.getBoundingClientRect()
+      const bottoms = items.map((el) => el.getBoundingClientRect().bottom)
+      // Filled to the bottom row — proof the row height came from the measured
+      // 480px, not from the pre-measurement fallback (which would give 640).
+      expect(Math.max(...bottoms) - outer.top).toBeLessThanOrEqual(481)
+      expect(Math.max(...bottoms) - outer.top).toBeGreaterThan(432) // 90% of 480
+    })
+  })
+
+  it('collapses to one column below the breakpoint — uncapped — and restores the authored layout exactly', async () => {
+    // Stacked single-column: 5 + 5 = 10 rows, deliberately more than the
+    // 8-row cap, proving the phone stack is not clamped into the cap.
+    const content = page([
+      ['left', 'cpu-utilization', { x: 0, y: 0, w: 6, h: 5 }],
+      ['right', 'memory', { x: 6, y: 0, w: 6, h: 5 }],
+    ])
+    const { container, rerender } = render(<Harness width={800} height={480} content={content} />)
+
+    await waitFor(() => {
+      expect(itemGeometry(container).get('right')).toMatchObject({ x: 6, y: 0, w: 6 })
+    })
+
+    // Narrow: both panels full-width in one column, stacked in reading order.
+    rerender(<Harness width={360} height={480} content={content} />)
+    await waitFor(() => {
+      const items = itemGeometry(container)
+      expect(items.get('left')).toMatchObject({ x: 0, w: 1, h: 5 })
+      expect(items.get('right')).toMatchObject({ x: 0, w: 1, h: 5 })
+      const ys = [items.get('left')!.y, items.get('right')!.y].sort((a, b) => a - b)
+      expect(ys).toEqual([0, 5]) // 10 rows deep — nothing squeezed into the cap
+    })
+
+    // Wide again: the authored desktop layout, not a recompacted approximation.
+    rerender(<Harness width={800} height={480} content={content} />)
+    await waitFor(() => {
+      const items = itemGeometry(container)
+      expect(items.get('left')).toMatchObject({ x: 0, y: 0, w: 6, h: 5 })
+      expect(items.get('right')).toMatchObject({ x: 6, y: 0, w: 6, h: 5 })
+    })
+  })
+
+  it('keeps every panel subtree mounted through the engine’s DOM manipulation', async () => {
+    const content = page([['only', 'memory', { x: 0, y: 0, w: 6, h: 4 }]])
+    const { container, getByRole } = render(
+      <Harness width={800} height={480} content={content} />,
+    )
+
+    await waitFor(() => {
+      // The panel content rendered through the portal, inside the engine's own
+      // item element — the frame carries its accessible name.
+      expect(getByRole('region', { name: 'Memory' })).toBeTruthy()
+      expect(container.querySelector('.grid-stack-item .grid-stack-item-content')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,0 +1,22 @@
+import { ConnectionBadge } from './ConnectionBadge'
+import type { ConnectionStatus } from '@/hooks/useMetrics'
+
+/**
+ * The product masthead: title and connection badge. Shared by the root
+ * dashboard and the grid pages so both routes read as the same product; the
+ * page tabs (#85) will slot in here between the two.
+ */
+export function AppHeader({ status, isStale }: { status: ConnectionStatus; isStale: boolean }) {
+  return (
+    <header className="shrink-0 border-b border-white/[0.04] px-4 py-1.5 flex justify-between items-center">
+      <h1
+        className="text-xl font-semibold text-zinc-100 tracking-tight"
+        style={{ fontFamily: 'Inter, sans-serif' }}
+      >
+        <span className="text-[#76B900]">Spark</span>{' '}
+        <span className="text-zinc-500 font-normal">Dashboard</span>
+      </h1>
+      <ConnectionBadge status={status} isStale={isStale} />
+    </header>
+  )
+}

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -1,0 +1,86 @@
+import 'gridstack/dist/gridstack.css'
+import { useMemo } from 'react'
+import { GridStack, GridStackItem, type GridStackOptions } from 'gridstack/dist/react'
+import { useElementSize } from '@/hooks/useElementSize'
+import { GRID_COLUMNS, GRID_MAX_ROWS } from '@/lib/dashboard/grid'
+import type { DashboardPage } from '@/lib/dashboard/schema'
+import { GridPanel } from './GridPanel'
+
+/**
+ * Container width in px at or below which the grid collapses to one column.
+ * The collapse is the engine's own responsive path, driven by the grid
+ * element's measured size (`breakpointForWindow` defaults to false): gridstack
+ * caches the authored 12-column layout before collapsing and restores it
+ * verbatim on the way back, which the #68 spike confirmed is lossless. Never
+ * persist what the collapsed grid looks like.
+ */
+export const SINGLE_COLUMN_BREAKPOINT = 640
+
+/**
+ * Row height until the container has been measured. jsdom never measures, so
+ * this is also what every unit test runs on; the number itself is arbitrary
+ * because fit-to-viewport replaces it on the first ResizeObserver tick.
+ */
+const FALLBACK_CELL_HEIGHT = 80
+
+/**
+ * One dashboard page as a grid of panels.
+ *
+ * Fit-to-viewport is the defining property: the row height is the measured
+ * container height divided by the row cap, so a full page exactly fills the
+ * space and never scrolls on desktop. Below the breakpoint the engine stacks
+ * panels into a single column and the container scrolls instead — the one place
+ * scrolling is the design.
+ *
+ * The grid is static here: rendering from the stored document is this ticket
+ * (#79); dragging, resizing and saving are edit mode (#83).
+ */
+export function GridPage({ page }: { page: DashboardPage }) {
+  const [containerRef, { width, height }] = useElementSize<HTMLDivElement>()
+  const narrow = width > 0 && width <= SINGLE_COLUMN_BREAKPOINT
+  const cellHeight = height > 0 ? Math.floor(height / GRID_MAX_ROWS) : FALLBACK_CELL_HEIGHT
+
+  const options = useMemo(
+    (): GridStackOptions => ({
+      column: GRID_COLUMNS,
+      columnOpts: {
+        columnMax: GRID_COLUMNS,
+        breakpoints: [{ w: SINGLE_COLUMN_BREAKPOINT, c: 1 }],
+      },
+      // `maxRow` is deliberately NOT set on the engine here. The engine clamps
+      // every node into the cap when it re-adds them during a column change,
+      // and the single-column stack legitimately needs more rows than the cap
+      // — setting it would mangle the phone layout. A static grid cannot
+      // violate the cap anyway: `readGeometry` clamps persisted geometry into
+      // `GRID_MAX_ROWS` on read. Edit mode (#83) wires the cap into the engine
+      // (`maxRow` + `willItFit`) for the desktop-only edit session, where
+      // "will one more fit" is actually a question.
+      cellHeight,
+      margin: 3,
+      // Authored gaps are authored. Without floating, the engine compacts
+      // everything upward on load and quietly rewrites the operator's layout.
+      float: true,
+      staticGrid: true,
+    }),
+    [cellHeight],
+  )
+
+  return (
+    <div
+      ref={containerRef}
+      // Inline rather than `h-full`: the height feeds the row-height math, so
+      // it must hold anywhere the component renders — including the browser
+      // test project, which runs no Tailwind build.
+      style={{ height: '100%' }}
+      className={`min-h-0 ${narrow ? 'overflow-y-auto' : 'overflow-hidden'}`}
+    >
+      <GridStack options={options}>
+        {page.panels.map((panel) => (
+          <GridStackItem key={panel.id} id={panel.id} options={panel.geometry}>
+            <GridPanel panel={panel} />
+          </GridStackItem>
+        ))}
+      </GridStack>
+    </div>
+  )
+}

--- a/frontend/src/components/grid/GridPanel.tsx
+++ b/frontend/src/components/grid/GridPanel.tsx
@@ -1,0 +1,44 @@
+import { isKnownPanelType } from '@/lib/dashboard/panels'
+import { panelTitle, type DashboardPanel } from '@/lib/dashboard/schema'
+import { renderPanelContent } from './panelRegistry'
+
+/**
+ * One panel on the grid: the product's card chrome around whatever the type's
+ * registered component renders. When nothing is registered the frame stays and
+ * a placeholder says why — a panel must keep its slot rather than break the
+ * page or silently vanish, because the layout around it is something the
+ * operator authored.
+ */
+export function GridPanel({ panel }: { panel: DashboardPanel }) {
+  return (
+    <section
+      aria-label={panelTitle(panel)}
+      className="h-full min-h-0 flex flex-col rounded-md border border-white/[0.04] bg-[#151519] px-2 py-1.5 overflow-hidden"
+    >
+      <h3 className="shrink-0 text-[11px] font-semibold text-zinc-200 truncate">
+        {panelTitle(panel)}
+      </h3>
+      <div className="flex-1 min-h-0 min-w-0">
+        {renderPanelContent(panel) ?? <PanelPlaceholder type={panel.type} />}
+      </div>
+    </section>
+  )
+}
+
+/**
+ * The two ways a panel can have no content, told apart because the operator's
+ * next move differs: an unknown type means this build was rolled back past the
+ * one that created the panel, while a known type without a component is simply
+ * not built yet (#80–#82) and needs no action at all.
+ */
+function PanelPlaceholder({ type }: { type: string }) {
+  return (
+    <div className="h-full flex items-center justify-center text-center">
+      <p className="text-xs text-zinc-500">
+        {isKnownPanelType(type)
+          ? 'This panel is not available yet.'
+          : `This version of the dashboard cannot render a “${type}” panel.`}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/grid/panelRegistry.tsx
+++ b/frontend/src/components/grid/panelRegistry.tsx
@@ -1,0 +1,41 @@
+/**
+ * Which React component renders each panel type's content.
+ *
+ * The registry is keyed by the persisted panel-type vocabulary in
+ * `lib/dashboard/panels`, and is deliberately allowed to lag it: a type the
+ * vocabulary knows but no component implements yet renders as a placeholder
+ * that keeps its grid slot. That is what lets the panel tickets (#80–#82) land
+ * one at a time against a preset that already names every type.
+ *
+ * Two tracer types are registered so the whole path — document, page, grid,
+ * store subscription, chart — is exercised end to end. Both bind to nothing;
+ * panels that resolve a GPU or engine binding arrive with #80/#81.
+ */
+
+import type { ComponentType, ReactElement } from 'react'
+import { isKnownPanelType, type PanelType } from '@/lib/dashboard/panels'
+import type { DashboardPanel } from '@/lib/dashboard/schema'
+import { CpuUtilizationPanel } from './panels/CpuUtilizationPanel'
+import { MemoryPanel } from './panels/MemoryPanel'
+
+/** Every panel content component takes the panel it renders, nothing else —
+ *  data comes from the metrics store, not from props threaded through the grid. */
+export interface PanelContentProps {
+  panel: DashboardPanel
+}
+
+const PANEL_CONTENT: Partial<Record<PanelType, ComponentType<PanelContentProps>>> = {
+  'cpu-utilization': CpuUtilizationPanel,
+  memory: MemoryPanel,
+}
+
+/**
+ * The panel's content element, or null when this build cannot render the type.
+ * Returns an element rather than the component so no caller holds a component
+ * looked up during its own render — the registered components stay the only
+ * component identities involved.
+ */
+export function renderPanelContent(panel: DashboardPanel): ReactElement | null {
+  const Content = isKnownPanelType(panel.type) ? PANEL_CONTENT[panel.type] : undefined
+  return Content ? <Content panel={panel} /> : null
+}

--- a/frontend/src/components/grid/panels/CpuUtilizationPanel.tsx
+++ b/frontend/src/components/grid/panels/CpuUtilizationPanel.tsx
@@ -1,0 +1,14 @@
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { useMetricSeries } from '@/hooks/useMetricsStore'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * Aggregate CPU utilization over the panel's own time window. One of the two
+ * tracer panels: host-wide, so nothing needs binding, and the interesting part
+ * is the plumbing it proves rather than the chart it draws.
+ */
+export function CpuUtilizationPanel({ panel }: PanelContentProps) {
+  const data = useMetricSeries('cpuAggregate', panel.window)
+
+  return <TimeSeriesChart data={data} yDomain={[0, 100]} unit="%" seriesLabel="CPU" height="100%" />
+}

--- a/frontend/src/components/grid/panels/MemoryPanel.tsx
+++ b/frontend/src/components/grid/panels/MemoryPanel.tsx
@@ -1,0 +1,15 @@
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { useMetricSeries } from '@/hooks/useMetricsStore'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * Used share of the host's memory pool over the panel's own time window. The
+ * second tracer panel — host-wide on unified-memory machines, so unbound.
+ */
+export function MemoryPanel({ panel }: PanelContentProps) {
+  const data = useMetricSeries('memoryUsedPercent', panel.window)
+
+  return (
+    <TimeSeriesChart data={data} yDomain={[0, 100]} unit="%" seriesLabel="Used" height="100%" />
+  )
+}

--- a/frontend/src/hooks/useMetricsHistory.ts
+++ b/frontend/src/hooks/useMetricsHistory.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
+import { useMetricsIngest } from './useMetricsIngest'
 import { useMetricsStore } from './useMetricsStore'
 import type { TimeWindow } from '../types/events'
 import type { GpuEventData, InferenceRequestData, MetricsSnapshot } from '../types/metrics'
@@ -13,9 +14,7 @@ import type { GpuEventData, InferenceRequestData, MetricsSnapshot } from '../typ
 export function useMetricsHistory(metrics: MetricsSnapshot | null) {
   const store = useMetricsStore()
 
-  useEffect(() => {
-    if (metrics) store.ingest(metrics)
-  }, [store, metrics])
+  useMetricsIngest(metrics)
 
   const subscribeAll = useCallback(
     (listener: () => void) => store.subscribeAll(listener),

--- a/frontend/src/hooks/useMetricsIngest.ts
+++ b/frontend/src/hooks/useMetricsIngest.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { useMetricsStore } from './useMetricsStore'
+import type { MetricsSnapshot } from '@/types/metrics'
+
+/**
+ * Feeds incoming snapshots into the metrics store — and nothing else. The grid
+ * page mounts this once at its root and stays out of the render path: panels
+ * subscribe to their own series through `useMetricSeries`, so a snapshot
+ * re-renders the panels it touched rather than the whole page. The pre-grid
+ * dashboard keeps `useMetricsHistory`, which layers its subscribe-to-everything
+ * accessors on top of this.
+ */
+export function useMetricsIngest(metrics: MetricsSnapshot | null): void {
+  const store = useMetricsStore()
+
+  useEffect(() => {
+    if (metrics) store.ingest(metrics)
+  }, [store, metrics])
+}

--- a/frontend/src/hooks/useRoute.ts
+++ b/frontend/src/hooks/useRoute.ts
@@ -1,0 +1,23 @@
+import { useMemo, useSyncExternalStore } from 'react'
+import { parseRoute, type Route } from '@/lib/dashboard/routes'
+
+/**
+ * The view the browser's current path names, kept current across history
+ * navigation. `popstate` covers back/forward; a programmatic `pushState` must
+ * be followed by dispatching a `popstate` event, which is the deal the future
+ * in-app navigation (#85) signs up to — no custom event channel until someone
+ * actually navigates.
+ */
+export function useRoute(): Route {
+  const pathname = useSyncExternalStore(subscribe, readPathname)
+  return useMemo(() => parseRoute(pathname), [pathname])
+}
+
+function subscribe(onChange: () => void): () => void {
+  window.addEventListener('popstate', onChange)
+  return () => window.removeEventListener('popstate', onChange)
+}
+
+function readPathname(): string {
+  return window.location.pathname
+}

--- a/frontend/src/lib/dashboard/routes.test.ts
+++ b/frontend/src/lib/dashboard/routes.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { pagePath, pageSlug, parseRoute } from './routes'
+
+describe('parseRoute', () => {
+  it('routes the root to the dashboard', () => {
+    expect(parseRoute('/')).toEqual({ kind: 'dashboard' })
+  })
+
+  it('routes a page URL to that page by id', () => {
+    expect(parseRoute('/pages/overview')).toEqual({ kind: 'page', pageId: 'overview' })
+  })
+
+  it('ignores the slug — only the id matches, so a rename breaks no bookmark', () => {
+    expect(parseRoute('/pages/abc123/training-view')).toEqual({ kind: 'page', pageId: 'abc123' })
+    expect(parseRoute('/pages/abc123/completely-stale-slug')).toEqual({
+      kind: 'page',
+      pageId: 'abc123',
+    })
+  })
+
+  it('tolerates a trailing slash', () => {
+    expect(parseRoute('/pages/overview/')).toEqual({ kind: 'page', pageId: 'overview' })
+  })
+
+  it('decodes an id that needed URL encoding', () => {
+    expect(parseRoute('/pages/page%202')).toEqual({ kind: 'page', pageId: 'page 2' })
+  })
+
+  it('routes every path that names nothing to the dashboard, as the server-side shell always did', () => {
+    expect(parseRoute('/pages')).toEqual({ kind: 'dashboard' })
+    expect(parseRoute('/pages/')).toEqual({ kind: 'dashboard' })
+    expect(parseRoute('/settings')).toEqual({ kind: 'dashboard' })
+    expect(parseRoute('/index.html')).toEqual({ kind: 'dashboard' })
+  })
+})
+
+describe('pagePath', () => {
+  it('builds an id-plus-slug URL that parses back to the same page', () => {
+    const page = { id: 'p-7f3a', name: 'Training View' }
+    expect(pagePath(page)).toBe('/pages/p-7f3a/training-view')
+    expect(parseRoute(pagePath(page))).toEqual({ kind: 'page', pageId: 'p-7f3a' })
+  })
+
+  it('drops a slug that only repeats the id', () => {
+    expect(pagePath({ id: 'overview', name: 'Overview' })).toBe('/pages/overview')
+  })
+
+  it('drops a slug the name has nothing usable for', () => {
+    expect(pagePath({ id: 'p-1', name: '???' })).toBe('/pages/p-1')
+  })
+
+  it('encodes an id that cannot sit in a path verbatim', () => {
+    const page = { id: 'page 2', name: 'Wall Display' }
+    expect(pagePath(page)).toBe('/pages/page%202/wall-display')
+    expect(parseRoute(pagePath(page))).toEqual({ kind: 'page', pageId: 'page 2' })
+  })
+})
+
+describe('pageSlug', () => {
+  it('lowercases and dashes a human name', () => {
+    expect(pageSlug('Training View')).toBe('training-view')
+  })
+
+  it('collapses runs of punctuation and trims the edges', () => {
+    expect(pageSlug('  GPU / Engine — watch!  ')).toBe('gpu-engine-watch')
+  })
+
+  it('keeps letters beyond ASCII rather than mangling them', () => {
+    expect(pageSlug('Übersicht')).toBe('übersicht')
+  })
+
+  it('is empty when nothing usable remains', () => {
+    expect(pageSlug('!!!')).toBe('')
+  })
+})

--- a/frontend/src/lib/dashboard/routes.ts
+++ b/frontend/src/lib/dashboard/routes.ts
@@ -1,0 +1,58 @@
+/**
+ * The dashboard's URLs: which view a path names, and what a page's URL is.
+ *
+ * Routing is history-based and deliberately minimal — the requirement is
+ * rendering one of N pages, not nested routes or data loading, so this is a
+ * pair of pure functions rather than a routing framework. The server already
+ * serves the app shell for every unmatched path, so no backend knows these
+ * shapes.
+ *
+ * A page URL is `/pages/<id>` or `/pages/<id>/<slug>`. **Only the id
+ * matches.** The slug is derived from the page's name purely so the URL reads
+ * like something — it is ignored on the way in, which is what keeps a kiosk
+ * bookmark working after the page is renamed.
+ *
+ * Every path that names nothing renders the root dashboard, exactly as the
+ * whole site did before these routes existed.
+ */
+
+import type { DashboardPage } from './schema'
+
+export type Route =
+  /** The pre-grid dashboard at the root — today's view, untouched until the #86 cutover. */
+  | { kind: 'dashboard' }
+  /** One grid page, named by its stable id. */
+  | { kind: 'page'; pageId: string }
+
+/** The view a browser path names. */
+export function parseRoute(pathname: string): Route {
+  const segments = pathname.split('/').filter(Boolean)
+
+  if (segments[0] === 'pages' && segments[1]) {
+    return { kind: 'page', pageId: decodeURIComponent(segments[1]) }
+  }
+
+  return { kind: 'dashboard' }
+}
+
+/**
+ * The canonical URL of a page. The slug is omitted when it adds nothing —
+ * empty, or already what the id says.
+ */
+export function pagePath(page: Pick<DashboardPage, 'id' | 'name'>): string {
+  const base = `/pages/${encodeURIComponent(page.id)}`
+  const slug = pageSlug(page.name)
+  return slug && slug !== page.id ? `${base}/${slug}` : base
+}
+
+/**
+ * A page name reduced to something that can sit in a URL: lowercased, runs of
+ * anything but letters and digits collapsed to single dashes. Empty when the
+ * name has nothing usable in it, and the URL is just the id.
+ */
+export function pageSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/frontend/src/test/gridstack.tsx
+++ b/frontend/src/test/gridstack.tsx
@@ -1,0 +1,41 @@
+/**
+ * The one shared substitute for the grid library in jsdom (seam 3 of the #70
+ * test plan). The vitest unit project aliases `gridstack/dist/react` here, so
+ * no spec has to remember to mock it and none can accidentally load the real
+ * engine — which measures elements, and jsdom measures every box as 0×0.
+ *
+ * It renders children in document order and nothing else. Layout — where a
+ * panel sits, whether it fits, how columns collapse — is deliberately not
+ * simulated: the pure grid module covers the geometry, and the browser project
+ * covers the real engine. Direct prior art: the multi-GPU dashboard spec
+ * substitutes the chart component for exactly this reason.
+ *
+ * The browser project must never load this file; it exists to exercise the
+ * real library.
+ */
+
+import type { ReactNode } from 'react'
+
+interface GridStackProps {
+  options?: unknown
+  children?: ReactNode
+  className?: string
+}
+
+interface GridStackItemProps {
+  id: string
+  options?: unknown
+  children?: ReactNode
+}
+
+export function GridStack({ children, className }: GridStackProps) {
+  return (
+    <div data-testid="grid-stack" className={className}>
+      {children}
+    </div>
+  )
+}
+
+export function GridStackItem({ id, children }: GridStackItemProps) {
+  return <div data-testid={`grid-stack-item-${id}`}>{children}</div>
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -31,6 +31,15 @@ export default defineConfig({
     projects: [
       {
         ...appPipeline,
+        resolve: {
+          alias: {
+            ...appPipeline.resolve.alias,
+            // The one shared grid-library substitute (seam 3): jsdom has no
+            // layout engine, so the unit project never loads the real thing.
+            // The browser project keeps the real library — that is its point.
+            'gridstack/dist/react': path.resolve(__dirname, './src/test/gridstack.tsx'),
+          },
+        },
         test: {
           ...shared,
           name: 'unit',


### PR DESCRIPTION
Closes #79. Spec: #70, decision record #68.

The tracer bullet: `/pages/<id>[/<slug>]` renders that page's panels from the stored configuration, end to end from document to screen. The root URL keeps serving today's dashboard untouched until the #86 cutover.

## What's here

- **gridstack 13.2.0, pinned exactly** — newest stable verified against npm at adoption time (newer than the spike-validated 13.1.2; only React-wrapper fixes and print support in between, and it now also holds the `latest` dist-tag). Pinned exactly because the package declares no React peer dependency, so no tool will ever warn on an incompatible combination — any gridstack/React bump must be deliberate and re-run the #68 spike checks (the #87 suite).
- **History-based routing**: pure parse/build helpers plus one `popstate`-backed hook. Only the id matches; the slug is cosmetic, so renames never break kiosk bookmarks. Unmatched paths render the root dashboard exactly as the server-side shell always did.
- **Fit-to-viewport**: row height = measured container height ÷ row cap, so a full desktop page exactly fills the viewport with no scrolling. Below 640px the engine's own responsive path collapses to a single scrolling column and restores the authored 12-column layout losslessly on widening (spike-confirmed, browser-tested here).
- **Panel registry** keyed by the persisted panel-type vocabulary, with two tracer panels (`cpu-utilization`, `memory` — host-wide, so binding resolution stays in #81's scope) and slot-keeping placeholders for both unknown types (rollback case, placeholder names the type) and known-but-not-yet-built types (#80–#82 land one family at a time).
- **One shared jsdom grid substitute** (seam 3 of the #70 test plan), aliased once in the vitest unit project so no spec can accidentally load the real engine. The browser project keeps the real library and covers what jsdom cannot: measured fit, collapse, exact restore, portal survival.

## Deliberate deviation for #83 to pick up

The ticket's "hard row cap, enforced by the engine simulating the move" is **not wired into the engine here**: the engine clamps every node into `maxRow` while re-adding nodes during a column change, which would mangle the single-column phone stack (which legitimately needs more rows than the cap — the browser spec proves a 10-row stack survives uncapped). A static grid cannot violate the cap anyway, because `readGeometry` clamps persisted geometry on read. **Edit mode (#83) owns wiring `maxRow` + `willItFit` for the desktop-only edit session**, where "will one more fit" is actually a question. Documented in `GridPage.tsx`.

## Verification

- `npm run lint` clean, `npm run build` green, 411/411 unit, 4/4 browser (`npm run test:browser`)
- Manual smoke against a live backend: tracer charts draw, placeholders keep slots, no scrollbar at desktop, collapse/restore round-trips

Rebase-merge; every commit is a valid Conventional Commit.