### PR TITLE
feat(frontend): engine metric panels and binding resolution

### DIFF
--- a/frontend/src/__tests__/App.enginePanels.test.tsx
+++ b/frontend/src/__tests__/App.enginePanels.test.tsx
@@ -267,6 +267,39 @@ describe('the engine panels on a grid page', () => {
     expect(screen.queryByText('This panel is not available yet.')).not.toBeInTheDocument()
   })
 
+  it('names the engine when it says one is not speculating', async () => {
+    // On a page holding two engines, "this engine" would not say which.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        {
+          id: 'alpha-spec',
+          type: 'engine-spec-decode',
+          title: 'Alpha speculation',
+          binding: { kind: 'engine', endpoint: ALPHA },
+          geometry: { x: 0, y: 0, w: 6, h: 4 },
+        },
+        {
+          id: 'beta-spec',
+          type: 'engine-spec-decode',
+          title: 'Beta speculation',
+          binding: { kind: 'engine', endpoint: BETA },
+          geometry: { x: 6, y: 0, w: 6, h: 4 },
+        },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, [makeEngine(ALPHA, {}, SPEC_DECODE), makeEngine(BETA)]))
+
+    expect(within(region('Alpha speculation')).getByText('75')).toBeInTheDocument()
+    expect(
+      within(region('Beta speculation')).getByText(
+        'vLLM localhost:8001 is not using speculative decoding.',
+      ),
+    ).toBeInTheDocument()
+  })
+
   it('shows speculative decoding once the engine has drafted tokens', async () => {
     const fetchMock = serveConfiguration({ document: storedDocument(enginePanels()) })
 

--- a/frontend/src/__tests__/App.enginePanels.test.tsx
+++ b/frontend/src/__tests__/App.enginePanels.test.tsx
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import App from '../App'
+import {
+  configurationResponse,
+  serveConfiguration,
+  type FetchMock,
+} from '../test/configurationServer'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+import type { EngineMetrics, EngineSnapshot, MetricsSnapshot } from '../types/metrics'
+
+// The engine panels through the application seam (#81): real routing, real
+// configuration loading, real registry, store and binding resolution, with the
+// snapshot arriving over the substituted metrics socket — the same seam the
+// hardware panels use. The chart is substituted so the series each panel
+// requested is assertable; every value assertion is on what the panels
+// themselves render.
+substituteWebSocket()
+
+vi.mock('@/components/charts/TimeSeriesChart', () => ({
+  TimeSeriesChart: (props: {
+    data?: Array<{ value: number }>
+    series?: Array<{ label: string; data: Array<{ value: number }> }>
+  }) => (
+    <div data-testid="chart" data-values={props.data?.map((p) => p.value).join(',')}>
+      {props.series?.map((s) => (
+        <div
+          key={s.label}
+          data-testid={`chart-series-${s.label}`}
+          data-values={s.data.map((p) => p.value).join(',')}
+        />
+      ))}
+    </div>
+  ),
+}))
+
+const ALPHA = 'http://localhost:8000'
+const BETA = 'http://localhost:8001'
+
+/** A stored page holding panels; binding omitted means `follow`. */
+function storedDocument(panels: unknown[]): string {
+  return JSON.stringify({
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [{ id: 'engines', name: 'Engines', panels }],
+  })
+}
+
+function engineMetrics(overrides: Partial<EngineMetrics> = {}): EngineMetrics {
+  return {
+    tokens_per_sec: 120,
+    avg_tokens_per_sec: 100,
+    per_request_tps: 40,
+    ttft_ms: 210,
+    active_requests: 3,
+    queued_requests: 1,
+    kv_cache_percent: 42,
+    kv_cache_is_estimated: false,
+    total_requests: 900,
+    e2e_latency_ms: 4200,
+    prompt_tokens_per_sec: 3000,
+    avg_prompt_tokens_per_sec: 2500,
+    per_request_prompt_tps: 800,
+    swapped_requests: 0,
+    prefix_cache_hit_rate: 55,
+    queue_time_ms: 12,
+    inter_token_latency_ms: 9,
+    preemptions_total: 0,
+    total_prompt_tokens: 1_000_000,
+    total_generation_tokens: 500_000,
+    prefix_cache_queries_total: 2_000_000,
+    avg_batch_size: 6.5,
+    ttft_percentiles: { p50_ms: 200, p95_ms: 400, p99_ms: 900 },
+    itl_percentiles: null,
+    e2e_percentiles: null,
+    ttft_goodput_pct: 99,
+    itl_goodput_pct: 98,
+    e2e_goodput_pct: 97,
+    ttft_buckets: null,
+    itl_buckets: null,
+    e2e_buckets: null,
+    tpot_ms: 8,
+    tpot_percentiles: null,
+    tpot_goodput_pct: 96,
+    tpot_buckets: null,
+    spec_decode_draft_tokens_total: null,
+    spec_decode_accepted_tokens_total: null,
+    spec_decode_drafts_total: null,
+    spec_decode_acceptance_rate: null,
+    spec_decode_acceptance_rate_live: null,
+    spec_decode_mean_acceptance_length: null,
+    ...overrides,
+  }
+}
+
+function makeEngine(
+  endpoint: string,
+  overrides: Partial<EngineSnapshot> = {},
+  metricOverrides: Partial<EngineMetrics> = {},
+): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status: { type: 'Running' },
+    model: {
+      name: 'Qwen/Qwen3-8B',
+      parameter_size: null,
+      quantization: null,
+      precision: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: engineMetrics(metricOverrides),
+    recent_requests: [],
+    deployment_mode: 'Native',
+    ...overrides,
+  }
+}
+
+function makeSnapshot(ts: number, engines: EngineSnapshot[]): MetricsSnapshot {
+  return {
+    timestamp_ms: ts,
+    gpu: {
+      index: 0,
+      name: 'NVIDIA GB10',
+      utilization_percent: 76,
+      memory_total_bytes: null,
+      memory_used_bytes: null,
+      temperature_celsius: 61,
+      power_watts: 220,
+      power_limit_watts: 300,
+      clock_graphics_mhz: 2100,
+      clock_sm_mhz: null,
+      clock_memory_mhz: null,
+      fan_speed_percent: null,
+    },
+    cpu: { name: 'Grace CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128,
+      used_bytes: 64,
+      available_bytes: 64,
+      cached_bytes: 8,
+      gpu_estimated_bytes: null,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: true,
+    },
+    disk: { name: 'nvme0n1', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
+    network: { name: 'enp1s0', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
+    engines,
+    gpu_events: [],
+  }
+}
+
+function visit(pathname: string) {
+  window.history.replaceState(null, '', pathname)
+}
+
+async function configurationSettles(fetchMock: FetchMock) {
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+  await act(() => configurationResponse(fetchMock))
+}
+
+/** The metrics socket delivers one snapshot; the first frame flushes at once,
+ *  later ones on the 2s coalescing timer the socket hook runs. */
+function receive(snapshot: MetricsSnapshot) {
+  act(() => {
+    MockWebSocket.instances[0].receive(JSON.stringify(snapshot))
+    vi.advanceTimersByTime(2000)
+  })
+}
+
+function region(name: string): HTMLElement {
+  return screen.getByRole('region', { name })
+}
+
+/** The four metric panels this page shows, tiled inside the 12×8 grid. */
+function enginePanels(): unknown[] {
+  return [
+    { id: 'prefill', type: 'engine-prefill-throughput', geometry: { x: 0, y: 0, w: 3, h: 4 } },
+    { id: 'decode', type: 'engine-decode-throughput', geometry: { x: 3, y: 0, w: 3, h: 4 } },
+    { id: 'latency', type: 'engine-latency', geometry: { x: 6, y: 0, w: 3, h: 4 } },
+    { id: 'requests', type: 'engine-requests', geometry: { x: 9, y: 0, w: 3, h: 4 } },
+  ]
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  window.localStorage.clear()
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  visit('/pages/engines')
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('the engine panels on a grid page', () => {
+  it('renders each metric from the followed engine', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(enginePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, [makeEngine(ALPHA)]))
+
+    const prefill = region('Prefill Throughput')
+    expect(within(prefill).getByText('3000.0')).toBeInTheDocument()
+    expect(within(prefill).getByText('2500.0')).toBeInTheDocument()
+    expect(within(prefill).getByText('Processed')).toBeInTheDocument()
+
+    const decode = region('Decode Throughput')
+    expect(within(decode).getByText('120.0')).toBeInTheDocument()
+    expect(within(decode).getByText('Generated')).toBeInTheDocument()
+
+    const latency = region('Latency')
+    expect(within(latency).getByText('210')).toBeInTheDocument()
+    expect(within(latency).getByText('4.20')).toBeInTheDocument()
+    expect(within(latency).getByText('6.5')).toBeInTheDocument()
+
+    const requests = region('Requests')
+    expect(within(requests).getByText('3')).toBeInTheDocument()
+    expect(within(requests).getByText('900')).toBeInTheDocument()
+    // Swapped and preempted stay hidden while they are zero.
+    expect(within(requests).queryByText('Swapped')).not.toBeInTheDocument()
+
+    // Every panel on the page is implemented — no slot-keeping placeholders.
+    expect(screen.queryByText('This panel is not available yet.')).not.toBeInTheDocument()
+  })
+
+  it('charts each panel’s own series over the panel’s window', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(enginePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, [makeEngine(ALPHA)]))
+    receive(makeSnapshot(2000, [makeEngine(ALPHA, {}, { tokens_per_sec: 140, ttft_ms: 250 })]))
+
+    expect(within(region('Decode Throughput')).getByTestId('chart-series-Live')).toHaveAttribute(
+      'data-values',
+      '120,140',
+    )
+    expect(within(region('Latency')).getByTestId('chart-series-TTFT')).toHaveAttribute(
+      'data-values',
+      '210,250',
+    )
+  })
+
+  it('shows two engines side by side when the panels are pinned to them', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        {
+          id: 'alpha',
+          type: 'engine-decode-throughput',
+          title: 'Alpha decode',
+          binding: { kind: 'engine', endpoint: ALPHA },
+          geometry: { x: 0, y: 0, w: 6, h: 4 },
+        },
+        {
+          id: 'beta',
+          type: 'engine-decode-throughput',
+          title: 'Beta decode',
+          binding: { kind: 'engine', endpoint: BETA },
+          geometry: { x: 6, y: 0, w: 6, h: 4 },
+        },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [
+        makeEngine(ALPHA, {}, { tokens_per_sec: 120 }),
+        makeEngine(BETA, {}, { tokens_per_sec: 640 }),
+      ]),
+    )
+
+    // Both engines are on screen at once, each panel showing its own — value
+    // and chart series, so no panel is reading the other engine's history.
+    const alpha = region('Alpha decode')
+    expect(within(alpha).getByText('120.0')).toBeInTheDocument()
+    expect(within(alpha).getByTestId('chart-series-Live')).toHaveAttribute('data-values', '120')
+
+    const beta = region('Beta decode')
+    expect(within(beta).getByText('640.0')).toBeInTheDocument()
+    expect(within(beta).getByTestId('chart-series-Live')).toHaveAttribute('data-values', '640')
+
+    // With several engines each panel names the one it is showing.
+    expect(within(alpha).getByText('vLLM localhost:8000')).toBeInTheDocument()
+    expect(within(beta).getByText('vLLM localhost:8001')).toBeInTheDocument()
+  })
+
+  it('keeps the slot of a panel pinned to an engine that is gone, naming it', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        {
+          id: 'moved',
+          type: 'engine-latency',
+          binding: { kind: 'engine', endpoint: 'http://localhost:9999' },
+          geometry: { x: 0, y: 0, w: 6, h: 4 },
+        },
+        { id: 'requests', type: 'engine-requests', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, [makeEngine(ALPHA)]))
+
+    // The endpoint the operator pinned is named, never substituted — and the
+    // neighbour still renders, so the page did not break or reflow.
+    expect(
+      within(region('Latency')).getByText('No engine at http://localhost:9999 — repoint this panel.'),
+    ).toBeInTheDocument()
+    expect(within(region('Requests')).getByText('900')).toBeInTheDocument()
+  })
+
+  it('degrades to an empty state on a host running no engines', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(enginePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, []))
+
+    // Every panel keeps its slot and says why it is empty; nothing breaks the
+    // page, which is what keeps the dashboard useful for hardware alone.
+    expect(screen.getAllByText('No inference engine running.')).toHaveLength(4)
+  })
+
+  it('tells an engine that is still starting apart from one that is not running', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        {
+          id: 'starting',
+          type: 'engine-decode-throughput',
+          title: 'Starting',
+          binding: { kind: 'engine', endpoint: ALPHA },
+          geometry: { x: 0, y: 0, w: 6, h: 4 },
+        },
+        {
+          id: 'stopped',
+          type: 'engine-decode-throughput',
+          title: 'Stopped',
+          binding: { kind: 'engine', endpoint: BETA },
+          geometry: { x: 6, y: 0, w: 6, h: 4 },
+        },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [
+        makeEngine(ALPHA, { status: { type: 'Loading' }, metrics: null }),
+        makeEngine(BETA, { status: { type: 'Stopped' } }),
+      ]),
+    )
+
+    expect(
+      within(region('Starting')).getByText('vLLM localhost:8000 has no metrics yet.'),
+    ).toBeInTheDocument()
+    expect(
+      within(region('Stopped')).getByText('vLLM localhost:8001 is not running.'),
+    ).toBeInTheDocument()
+  })
+
+  it('waits quietly before the first snapshot, then fills in when it arrives', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(enginePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(screen.getAllByText('Waiting for metrics')).toHaveLength(4)
+
+    // The first snapshot must not trip the changed-hook-count trap.
+    receive(makeSnapshot(1000, [makeEngine(ALPHA)]))
+    expect(screen.queryByText('Waiting for metrics')).not.toBeInTheDocument()
+    expect(within(region('Decode Throughput')).getByText('120.0')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/App.enginePanels.test.tsx
+++ b/frontend/src/__tests__/App.enginePanels.test.tsx
@@ -175,14 +175,29 @@ function region(name: string): HTMLElement {
   return screen.getByRole('region', { name })
 }
 
-/** The four metric panels this page shows, tiled inside the 12×8 grid. */
+/** The engine block's six tiles as panels, tiled inside the 12×8 grid. Cache
+ *  and speculative decoding are one tile on the old card and two panels here,
+ *  because a panel is one metric. */
 function enginePanels(): unknown[] {
   return [
     { id: 'prefill', type: 'engine-prefill-throughput', geometry: { x: 0, y: 0, w: 3, h: 4 } },
     { id: 'decode', type: 'engine-decode-throughput', geometry: { x: 3, y: 0, w: 3, h: 4 } },
     { id: 'latency', type: 'engine-latency', geometry: { x: 6, y: 0, w: 3, h: 4 } },
     { id: 'requests', type: 'engine-requests', geometry: { x: 9, y: 0, w: 3, h: 4 } },
+    { id: 'goodput', type: 'engine-slo-goodput', geometry: { x: 0, y: 4, w: 4, h: 4 } },
+    { id: 'cache', type: 'engine-cache', geometry: { x: 4, y: 4, w: 4, h: 4 } },
+    { id: 'spec', type: 'engine-spec-decode', geometry: { x: 8, y: 4, w: 4, h: 4 } },
   ]
+}
+
+/** Speculative decoding, as an engine that has it enabled reports it. */
+const SPEC_DECODE: Partial<EngineMetrics> = {
+  spec_decode_draft_tokens_total: 400_000,
+  spec_decode_accepted_tokens_total: 300_000,
+  spec_decode_drafts_total: 100_000,
+  spec_decode_acceptance_rate: 75,
+  spec_decode_acceptance_rate_live: 71,
+  spec_decode_mean_acceptance_length: 3,
 }
 
 beforeEach(() => {
@@ -224,8 +239,46 @@ describe('the engine panels on a grid page', () => {
     // Swapped and preempted stay hidden while they are zero.
     expect(within(requests).queryByText('Swapped')).not.toBeInTheDocument()
 
+    // Goodput falls back to the backend's percentages while the engine ships
+    // no histogram buckets, and the combined figure is the worst of the three.
+    const goodput = region('SLO Goodput')
+    expect(within(goodput).getByText('Combined')).toBeInTheDocument()
+    // Combined is the worst of the three dimensions, so it reads as E2E's own
+    // figure — the same number twice, deliberately.
+    expect(within(goodput).getAllByText('97.0')).toHaveLength(2)
+    expect(within(goodput).getByText('99.0')).toBeInTheDocument()
+    expect(within(goodput).getByText('TTFT ≤ 500ms')).toBeInTheDocument()
+    expect(within(goodput).getByText('E2E ≤ 5s')).toBeInTheDocument()
+
+    const cache = region('Cache')
+    expect(within(cache).getByText('42')).toBeInTheDocument()
+    expect(within(cache).getByText('55')).toBeInTheDocument()
+    expect(within(cache).getByText('2M')).toBeInTheDocument()
+
+    // This engine is not speculating, so the panel says so rather than
+    // rendering a section of dashes.
+    expect(
+      within(region('Speculative Decoding')).getByText(
+        'This engine is not using speculative decoding.',
+      ),
+    ).toBeInTheDocument()
+
     // Every panel on the page is implemented — no slot-keeping placeholders.
     expect(screen.queryByText('This panel is not available yet.')).not.toBeInTheDocument()
+  })
+
+  it('shows speculative decoding once the engine has drafted tokens', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(enginePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, [makeEngine(ALPHA, {}, SPEC_DECODE)]))
+
+    const spec = region('Speculative Decoding')
+    expect(within(spec).getByText('75')).toBeInTheDocument()
+    expect(within(spec).getByText('71% live')).toBeInTheDocument()
+    expect(within(spec).getByText('300K')).toBeInTheDocument()
+    expect(within(spec).getByText('400K')).toBeInTheDocument()
   })
 
   it('charts each panel’s own series over the panel’s window', async () => {
@@ -243,6 +296,10 @@ describe('the engine panels on a grid page', () => {
     expect(within(region('Latency')).getByTestId('chart-series-TTFT')).toHaveAttribute(
       'data-values',
       '210,250',
+    )
+    expect(within(region('Cache')).getByTestId('chart-series-KV Cache')).toHaveAttribute(
+      'data-values',
+      '42,42',
     )
   })
 
@@ -324,7 +381,7 @@ describe('the engine panels on a grid page', () => {
 
     // Every panel keeps its slot and says why it is empty; nothing breaks the
     // page, which is what keeps the dashboard useful for hardware alone.
-    expect(screen.getAllByText('No inference engine running.')).toHaveLength(4)
+    expect(screen.getAllByText('No inference engine running.')).toHaveLength(7)
   })
 
   it('tells an engine that is still starting apart from one that is not running', async () => {
@@ -370,7 +427,7 @@ describe('the engine panels on a grid page', () => {
     render(<App />)
     await configurationSettles(fetchMock)
 
-    expect(screen.getAllByText('Waiting for metrics')).toHaveLength(4)
+    expect(screen.getAllByText('Waiting for metrics')).toHaveLength(7)
 
     // The first snapshot must not trip the changed-hook-count trap.
     receive(makeSnapshot(1000, [makeEngine(ALPHA)]))

--- a/frontend/src/__tests__/App.gridPage.test.tsx
+++ b/frontend/src/__tests__/App.gridPage.test.tsx
@@ -92,12 +92,37 @@ describe('the grid page route', () => {
     render(<App />)
     await configurationSettles(fetchMock)
 
-    // The tracer panels render for real; the preset panels no component
-    // implements yet keep their slots as placeholders (#80–#82).
+    // Every panel the preset places is implemented (#80/#81), so the page
+    // renders in full rather than around placeholders.
     expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
     expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
     expect(screen.getByRole('region', { name: 'GPU Utilization' })).toBeInTheDocument()
-    expect(screen.getAllByText('This panel is not available yet.')).not.toHaveLength(0)
+    expect(screen.getByRole('region', { name: 'Latency' })).toBeInTheDocument()
+    expect(screen.queryByText('This panel is not available yet.')).not.toBeInTheDocument()
+  })
+
+  it('keeps the slot of a panel type this build has not implemented yet', async () => {
+    // The vocabulary names more panels than the registry implements — the log
+    // panel arrives with #82, and a preset written by a newer build can place
+    // one this build has never rendered. It keeps its slot rather than
+    // reflowing the arrangement around it.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'a', type: 'logs', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+        { id: 'b', type: 'memory', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+    visit('/pages/watch')
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    expect(
+      within(screen.getByRole('region', { name: 'Logs' })).getByText(
+        'This panel is not available yet.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
   })
 
   it('keeps an unknown panel type’s slot with a placeholder naming the type', async () => {

--- a/frontend/src/__tests__/browser/enginePanels.browser.test.tsx
+++ b/frontend/src/__tests__/browser/enginePanels.browser.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { EngineDecodeThroughputPanel } from '@/components/grid/panels/EngineThroughputPanel'
+import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
+import { useMetricsStore } from '@/hooks/useMetricsStore'
+import { FOLLOW } from '@/lib/dashboard/bindings'
+import { DEFAULT_TIME_WINDOW, type DashboardPanel } from '@/lib/dashboard/schema'
+import type { EngineMetrics, EngineSnapshot, MetricsSnapshot } from '@/types/metrics'
+
+// An engine panel adapting to its own box (#81): the mode decision runs on a
+// measured content size, which only a real layout engine produces — jsdom
+// measures every box as 0×0 and would render the chart at any size. The
+// thresholds themselves are unit-tested in mode.test.ts; this spec proves the
+// measurement drives them at the sizes the grid can produce.
+//
+// Tailwind classes do not apply here (no Tailwind build in the browser
+// project), so assertions use structural hooks — the chart container's
+// [data-chart] attribute — never the product styling.
+
+function engine(): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint: 'http://localhost:8000',
+    status: { type: 'Running' },
+    model: {
+      name: 'Qwen/Qwen3-8B',
+      parameter_size: null,
+      quantization: null,
+      precision: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: {
+      tokens_per_sec: 120,
+      avg_tokens_per_sec: 100,
+      per_request_tps: 40,
+      total_generation_tokens: 500_000,
+    } as EngineMetrics,
+    recent_requests: [],
+    deployment_mode: 'Native',
+  }
+}
+
+function snapshot(): MetricsSnapshot {
+  return {
+    timestamp_ms: 1000,
+    gpu: {
+      index: 0,
+      name: 'GPU 0',
+      utilization_percent: 76,
+      temperature_celsius: 61,
+      power_watts: 220,
+      power_limit_watts: 300,
+      clock_graphics_mhz: 2100,
+      clock_sm_mhz: null,
+      clock_memory_mhz: null,
+      fan_speed_percent: null,
+    },
+    cpu: { name: 'CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128,
+      used_bytes: 64,
+      available_bytes: 64,
+      cached_bytes: 8,
+      gpu_estimated_bytes: null,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: true,
+    },
+    disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
+    network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
+    engines: [engine()],
+    gpu_events: [],
+  }
+}
+
+const panel: DashboardPanel = {
+  id: 'decode',
+  type: 'engine-decode-throughput',
+  geometry: { x: 0, y: 0, w: 3, h: 3 },
+  binding: FOLLOW,
+  window: DEFAULT_TIME_WINDOW,
+}
+
+function Ingest() {
+  const store = useMetricsStore()
+  useEffect(() => {
+    store.ingest(snapshot())
+  }, [store])
+  return null
+}
+
+function Harness({ width, height }: { width: number; height: number }) {
+  return (
+    <MetricsStoreProvider>
+      <Ingest />
+      <div style={{ width, height }}>
+        <EngineDecodeThroughputPanel panel={panel} />
+      </div>
+    </MetricsStoreProvider>
+  )
+}
+
+describe('an engine panel in a real layout engine', () => {
+  it('keeps its values and drops the chart in a short grid cell', async () => {
+    const { container, getByText } = render(<Harness width={320} height={140} />)
+
+    await waitFor(() => {
+      // The values are what the panel is for, so they survive the squeeze…
+      expect(getByText('120.0')).toBeTruthy()
+      // …and nothing tries to squeeze a chart into what is left.
+      expect(container.querySelector('[data-chart]')).toBeNull()
+    })
+  })
+
+  it('charts under its values when its own box has room for both', async () => {
+    const { container, getByText } = render(<Harness width={320} height={320} />)
+
+    await waitFor(() => {
+      expect(getByText('120.0')).toBeTruthy()
+      expect(container.querySelector('[data-chart]')).toBeTruthy()
+    })
+  })
+})

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -4,7 +4,9 @@ import {
   formatGiB,
   formatCompactTokens,
   formatAcceptanceLength,
+  formatEndpoint,
   formatGpuIndexes,
+  engineDescription,
 } from '../lib/format'
 
 const GIB = 1_073_741_824
@@ -87,5 +89,35 @@ describe('formatGpuIndexes', () => {
 
   it('renders an empty string when no indexes are known', () => {
     expect(formatGpuIndexes([])).toBe('')
+  })
+})
+
+describe('formatEndpoint', () => {
+  it('keeps the host and port an operator configured', () => {
+    expect(formatEndpoint('http://localhost:8000')).toBe('localhost:8000')
+    expect(formatEndpoint('https://gpu-node-2.internal:8443/v1')).toBe('gpu-node-2.internal:8443')
+  })
+
+  it('keeps a default port that the URL leaves implicit', () => {
+    // Two engines can differ only by scheme, so dropping the host would be
+    // worse than showing no port.
+    expect(formatEndpoint('http://localhost')).toBe('localhost')
+  })
+
+  it('falls back to the endpoint as stored when it is not a URL', () => {
+    // The operator has to be able to match the label against their config,
+    // whatever shape the endpoint came in.
+    expect(formatEndpoint('localhost:8000')).toBe('localhost:8000')
+    expect(formatEndpoint('')).toBe('')
+  })
+})
+
+describe('engineDescription', () => {
+  it('names the provider and the instance', () => {
+    // Both halves are needed: a host can run several engines of one provider,
+    // which is exactly when a panel has to say which one it shows.
+    expect(engineDescription({ engine_type: 'Vllm', endpoint: 'http://localhost:8001' })).toBe(
+      'vLLM localhost:8001',
+    )
   })
 })

--- a/frontend/src/__tests__/pageSelection.test.tsx
+++ b/frontend/src/__tests__/pageSelection.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest'
+import { act, render, screen, within } from '@testing-library/react'
+import { useEffect } from 'react'
+import { GridPanel } from '@/components/grid/GridPanel'
+import { PageSelectionProvider } from '@/hooks/PageSelectionProvider'
+import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
+import { useMetricsStore } from '@/hooks/useMetricsStore'
+import { usePageSelection } from '@/hooks/usePageSelection'
+import { FOLLOW } from '@/lib/dashboard/bindings'
+import { DEFAULT_TIME_WINDOW, type DashboardPanel } from '@/lib/dashboard/schema'
+import type { GpuMetrics, MetricsSnapshot } from '@/types/metrics'
+
+// The page-level selection (#81): what every `follow` panel on a page defers
+// to. The panels are the real ones, rendered through the real frame; only the
+// affordance that changes the selection is local to this spec, because the UI
+// for changing it ships later (#84/#85) and the machinery has to be right
+// first.
+vi.mock('@/components/charts/TimeSeriesChart', () => ({
+  TimeSeriesChart: (props: { data?: Array<{ value: number }> }) => (
+    <div data-testid="chart" data-values={props.data?.map((p) => p.value).join(',')} />
+  ),
+}))
+
+function makeGpu(index: number, utilization: number): GpuMetrics {
+  return {
+    index,
+    name: `NVIDIA Alpha ${index}`,
+    utilization_percent: utilization,
+    memory_total_bytes: null,
+    memory_used_bytes: null,
+    temperature_celsius: 40 + index,
+    power_watts: 100 + index,
+    power_limit_watts: 300,
+    clock_graphics_mhz: 2000 + index,
+    clock_sm_mhz: null,
+    clock_memory_mhz: null,
+    fan_speed_percent: null,
+  }
+}
+
+function snapshot(): MetricsSnapshot {
+  const gpus = [makeGpu(0, 11), makeGpu(1, 77)]
+  return {
+    timestamp_ms: 1000,
+    gpu: gpus[0],
+    gpus,
+    cpu: { name: 'CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128,
+      used_bytes: 64,
+      available_bytes: 64,
+      cached_bytes: 8,
+      gpu_estimated_bytes: null,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: true,
+    },
+    disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
+    network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
+    engines: [],
+    gpu_events: [],
+  }
+}
+
+function panel(id: string, type: string): DashboardPanel {
+  return {
+    id,
+    type,
+    geometry: { x: 0, y: 0, w: 3, h: 3 },
+    binding: FOLLOW,
+    window: DEFAULT_TIME_WINDOW,
+  }
+}
+
+/** Stands in for the selector UI that ships with #84/#85. */
+function SelectGpu({ index }: { index: number | null }) {
+  const { selectGpu } = usePageSelection()
+  return (
+    <button type="button" onClick={() => selectGpu(index)}>
+      Select GPU {index ?? 'default'}
+    </button>
+  )
+}
+
+function Ingest() {
+  const store = useMetricsStore()
+  useEffect(() => {
+    store.ingest(snapshot())
+  }, [store])
+  return null
+}
+
+function Page() {
+  return (
+    <MetricsStoreProvider>
+      <Ingest />
+      <PageSelectionProvider>
+        <SelectGpu index={1} />
+        <SelectGpu index={null} />
+        <GridPanel panel={panel('util', 'gpu-utilization')} />
+        <GridPanel panel={panel('temp', 'gpu-temperature')} />
+        <GridPanel
+          panel={{ ...panel('pinned', 'gpu-utilization'), title: 'Pinned to GPU 0', binding: { kind: 'gpu', index: 0 } }}
+        />
+      </PageSelectionProvider>
+    </MetricsStoreProvider>
+  )
+}
+
+function region(name: string): HTMLElement {
+  return screen.getByRole('region', { name })
+}
+
+function click(name: string) {
+  act(() => screen.getByRole('button', { name }).click())
+}
+
+describe('the page-level GPU selection', () => {
+  it('starts on the primary GPU, moves every following panel together, and leaves pins alone', () => {
+    render(<Page />)
+
+    // Nothing chosen: the page follows the host's primary GPU.
+    expect(within(region('GPU Utilization')).getByText('11')).toBeInTheDocument()
+    expect(within(region('GPU Temp')).getByText('40')).toBeInTheDocument()
+
+    click('Select GPU 1')
+
+    // One selection change, and every following panel moved with it — value and
+    // chart series, so no panel is showing another GPU's numbers.
+    const util = region('GPU Utilization')
+    expect(within(util).getByText('77')).toBeInTheDocument()
+    expect(within(util).getByTestId('chart')).toHaveAttribute('data-values', '77')
+    expect(within(region('GPU Temp')).getByText('41')).toBeInTheDocument()
+
+    // The pinned panel stayed where it was pinned.
+    expect(within(region('Pinned to GPU 0')).getByText('11')).toBeInTheDocument()
+
+    click('Select GPU default')
+    expect(within(region('GPU Utilization')).getByText('11')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/pageSelection.test.tsx
+++ b/frontend/src/__tests__/pageSelection.test.tsx
@@ -8,7 +8,7 @@ import { useMetricsStore } from '@/hooks/useMetricsStore'
 import { usePageSelection } from '@/hooks/usePageSelection'
 import { FOLLOW } from '@/lib/dashboard/bindings'
 import { DEFAULT_TIME_WINDOW, type DashboardPanel } from '@/lib/dashboard/schema'
-import type { GpuMetrics, MetricsSnapshot } from '@/types/metrics'
+import type { EngineMetrics, EngineSnapshot, GpuMetrics, MetricsSnapshot } from '@/types/metrics'
 
 // The page-level selection (#81): what every `follow` panel on a page defers
 // to. The panels are the real ones, rendered through the real frame; only the
@@ -20,6 +20,9 @@ vi.mock('@/components/charts/TimeSeriesChart', () => ({
     <div data-testid="chart" data-values={props.data?.map((p) => p.value).join(',')} />
   ),
 }))
+
+const ALPHA = 'http://localhost:8000'
+const BETA = 'http://localhost:8001'
 
 function makeGpu(index: number, utilization: number): GpuMetrics {
   return {
@@ -35,6 +38,26 @@ function makeGpu(index: number, utilization: number): GpuMetrics {
     clock_sm_mhz: null,
     clock_memory_mhz: null,
     fan_speed_percent: null,
+  }
+}
+
+function makeEngine(endpoint: string, tokensPerSec: number): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status: { type: 'Running' },
+    model: {
+      name: 'Qwen/Qwen3-8B',
+      parameter_size: null,
+      quantization: null,
+      precision: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: { tokens_per_sec: tokensPerSec } as EngineMetrics,
+    recent_requests: [],
+    deployment_mode: 'Native',
   }
 }
 
@@ -57,7 +80,7 @@ function snapshot(): MetricsSnapshot {
     },
     disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
     network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
-    engines: [],
+    engines: [makeEngine(ALPHA, 120), makeEngine(BETA, 640)],
     gpu_events: [],
   }
 }
@@ -72,12 +95,21 @@ function panel(id: string, type: string): DashboardPanel {
   }
 }
 
-/** Stands in for the selector UI that ships with #84/#85. */
+/** Stand-ins for the selector UI that ships with #84/#85. */
 function SelectGpu({ index }: { index: number | null }) {
   const { selectGpu } = usePageSelection()
   return (
     <button type="button" onClick={() => selectGpu(index)}>
       Select GPU {index ?? 'default'}
+    </button>
+  )
+}
+
+function SelectEngine({ endpoint }: { endpoint: string }) {
+  const { selectEngine } = usePageSelection()
+  return (
+    <button type="button" onClick={() => selectEngine(endpoint)}>
+      Select {endpoint}
     </button>
   )
 }
@@ -97,10 +129,20 @@ function Page() {
       <PageSelectionProvider>
         <SelectGpu index={1} />
         <SelectGpu index={null} />
+        <SelectEngine endpoint={BETA} />
         <GridPanel panel={panel('util', 'gpu-utilization')} />
         <GridPanel panel={panel('temp', 'gpu-temperature')} />
         <GridPanel
           panel={{ ...panel('pinned', 'gpu-utilization'), title: 'Pinned to GPU 0', binding: { kind: 'gpu', index: 0 } }}
+        />
+        <GridPanel panel={panel('decode', 'engine-decode-throughput')} />
+        <GridPanel panel={panel('requests', 'engine-requests')} />
+        <GridPanel
+          panel={{
+            ...panel('pinned-engine', 'engine-decode-throughput'),
+            title: 'Pinned to Alpha',
+            binding: { kind: 'engine', endpoint: ALPHA },
+          }}
         />
       </PageSelectionProvider>
     </MetricsStoreProvider>
@@ -137,5 +179,23 @@ describe('the page-level GPU selection', () => {
 
     click('Select GPU default')
     expect(within(region('GPU Utilization')).getByText('11')).toBeInTheDocument()
+  })
+})
+
+describe('the page-level engine selection', () => {
+  it('starts on the running engine and moves every following panel together', () => {
+    render(<Page />)
+
+    // Nothing chosen: the page follows the first running engine.
+    expect(within(region('Decode Throughput')).getByText('120.0')).toBeInTheDocument()
+    expect(within(region('Pinned to Alpha')).getByText('120.0')).toBeInTheDocument()
+
+    click(`Select ${BETA}`)
+
+    // Both following panels moved to the other engine…
+    expect(within(region('Decode Throughput')).getByText('640.0')).toBeInTheDocument()
+    expect(within(region('Requests')).getByText('vLLM localhost:8001')).toBeInTheDocument()
+    // …and the pinned one stayed on the engine it names.
+    expect(within(region('Pinned to Alpha')).getByText('120.0')).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/slo.test.ts
+++ b/frontend/src/__tests__/slo.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   combinedGoodput,
   DEFAULT_SLO,
+  formatSloThreshold,
   fractionLe,
   recomputeGoodputPct,
   SLO,
@@ -152,5 +153,24 @@ describe('combinedGoodput', () => {
     // combinedGoodput must still take exactly three dimensions.
     expect(combinedGoodput.length).toBe(3)
     expect(combinedGoodput(99, 95, 88)).toBe(88)
+  })
+})
+
+describe('formatSloThreshold', () => {
+  it('renders a whole number of seconds without a decimal', () => {
+    // The default E2E objective has always read "5s"; tuning another threshold
+    // must not change how this one looks.
+    expect(formatSloThreshold(5000)).toBe('5s')
+    expect(formatSloThreshold(1000)).toBe('1s')
+  })
+
+  it('renders a tuned value to one decimal', () => {
+    expect(formatSloThreshold(2500)).toBe('2.5s')
+    expect(formatSloThreshold(1250)).toBe('1.3s')
+  })
+
+  it('stays in milliseconds below a second', () => {
+    expect(formatSloThreshold(800)).toBe('800ms')
+    expect(formatSloThreshold(50)).toBe('50ms')
   })
 })

--- a/frontend/src/__tests__/useLatencyMode.test.ts
+++ b/frontend/src/__tests__/useLatencyMode.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useLatencyMode } from '@/hooks/useLatencyMode'
+
+const STORAGE_KEY = 'spark-dashboard:latency-mode'
+
+beforeEach(() => {
+  // Storage is where the setting lives, so clearing it is a full reset.
+  window.localStorage.clear()
+})
+
+describe('useLatencyMode', () => {
+  it('starts from the setting the operator left behind', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'p95')
+
+    const { result } = renderHook(() => useLatencyMode())
+
+    expect(result.current[0]).toBe('p95')
+  })
+
+  it('falls back to the average when nothing readable is stored', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'p42')
+
+    expect(renderHook(() => useLatencyMode()).result.current[0]).toBe('avg')
+  })
+
+  it('moves every consumer together', () => {
+    // Two latency panels on one page must not show different statistics:
+    // comparing a p95 tile against an average one is how a tail-latency
+    // problem gets misread.
+    const first = renderHook(() => useLatencyMode())
+    const second = renderHook(() => useLatencyMode())
+
+    act(() => first.result.current[1]('p99'))
+
+    expect(first.result.current[0]).toBe('p99')
+    expect(second.result.current[0]).toBe('p99')
+  })
+
+  it('stores the choice for the next session', () => {
+    const { result } = renderHook(() => useLatencyMode())
+
+    act(() => result.current[1]('p50'))
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('p50')
+  })
+})

--- a/frontend/src/components/engines/EngineCard.tsx
+++ b/frontend/src/components/engines/EngineCard.tsx
@@ -14,22 +14,9 @@ import {
 import { type ChartDataPoint, type Trend, computeTrend } from '@/lib/engineStats'
 import { AnimatedCounter } from './AnimatedCounter'
 import { type LatencyMode, latencyModeLabel, pickLatencyValue } from '@/lib/latencyMode'
-import { combinedGoodput, recomputeGoodputPct } from '@/lib/slo'
+import { combinedGoodput, formatSloThreshold, recomputeGoodputPct } from '@/lib/slo'
 import { useSloSettings } from '@/hooks/useSloSettings'
 import { SloSettingsControl } from './SloSettingsControl'
-
-/** Render an E2E threshold in seconds when it's a clean multiple of 1000ms,
- *  otherwise fall through to milliseconds. Keeps the default "5s" label
- *  intact while supporting user-tuned values like 2500ms ("2.5s") or 800ms.
- */
-function formatE2eLabel(e2eMs: number): string {
-  if (e2eMs >= 1000) {
-    const seconds = e2eMs / 1000
-    const formatted = Number.isInteger(seconds) ? seconds.toString() : seconds.toFixed(1)
-    return `${formatted}s`
-  }
-  return `${e2eMs}ms`
-}
 
 function decodeTokenSeries(chartData: {
   tps: ChartDataPoint[]
@@ -279,7 +266,7 @@ export function EngineCard({
                 <GoodputTile label={`TTFT ≤ ${slo.ttftMs}ms`} pct={ttftGoodput} />
                 <GoodputTile label={`ITL ≤ ${slo.itlMs}ms`} pct={itlGoodput} />
                 <GoodputTile label={`TPOT ≤ ${slo.tpotMs}ms`} pct={tpotGoodput} />
-                <GoodputTile label={`E2E ≤ ${formatE2eLabel(slo.e2eMs)}`} pct={e2eGoodput} />
+                <GoodputTile label={`E2E ≤ ${formatSloThreshold(slo.e2eMs)}`} pct={e2eGoodput} />
               </div>
             </div>
 

--- a/frontend/src/components/engines/EngineSection.tsx
+++ b/frontend/src/components/engines/EngineSection.tsx
@@ -12,15 +12,11 @@ import {
   serializeRotationState,
   type RotationInterval,
 } from '@/lib/rotation'
-import {
-  parseLatencyMode,
-  serializeLatencyMode,
-  type LatencyMode,
-} from '@/lib/latencyMode'
 import { aggregateEngines, groupRunningByProvider } from '@/lib/engineAggregate'
 import { engineDisplayName, formatGpuIndexes } from '@/lib/format'
 import { engineKey, findEngineByKey } from '@/lib/identity'
 import { getProviderLogo } from '@/lib/providerLogo'
+import { useLatencyMode } from '@/hooks/useLatencyMode'
 import { useTabRotation } from '@/hooks/useTabRotation'
 import type { EngineSnapshot, EngineType, DeploymentMode } from '@/types/metrics'
 import type { InferenceRequest } from '@/types/events'
@@ -31,7 +27,6 @@ const ENGINE_ICON: Record<EngineType, string> = {
 }
 
 const ROTATION_INTERVAL_STORAGE_KEY = 'spark-dashboard:engine-rotation-interval'
-const LATENCY_MODE_STORAGE_KEY = 'spark-dashboard:latency-mode'
 const ACTIVE_TAB_STORAGE_KEY = 'spark-dashboard:active-tab'
 
 function EngineChip({ label, iconSrc }: { label: string; iconSrc?: string }) {
@@ -167,14 +162,7 @@ export function EngineSection({
       return 10000
     }
   })
-  const [latencyMode, setLatencyMode] = useState<LatencyMode>(() => {
-    if (typeof window === 'undefined') return 'avg'
-    try {
-      return parseLatencyMode(window.localStorage.getItem(LATENCY_MODE_STORAGE_KEY))
-    } catch {
-      return 'avg'
-    }
-  })
+  const [latencyMode, setLatencyMode] = useLatencyMode()
   const [focusWithin, setFocusWithin] = useState(false)
   const [userPaused, setUserPaused] = useState(false)
 
@@ -228,15 +216,6 @@ export function EngineSection({
       // ignore storage errors (private mode, quota, etc.)
     }
   }, [rotationEnabledState, rotationInterval])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    try {
-      window.localStorage.setItem(LATENCY_MODE_STORAGE_KEY, serializeLatencyMode(latencyMode))
-    } catch {
-      // ignore storage errors
-    }
-  }, [latencyMode])
 
   const aggregate = useMemo(() => aggregateEngines(engines), [engines])
   const providerGroups = useMemo(() => groupRunningByProvider(engines), [engines])

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -1,6 +1,7 @@
 import 'gridstack/dist/gridstack.css'
 import { useMemo } from 'react'
 import { GridStack, GridStackItem, type GridStackOptions } from 'gridstack/dist/react'
+import { PageSelectionProvider } from '@/hooks/PageSelectionProvider'
 import { useElementSize } from '@/hooks/useElementSize'
 import { GRID_COLUMNS, GRID_MAX_ROWS } from '@/lib/dashboard/grid'
 import type { DashboardPage } from '@/lib/dashboard/schema'
@@ -74,13 +75,18 @@ export function GridPage({ page }: { page: DashboardPage }) {
       style={{ height: '100%' }}
       className={`min-h-0 ${narrow ? 'overflow-y-auto' : 'overflow-hidden'}`}
     >
-      <GridStack options={options}>
-        {page.panels.map((panel) => (
-          <GridStackItem key={panel.id} id={panel.id} options={panel.geometry}>
-            <GridPanel panel={panel} />
-          </GridStackItem>
-        ))}
-      </GridStack>
+      {/* The selection is per page and lives inside it: every following panel
+          on this page reads the same GPU and engine, and a page mounted at
+          another id starts from the host's defaults again. */}
+      <PageSelectionProvider>
+        <GridStack options={options}>
+          {page.panels.map((panel) => (
+            <GridStackItem key={panel.id} id={panel.id} options={panel.geometry}>
+              <GridPanel panel={panel} />
+            </GridStackItem>
+          ))}
+        </GridStack>
+      </PageSelectionProvider>
     </div>
   )
 }

--- a/frontend/src/components/grid/panelRegistry.tsx
+++ b/frontend/src/components/grid/panelRegistry.tsx
@@ -7,8 +7,8 @@
  * that keeps its grid slot. That is what lets the panel tickets (#81–#82) land
  * one at a time against a preset that already names every type.
  *
- * The eight hardware panels (#80) are implemented; the engine and log panels
- * arrive with #81/#82.
+ * The eight hardware panels (#80) and the engine metric panels (#81) are
+ * implemented; the log panel arrives with #82.
  */
 
 import type { ComponentType, ReactElement } from 'react'
@@ -16,6 +16,12 @@ import { isKnownPanelType, type PanelType } from '@/lib/dashboard/panels'
 import type { DashboardPanel } from '@/lib/dashboard/schema'
 import { CpuUtilizationPanel } from './panels/CpuUtilizationPanel'
 import { DiskIoPanel } from './panels/DiskIoPanel'
+import { EngineLatencyPanel } from './panels/EngineLatencyPanel'
+import { EngineRequestsPanel } from './panels/EngineRequestsPanel'
+import {
+  EngineDecodeThroughputPanel,
+  EnginePrefillThroughputPanel,
+} from './panels/EngineThroughputPanel'
 import { GpuClockPanel } from './panels/GpuClockPanel'
 import { GpuPowerPanel } from './panels/GpuPowerPanel'
 import { GpuTemperaturePanel } from './panels/GpuTemperaturePanel'
@@ -38,6 +44,10 @@ const PANEL_CONTENT: Partial<Record<PanelType, ComponentType<PanelContentProps>>
   memory: MemoryPanel,
   'disk-io': DiskIoPanel,
   'network-io': NetworkIoPanel,
+  'engine-prefill-throughput': EnginePrefillThroughputPanel,
+  'engine-decode-throughput': EngineDecodeThroughputPanel,
+  'engine-latency': EngineLatencyPanel,
+  'engine-requests': EngineRequestsPanel,
 }
 
 /**

--- a/frontend/src/components/grid/panelRegistry.tsx
+++ b/frontend/src/components/grid/panelRegistry.tsx
@@ -16,8 +16,11 @@ import { isKnownPanelType, type PanelType } from '@/lib/dashboard/panels'
 import type { DashboardPanel } from '@/lib/dashboard/schema'
 import { CpuUtilizationPanel } from './panels/CpuUtilizationPanel'
 import { DiskIoPanel } from './panels/DiskIoPanel'
+import { EngineCachePanel } from './panels/EngineCachePanel'
 import { EngineLatencyPanel } from './panels/EngineLatencyPanel'
 import { EngineRequestsPanel } from './panels/EngineRequestsPanel'
+import { EngineSloGoodputPanel } from './panels/EngineSloGoodputPanel'
+import { EngineSpecDecodePanel } from './panels/EngineSpecDecodePanel'
 import {
   EngineDecodeThroughputPanel,
   EnginePrefillThroughputPanel,
@@ -48,6 +51,9 @@ const PANEL_CONTENT: Partial<Record<PanelType, ComponentType<PanelContentProps>>
   'engine-decode-throughput': EngineDecodeThroughputPanel,
   'engine-latency': EngineLatencyPanel,
   'engine-requests': EngineRequestsPanel,
+  'engine-slo-goodput': EngineSloGoodputPanel,
+  'engine-cache': EngineCachePanel,
+  'engine-spec-decode': EngineSpecDecodePanel,
 }
 
 /**

--- a/frontend/src/components/grid/panels/EngineCachePanel.tsx
+++ b/frontend/src/components/grid/panels/EngineCachePanel.tsx
@@ -1,0 +1,80 @@
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { AnimatedCounter } from '@/components/engines/AnimatedCounter'
+import { KvBar, MetricTile, TrendArrow } from '@/components/engines/EngineCardPrimitives'
+import { computeTrend } from '@/lib/engineStats'
+import { formatCompactTokens } from '@/lib/format'
+import { EnginePanelBody } from './EnginePanelBody'
+import { engineLabel } from './engineLabel'
+import { EnginePanelNotice } from './PanelNotice'
+import { useEnginePanel } from './useEnginePanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * How much of the engine's KV cache is in use, and how much of the prompt
+ * traffic the prefix cache is answering.
+ *
+ * The two belong together: a KV cache filling up is what limits how many
+ * requests an engine can hold, and prefix hits are what keep it from filling.
+ */
+export function EngineCachePanel({ panel }: PanelContentProps) {
+  const resolution = useEnginePanel(panel)
+  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+
+  const { metric, series } = resolution
+  const kvPercent = metric('kv_cache_percent')
+  const prefixHit = metric('prefix_cache_hit_rate')
+  const kvSeries = series('kvCache')
+
+  return (
+    <EnginePanelBody
+      label={engineLabel(resolution)}
+      tiles={
+        <div className="flex flex-col gap-2">
+          <div className="grid grid-cols-2 gap-1.5">
+            <div className="flex flex-col gap-0.5 min-w-0">
+              <span className="text-[10px] font-medium text-zinc-400 uppercase tracking-wider truncate">
+                KV Cache
+              </span>
+              <div className="flex items-baseline">
+                <span className="text-lg xl:text-xl 2xl:text-2xl min-[1920px]:text-3xl font-bold text-zinc-100 font-mono tabular-nums leading-none">
+                  {kvPercent !== null ? Math.round(kvPercent) : '--'}
+                </span>
+                <span className="text-xs text-zinc-500 ml-1">%</span>
+                {/* A filling cache is bad news, so the arrow's colours invert. */}
+                <TrendArrow trend={computeTrend(kvSeries)} invertColor />
+              </div>
+              {kvPercent !== null && <KvBar percent={kvPercent} />}
+            </div>
+            <MetricTile
+              label="Prefix Hit"
+              value={prefixHit !== null ? `${Math.round(prefixHit)}` : '--'}
+              unit="%"
+            />
+          </div>
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <span className="text-[10px] 2xl:text-xs font-medium text-zinc-400 uppercase tracking-wider truncate">
+              Prefix Queries
+            </span>
+            <AnimatedCounter
+              value={metric('prefix_cache_queries_total')}
+              format={formatCompactTokens}
+              className="text-lg xl:text-xl 2xl:text-2xl min-[1920px]:text-3xl font-bold text-zinc-100 font-mono tabular-nums leading-none"
+            />
+          </div>
+        </div>
+      }
+      chart={
+        <TimeSeriesChart
+          hideTooltipLabel
+          series={[
+            { data: kvSeries, label: 'KV Cache', color: '#76B900' },
+            { data: series('prefixCacheHit'), label: 'Prefix Hit', color: '#3b82f6' },
+          ]}
+          yDomain={[0, 100]}
+          unit="%"
+          height="100%"
+        />
+      }
+    />
+  )
+}

--- a/frontend/src/components/grid/panels/EngineLatencyPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineLatencyPanel.tsx
@@ -1,0 +1,122 @@
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { MetricTile } from '@/components/engines/EngineCardPrimitives'
+import { LatencyModeControl } from '@/components/engines/LatencyModeControl'
+import { useLatencyMode } from '@/hooks/useLatencyMode'
+import { computeTrend } from '@/lib/engineStats'
+import { formatDurationMs, formatTtft, fmtVal } from '@/lib/format'
+import { pickLatencyValue, type LatencyMode } from '@/lib/latencyMode'
+import type { EngineSeriesName } from '@/lib/metricsHistoryStore'
+import { EnginePanelBody } from './EnginePanelBody'
+import { engineLabel } from './engineLabel'
+import { EnginePanelNotice } from './PanelNotice'
+import { useEnginePanel } from './useEnginePanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * The latency an engine is serving at: time to first token, end to end, queue
+ * wait, and the two per-token measures.
+ *
+ * Every value and every line follows the same statistic — average, or one of
+ * the percentiles. Mixing them within a panel would be the quiet way to
+ * misread a tail-latency problem as a healthy average, so the mode is one
+ * choice made in the panel's own header.
+ */
+export function EngineLatencyPanel({ panel }: PanelContentProps) {
+  const resolution = useEnginePanel(panel)
+  const [mode, setMode] = useLatencyMode()
+  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+
+  const { metric, series } = resolution
+  const ttft = pickLatencyValue(mode, metric('ttft_ms'), metric('ttft_percentiles'))
+  const itl = pickLatencyValue(mode, metric('inter_token_latency_ms'), metric('itl_percentiles'))
+  const e2e = pickLatencyValue(mode, metric('e2e_latency_ms'), metric('e2e_percentiles'))
+  const tpot = pickLatencyValue(mode, metric('tpot_ms'), metric('tpot_percentiles'))
+  const batchSize = metric('avg_batch_size')
+  const e2eDisplay = formatDurationMs(e2e)
+
+  const ttftSeries = series(LATENCY_SERIES.ttft[mode])
+  const itlSeries = series(LATENCY_SERIES.itl[mode])
+  const tpotSeries = series(LATENCY_SERIES.tpot[mode])
+  const e2eSeries = series(LATENCY_SERIES.e2e[mode])
+  const queueSeries = series('queueTime')
+
+  return (
+    <EnginePanelBody
+      label={engineLabel(resolution)}
+      actions={<LatencyModeControl mode={mode} onModeChange={setMode} />}
+      tiles={
+        <div className="grid grid-cols-2 gap-1.5">
+          <MetricTile
+            label="TTFT"
+            value={fmtVal(ttft, formatTtft)}
+            unit="ms"
+            trend={computeTrend(ttftSeries)}
+            invertTrend
+          />
+          <MetricTile
+            label="E2E"
+            value={e2eDisplay.value}
+            unit={e2eDisplay.unit}
+            trend={computeTrend(e2eSeries)}
+            invertTrend
+          />
+          <MetricTile
+            label="Queue"
+            value={fmtVal(metric('queue_time_ms'), formatTtft)}
+            unit="ms"
+            trend={computeTrend(queueSeries)}
+            invertTrend
+          />
+          <MetricTile
+            label="ITL"
+            value={fmtVal(itl, formatTtft)}
+            unit="ms"
+            trend={computeTrend(itlSeries)}
+            invertTrend
+          />
+          <MetricTile
+            label="TPOT"
+            value={fmtVal(tpot, formatTtft)}
+            unit="ms"
+            trend={computeTrend(tpotSeries)}
+            invertTrend
+          />
+          <MetricTile
+            label="Batch"
+            value={batchSize !== null ? batchSize.toFixed(1) : '--'}
+            unit="/step"
+            trend={computeTrend(series('batchSize'))}
+          />
+        </div>
+      }
+      chart={
+        <TimeSeriesChart
+          hideTooltipLabel
+          series={[
+            // TTFT lives on the left axis (typically hundreds of ms); queue,
+            // ITL and TPOT share a right axis (often single or double digits)
+            // so their variation stays visible against the TTFT scale.
+            { data: ttftSeries, label: 'TTFT', color: '#f59e0b', axis: 'left' },
+            { data: queueSeries, label: 'Queue', color: '#8b5cf6', axis: 'right' },
+            { data: itlSeries, label: 'ITL', color: '#14b8a6', axis: 'right' },
+            { data: tpotSeries, label: 'TPOT', color: '#ec4899', axis: 'right' },
+          ]}
+          unit="ms"
+          height="100%"
+        />
+      }
+    />
+  )
+}
+
+/**
+ * Which series carries each latency dimension under each statistic. The
+ * percentile series are ingested alongside the averages, so switching the mode
+ * re-reads history rather than starting a new one.
+ */
+const LATENCY_SERIES = {
+  ttft: { avg: 'ttft', p50: 'ttftP50', p95: 'ttftP95', p99: 'ttftP99' },
+  itl: { avg: 'interTokenLatency', p50: 'itlP50', p95: 'itlP95', p99: 'itlP99' },
+  e2e: { avg: 'e2eLatency', p50: 'e2eP50', p95: 'e2eP95', p99: 'e2eP99' },
+  tpot: { avg: 'tpot', p50: 'tpotP50', p95: 'tpotP95', p99: 'tpotP99' },
+} as const satisfies Record<string, Record<LatencyMode, EngineSeriesName>>

--- a/frontend/src/components/grid/panels/EnginePanelBody.tsx
+++ b/frontend/src/components/grid/panels/EnginePanelBody.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react'
+import { useElementSize } from '@/hooks/useElementSize'
+import { enginePanelMode } from './mode'
+
+interface EnginePanelBodyProps {
+  /** Names the engine, on a host running more than one. Null keeps the row out
+   *  of the layout entirely, which is the single-engine case. */
+  label?: string | null
+  /** Controls belonging to this panel — the SLO thresholds, the latency mode.
+   *  They share the label row, so they cost no height of their own. */
+  actions?: ReactNode
+  /** The values. Always rendered: they are what the panel is for. */
+  tiles: ReactNode
+  /** The trend chart, given the room the tiles leave. Omitted by panels that
+   *  have no series worth charting. */
+  chart?: ReactNode
+}
+
+/**
+ * The shared body of every engine panel: measures its own box and drops the
+ * chart when the tiles have taken the height.
+ *
+ * The label row is how a panel keeps its promise not to show one engine's
+ * numbers under another's name — with several engines on a host, "Latency"
+ * alone does not say whose.
+ */
+export function EnginePanelBody({ label, actions, tiles, chart }: EnginePanelBodyProps) {
+  const [ref, size] = useElementSize<HTMLDivElement>()
+  const mode = enginePanelMode(size)
+
+  return (
+    <div
+      ref={ref}
+      // Inline rather than `h-full`: the measured height decides the mode, so it
+      // must hold anywhere the component renders — including the browser test
+      // project, which runs no Tailwind build (same rule as GridPage).
+      style={{ height: '100%' }}
+      className="flex flex-col min-h-0 min-w-0 overflow-hidden gap-1"
+    >
+      {(label || actions) && (
+        <div className="shrink-0 flex items-center justify-between gap-2 min-w-0">
+          {label && (
+            <span className="text-[10px] font-medium uppercase tracking-wider text-zinc-500 truncate">
+              {label}
+            </span>
+          )}
+          {actions}
+        </div>
+      )}
+      <div className="shrink-0 min-w-0">{tiles}</div>
+      {mode === 'full' && chart && <div className="flex-1 min-h-0 min-w-0">{chart}</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/grid/panels/EngineRequestsPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineRequestsPanel.tsx
@@ -1,0 +1,57 @@
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { MetricTile } from '@/components/engines/EngineCardPrimitives'
+import { fmtInt } from '@/lib/format'
+import { EnginePanelBody } from './EnginePanelBody'
+import { engineLabel } from './engineLabel'
+import { EnginePanelNotice } from './PanelNotice'
+import { useEnginePanel } from './useEnginePanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * What the engine has in flight: active, queued and lifetime request counts.
+ *
+ * Swapped and preempted requests appear only once they have happened. They are
+ * both signs of an engine under memory pressure, so a zero would be noise on a
+ * healthy engine and the tile appearing at all is the signal.
+ */
+export function EngineRequestsPanel({ panel }: PanelContentProps) {
+  const resolution = useEnginePanel(panel)
+  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+
+  const { metric, series } = resolution
+  const swapped = metric('swapped_requests')
+  const preemptions = metric('preemptions_total')
+
+  return (
+    <EnginePanelBody
+      label={engineLabel(resolution)}
+      tiles={
+        <div className="grid grid-cols-2 gap-1.5">
+          <MetricTile label="Active" value={fmtInt(metric('active_requests'))} />
+          <MetricTile label="Queued" value={fmtInt(metric('queued_requests'))} />
+          <MetricTile label="Total" value={fmtInt(metric('total_requests'))} />
+          {swapped !== null && swapped > 0 && (
+            <MetricTile label="Swapped" value={fmtInt(swapped)} warn />
+          )}
+          {preemptions !== null && preemptions > 0 && (
+            <MetricTile label="Preempt" value={fmtInt(preemptions)} warn />
+          )}
+        </div>
+      }
+      chart={
+        <TimeSeriesChart
+          hideTooltipLabel
+          series={[
+            { data: series('activeRequests'), label: 'Active', color: '#76B900', axis: 'left' },
+            { data: series('queuedRequests'), label: 'Queued', color: '#f59e0b', axis: 'left' },
+            // The lifetime counter only climbs, so it needs its own axis or it
+            // flattens the two live counts against it.
+            { data: series('totalRequests'), label: 'Total', color: '#3b82f6', axis: 'right' },
+          ]}
+          unit=""
+          height="100%"
+        />
+      }
+    />
+  )
+}

--- a/frontend/src/components/grid/panels/EngineSloGoodputPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineSloGoodputPanel.tsx
@@ -1,0 +1,73 @@
+import { GoodputTile } from '@/components/engines/EngineCardPrimitives'
+import { SloSettingsControl } from '@/components/engines/SloSettingsControl'
+import { useSloSettings } from '@/hooks/useSloSettings'
+import { engineKey } from '@/lib/identity'
+import { combinedGoodput, formatSloThreshold, recomputeGoodputPct } from '@/lib/slo'
+import { EnginePanelBody } from './EnginePanelBody'
+import { engineLabel } from './engineLabel'
+import { EnginePanelNotice } from './PanelNotice'
+import { useEnginePanel } from './useEnginePanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * The share of requests meeting each latency objective, and the combined
+ * headline.
+ *
+ * Goodput is recomputed here from the engine's histogram buckets rather than
+ * read off the backend's percentages, so an operator who tightens a threshold
+ * sees the number move. The backend's own figure is the fallback for an engine
+ * that is not shipping buckets yet — warming up, or with no traffic — so the
+ * tiles say something rather than nothing.
+ *
+ * Thresholds are per model and stored in the browser, which is why the control
+ * sits in the panel: they are one operator's reading of their own workload, not
+ * part of the shared dashboard document.
+ */
+export function EngineSloGoodputPanel({ panel }: PanelContentProps) {
+  const resolution = useEnginePanel(panel)
+  const engine = resolution.status === 'resolved' ? resolution.engine : null
+  const {
+    thresholds,
+    setThresholds,
+    reset,
+    isCustomized,
+  } = useSloSettings(engine ? engineKey(engine) : '', engine?.model?.name ?? null)
+
+  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+
+  const { metric } = resolution
+  const ttft = recomputeGoodputPct(metric('ttft_buckets'), thresholds.ttftMs)
+    ?? metric('ttft_goodput_pct')
+  const itl = recomputeGoodputPct(metric('itl_buckets'), thresholds.itlMs)
+    ?? metric('itl_goodput_pct')
+  const e2e = recomputeGoodputPct(metric('e2e_buckets'), thresholds.e2eMs)
+    ?? metric('e2e_goodput_pct')
+  const tpot = recomputeGoodputPct(metric('tpot_buckets'), thresholds.tpotMs)
+    ?? metric('tpot_goodput_pct')
+
+  return (
+    <EnginePanelBody
+      label={engineLabel(resolution)}
+      actions={
+        <SloSettingsControl
+          thresholds={thresholds}
+          isCustomized={isCustomized}
+          disabled={resolution.engine.model === null}
+          onChange={setThresholds}
+          onReset={reset}
+        />
+      }
+      tiles={
+        <div className="grid grid-cols-2 gap-1.5">
+          <div className="col-span-2">
+            <GoodputTile label="Combined" pct={combinedGoodput(ttft, itl, e2e)} emphasize />
+          </div>
+          <GoodputTile label={`TTFT ≤ ${formatSloThreshold(thresholds.ttftMs)}`} pct={ttft} />
+          <GoodputTile label={`ITL ≤ ${formatSloThreshold(thresholds.itlMs)}`} pct={itl} />
+          <GoodputTile label={`TPOT ≤ ${formatSloThreshold(thresholds.tpotMs)}`} pct={tpot} />
+          <GoodputTile label={`E2E ≤ ${formatSloThreshold(thresholds.e2eMs)}`} pct={e2e} />
+        </div>
+      }
+    />
+  )
+}

--- a/frontend/src/components/grid/panels/EngineSloGoodputPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineSloGoodputPanel.tsx
@@ -31,7 +31,7 @@ export function EngineSloGoodputPanel({ panel }: PanelContentProps) {
     setThresholds,
     reset,
     isCustomized,
-  } = useSloSettings(engine ? engineKey(engine) : '', engine?.model?.name ?? null)
+  } = useSloSettings(engine && engineKey(engine), engine?.model?.name ?? null)
 
   if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
 

--- a/frontend/src/components/grid/panels/EngineSpecDecodePanel.tsx
+++ b/frontend/src/components/grid/panels/EngineSpecDecodePanel.tsx
@@ -24,12 +24,16 @@ export function EngineSpecDecodePanel({ panel }: PanelContentProps) {
   // sits at zero on an engine that has not drafted anything yet. Gating on a
   // drafted token keeps the panel from showing an all-dashes section that
   // looks like a fault.
+  //
+  // The engine is named on a multi-engine host for the same reason its data
+  // would be: with two engines on a page, "this engine" does not say which.
   if (draftTokens === null || draftTokens === 0) {
+    const subject = engineLabel(resolution) ?? 'This engine'
     return (
       <PanelNotice>
         {draftTokens === null
-          ? 'This engine is not using speculative decoding.'
-          : 'No tokens drafted yet.'}
+          ? `${subject} is not using speculative decoding.`
+          : `${subject} has drafted no tokens yet.`}
       </PanelNotice>
     )
   }

--- a/frontend/src/components/grid/panels/EngineSpecDecodePanel.tsx
+++ b/frontend/src/components/grid/panels/EngineSpecDecodePanel.tsx
@@ -1,0 +1,51 @@
+import { SpecDecodeSection } from '@/components/engines/EngineCardPrimitives'
+import { EnginePanelBody } from './EnginePanelBody'
+import { engineLabel } from './engineLabel'
+import { EnginePanelNotice, PanelNotice } from './PanelNotice'
+import { useEnginePanel } from './useEnginePanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * How well speculative decoding is paying off: the token acceptance rate, the
+ * mean accepted length, and the cumulative draft and accepted counters.
+ *
+ * The panel is its own placeable type rather than a corner of the cache panel,
+ * because on the engines that run it, acceptance is the number that explains
+ * the throughput — and on the engines that do not, it is dead space.
+ */
+export function EngineSpecDecodePanel({ panel }: PanelContentProps) {
+  const resolution = useEnginePanel(panel)
+  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+
+  const { metric } = resolution
+  const draftTokens = metric('spec_decode_draft_tokens_total')
+
+  // The counter is present whenever speculative decoding is configured, and
+  // sits at zero on an engine that has not drafted anything yet. Gating on a
+  // drafted token keeps the panel from showing an all-dashes section that
+  // looks like a fault.
+  if (draftTokens === null || draftTokens === 0) {
+    return (
+      <PanelNotice>
+        {draftTokens === null
+          ? 'This engine is not using speculative decoding.'
+          : 'No tokens drafted yet.'}
+      </PanelNotice>
+    )
+  }
+
+  return (
+    <EnginePanelBody
+      label={engineLabel(resolution)}
+      tiles={
+        <SpecDecodeSection
+          acceptanceRate={metric('spec_decode_acceptance_rate')}
+          acceptanceRateLive={metric('spec_decode_acceptance_rate_live')}
+          meanAcceptanceLength={metric('spec_decode_mean_acceptance_length')}
+          acceptedTokens={metric('spec_decode_accepted_tokens_total')}
+          draftTokens={draftTokens}
+        />
+      }
+    />
+  )
+}

--- a/frontend/src/components/grid/panels/EngineThroughputPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineThroughputPanel.tsx
@@ -1,0 +1,106 @@
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { LiveWithTotal, MetricTile } from '@/components/engines/EngineCardPrimitives'
+import { computeTrend } from '@/lib/engineStats'
+import { formatTps, fmtVal } from '@/lib/format'
+import type { NumericEngineMetric } from '@/lib/engineMetrics'
+import type { EngineSeriesName } from '@/lib/metricsHistoryStore'
+import { EnginePanelBody } from './EnginePanelBody'
+import { engineLabel } from './engineLabel'
+import { EnginePanelNotice } from './PanelNotice'
+import { useEnginePanel } from './useEnginePanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * The two throughput panels are the same panel over different fields: prefill
+ * measures the prompt the engine is reading, decode the tokens it is writing.
+ * Keeping them one component keeps the pair honest — a change to how live,
+ * average and per-request throughput are laid out cannot land on one of them.
+ */
+interface ThroughputFields {
+  live: NumericEngineMetric
+  average: NumericEngineMetric
+  perRequest: NumericEngineMetric
+  total: NumericEngineMetric
+  /** What the cumulative total counts, as the tile labels it. */
+  totalLabel: string
+  series: { live: EngineSeriesName; average: EngineSeriesName; perRequest: EngineSeriesName }
+}
+
+const PREFILL: ThroughputFields = {
+  live: 'prompt_tokens_per_sec',
+  average: 'avg_prompt_tokens_per_sec',
+  perRequest: 'per_request_prompt_tps',
+  total: 'total_prompt_tokens',
+  totalLabel: 'Processed',
+  series: { live: 'promptTps', average: 'avgPromptTps', perRequest: 'perReqPromptTps' },
+}
+
+const DECODE: ThroughputFields = {
+  live: 'tokens_per_sec',
+  average: 'avg_tokens_per_sec',
+  perRequest: 'per_request_tps',
+  total: 'total_generation_tokens',
+  totalLabel: 'Generated',
+  series: { live: 'tps', average: 'avgTps', perRequest: 'perReqTps' },
+}
+
+/** Prompt processing: how fast the engine is reading its prompts. */
+export function EnginePrefillThroughputPanel({ panel }: PanelContentProps) {
+  return <ThroughputPanel panel={panel} fields={PREFILL} />
+}
+
+/** Token generation: how fast the engine is producing output. */
+export function EngineDecodeThroughputPanel({ panel }: PanelContentProps) {
+  return <ThroughputPanel panel={panel} fields={DECODE} />
+}
+
+function ThroughputPanel({ panel, fields }: PanelContentProps & { fields: ThroughputFields }) {
+  const resolution = useEnginePanel(panel)
+  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+
+  const { metric, series } = resolution
+  const live = series(fields.series.live)
+  const average = series(fields.series.average)
+  const perRequest = series(fields.series.perRequest)
+
+  return (
+    <EnginePanelBody
+      label={engineLabel(resolution)}
+      tiles={
+        <div className="grid grid-cols-1 gap-1.5">
+          <LiveWithTotal
+            liveValue={fmtVal(metric(fields.live), formatTps)}
+            liveUnit="tok/s"
+            trend={computeTrend(live)}
+            totalLabel={fields.totalLabel}
+            total={metric(fields.total)}
+          />
+          <MetricTile
+            label="Avg"
+            value={fmtVal(metric(fields.average), formatTps)}
+            unit="tok/s"
+            trend={computeTrend(average)}
+          />
+          <MetricTile
+            label="Per-Req Avg"
+            value={fmtVal(metric(fields.perRequest), formatTps)}
+            unit="tok/s"
+            trend={computeTrend(perRequest)}
+          />
+        </div>
+      }
+      chart={
+        <TimeSeriesChart
+          hideTooltipLabel
+          series={[
+            { data: live, label: 'Live', color: '#76B900' },
+            { data: average, label: 'Avg', color: '#3b82f6' },
+            { data: perRequest, label: 'Per-req', color: '#a855f7' },
+          ]}
+          unit="tok/s"
+          height="100%"
+        />
+      }
+    />
+  )
+}

--- a/frontend/src/components/grid/panels/PanelNotice.tsx
+++ b/frontend/src/components/grid/panels/PanelNotice.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react'
+import { engineDescription } from '@/lib/format'
+import type { EnginePanelNoticeState } from './useEnginePanel'
 import type { GpuPanelResolution } from './useGpuPanel'
 
 /**
@@ -15,9 +17,35 @@ export function PanelNotice({ children }: { children: ReactNode }) {
 }
 
 /**
- * What a GPU panel says instead of data. Silent substitution is prohibited
+ * What an engine panel says instead of data. Silent substitution is prohibited
  * (see `lib/dashboard/bindings.ts`), so each way of having no target names
- * itself; #81 extends the same vocabulary to the engine panels.
+ * itself — an operator who changed an engine's port sees which panels now point
+ * at nothing, and a panel never fills the gap with another engine's numbers.
+ */
+export function EnginePanelNotice({ resolution }: { resolution: EnginePanelNoticeState }) {
+  switch (resolution.status) {
+    case 'waiting':
+      return <PanelNotice>Waiting for metrics</PanelNotice>
+    case 'starting':
+      return <PanelNotice>{engineDescription(resolution.engine)} has no metrics yet.</PanelNotice>
+    case 'offline':
+      return (
+        <PanelNotice>
+          {engineDescription(resolution.engine)} {resolution.detail}
+        </PanelNotice>
+      )
+    case 'missing':
+      return <PanelNotice>No engine at {resolution.requested} — repoint this panel.</PanelNotice>
+    case 'unselected':
+      return <PanelNotice>No inference engine running.</PanelNotice>
+    case 'unreadable':
+      return <PanelNotice>This panel’s pinned engine could not be read — repoint it.</PanelNotice>
+  }
+}
+
+/**
+ * What a GPU panel says instead of data, on the same terms as the engine
+ * notices above.
  */
 export function GpuPanelNotice({
   resolution,

--- a/frontend/src/components/grid/panels/engineLabel.ts
+++ b/frontend/src/components/grid/panels/engineLabel.ts
@@ -1,0 +1,17 @@
+import { engineDescription } from '@/lib/format'
+import type { EnginePanelResolution } from './useEnginePanel'
+
+/**
+ * The engine a panel resolved to, named — or null on a host running a single
+ * engine, where the panel title alone is unambiguous.
+ *
+ * On a host running several, every engine panel says whose numbers it is
+ * showing. Two panels pinned to two engines otherwise differ only by their
+ * position on the page, and a panel that has followed the page selection
+ * somewhere else would look identical to one that has not.
+ */
+export function engineLabel(
+  resolution: Extract<EnginePanelResolution, { status: 'resolved' }>,
+): string | null {
+  return resolution.multiEngine ? engineDescription(resolution.engine) : null
+}

--- a/frontend/src/components/grid/panels/mode.test.ts
+++ b/frontend/src/components/grid/panels/mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { gaugeSizePx, hardwarePanelMode } from './mode'
+import { enginePanelMode, gaugeSizePx, hardwarePanelMode } from './mode'
 
 describe('hardwarePanelMode', () => {
   it('renders the richest layout while the box is unmeasured', () => {
@@ -23,6 +23,28 @@ describe('hardwarePanelMode', () => {
 
   it('prefers compact over chart-only when the box is both short and narrow', () => {
     expect(hardwarePanelMode({ width: 100, height: 40 })).toBe('compact')
+  })
+})
+
+describe('enginePanelMode', () => {
+  it('renders the richest layout while the box is unmeasured', () => {
+    expect(enginePanelMode({ width: 0, height: 0 })).toBe('full')
+  })
+
+  it('keeps the values and drops the chart in a short box', () => {
+    // Two rows of engine tiles alone need most of this height.
+    expect(enginePanelMode({ width: 400, height: 150 })).toBe('tiles')
+  })
+
+  it('charts under the values when the box is tall enough for both', () => {
+    // A 4×3 preset cell on a desktop viewport.
+    expect(enginePanelMode({ width: 400, height: 260 })).toBe('full')
+  })
+
+  it('keeps the chart in a narrow box, unlike the hardware panels', () => {
+    // Engine panels have no gauge column competing for the width, so narrow is
+    // not a reason to drop anything.
+    expect(enginePanelMode({ width: 120, height: 300 })).toBe('full')
   })
 })
 

--- a/frontend/src/components/grid/panels/mode.ts
+++ b/frontend/src/components/grid/panels/mode.ts
@@ -32,6 +32,32 @@ export function hardwarePanelMode({ width, height }: ElementSize): HardwarePanel
 }
 
 /**
+ * How an engine panel renders inside its own measured box.
+ *
+ *   - `full`  — the tile values with their trend chart underneath.
+ *   - `tiles` — the values alone; the box has no room left for a chart once the
+ *               tiles have taken what they need.
+ *
+ * Engine tiles are read, not glanced at — several labelled numbers rather than
+ * one gauge — so they claim their height first and the chart takes what is left.
+ */
+export type EnginePanelMode = 'full' | 'tiles'
+
+/**
+ * Below this content height (px) the tiles leave too little for a chart to say
+ * anything. Deliberately higher than the hardware panels' threshold: those give
+ * their chart the whole box beside a gauge, while here it shares the box with
+ * two or three rows of values.
+ */
+const TILES_ONLY_BELOW_PX = 200
+
+/** Pick the mode for a measured content box, on the same unmeasured-means-
+ *  richest terms as `hardwarePanelMode`. */
+export function enginePanelMode({ height }: ElementSize): EnginePanelMode {
+  return height > 0 && height < TILES_ONLY_BELOW_PX ? 'tiles' : 'full'
+}
+
+/**
  * The gauge column's square size for a measured content height: fill the row
  * up to the size the pre-grid dashboard capped its gauges at. Unmeasured
  * boxes get the cap, consistent with `hardwarePanelMode`'s richest-layout

--- a/frontend/src/components/grid/panels/useEnginePanel.ts
+++ b/frontend/src/components/grid/panels/useEnginePanel.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react'
+import { useLatestSnapshot, useMetricsStore } from '@/hooks/useMetricsStore'
+import { usePageSelection } from '@/hooks/usePageSelection'
+import { resolveEngineBinding } from '@/lib/dashboard/bindings'
+import { pageSelection } from '@/lib/dashboard/selection'
+import { engineAvailability, engineMetricReader, type EngineMetricReader } from '@/lib/engineMetrics'
+import { engineKey } from '@/lib/identity'
+import { engineSeries, type DataPoint, type EngineSeriesName } from '@/lib/metricsHistoryStore'
+import type { DashboardPanel } from '@/lib/dashboard/schema'
+import type { EngineSnapshot } from '@/types/metrics'
+
+/** What an engine panel found at the other end of its binding. */
+export type EnginePanelResolution =
+  /** No snapshot has arrived yet; there are no engines to resolve against. */
+  | { status: 'waiting' }
+  | {
+      status: 'resolved'
+      engine: EngineSnapshot
+      /** True when the host runs more than one engine, and a panel therefore has
+       *  to name the one it is showing. */
+      multiEngine: boolean
+      /** This engine's metrics, with the no-model rule applied. */
+      metric: EngineMetricReader
+      /** One of this engine's series over the panel's own time window. */
+      series: (name: EngineSeriesName) => DataPoint[]
+    }
+  /** The engine resolved, and has no metrics yet — starting, or loading a model. */
+  | { status: 'starting'; engine: EngineSnapshot }
+  /** The engine resolved and is not serving; `detail` says why. */
+  | { status: 'offline'; engine: EngineSnapshot; detail: string }
+  | { status: 'missing'; requested: string }
+  | { status: 'unselected' }
+  | { status: 'unreadable' }
+
+/** Everything but a resolved engine — what a panel hands to `EnginePanelNotice`. */
+export type EnginePanelNoticeState = Exclude<EnginePanelResolution, { status: 'resolved' }>
+
+/**
+ * What an engine panel renders on this host: its binding resolved against the
+ * latest snapshot's engines, the reader for that engine's current values, and
+ * its chart series over the panel's own window.
+ *
+ * A following panel resolves to the page-level engine selection, so a page of
+ * following panels shows one engine coherently and moves to another together.
+ * A pinned panel resolves to its own engine and to nothing else — two panels
+ * pinned to two engines sit side by side, and a pin to an engine that is gone
+ * says so rather than showing the neighbour's numbers.
+ *
+ * Series are read from the store during render rather than through a per-series
+ * subscription: an engine panel shows current values as well as a chart, so it
+ * already re-renders on every ingest, and a subscription per series would buy
+ * nothing but bookkeeping.
+ */
+export function useEnginePanel(panel: DashboardPanel): EnginePanelResolution {
+  const store = useMetricsStore()
+  const snapshot = useLatestSnapshot()
+  const { chosen } = usePageSelection()
+  const window = panel.window
+
+  return useMemo(() => {
+    if (!snapshot) return { status: 'waiting' }
+
+    const engines = snapshot.engines
+    const resolution = resolveEngineBinding(
+      panel.binding,
+      engines,
+      pageSelection(snapshot, chosen).engineEndpoint,
+    )
+    if (resolution.status !== 'resolved') return resolution
+
+    const engine = resolution.target
+    const availability = engineAvailability(engine)
+    if (availability.kind === 'starting') return { status: 'starting', engine }
+    if (availability.kind === 'offline') {
+      return { status: 'offline', engine, detail: availability.detail }
+    }
+
+    const key = engineKey(engine)
+    return {
+      status: 'resolved',
+      engine,
+      multiEngine: engines.length > 1,
+      metric: engineMetricReader(engine),
+      series: (name) => store.getChartData(engineSeries(name, key), window),
+    }
+  }, [store, snapshot, chosen, panel.binding, window])
+}

--- a/frontend/src/components/grid/panels/useGpuPanel.ts
+++ b/frontend/src/components/grid/panels/useGpuPanel.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
 import { useLatestSnapshot, useMetricSeries } from '@/hooks/useMetricsStore'
+import { usePageSelection } from '@/hooks/usePageSelection'
 import { resolveGpuBinding } from '@/lib/dashboard/bindings'
+import { pageSelection } from '@/lib/dashboard/selection'
 import { gpuIndexOf, snapshotGpus } from '@/lib/identity'
 import { gpuSeries, type DataPoint, type GpuSeriesMetric } from '@/lib/metricsHistoryStore'
 import type { DashboardPanel } from '@/lib/dashboard/schema'
@@ -25,18 +27,23 @@ export type GpuPanelResolution =
  * What a GPU panel renders on this host: its binding resolved against the
  * latest snapshot's GPUs, plus the series-key vocabulary for its charts.
  *
- * A following panel resolves to the primary GPU for now — the page-level GPU
- * selection this defers to arrives with #81, and the primary GPU is what the
- * pre-grid dashboard defaults to as well.
+ * A following panel resolves to the page-level GPU selection, which is the
+ * primary GPU until the operator points the page somewhere else — so a page of
+ * following panels moves to another GPU coherently, all at once.
  */
 function useGpuPanel(panel: DashboardPanel): GpuPanelResolution {
   const snapshot = useLatestSnapshot()
+  const { chosen } = usePageSelection()
 
   return useMemo(() => {
     if (!snapshot) return { status: 'waiting' }
 
     const gpus = snapshotGpus(snapshot)
-    const resolution = resolveGpuBinding(panel.binding, gpus, gpuIndexOf(gpus[0]))
+    const resolution = resolveGpuBinding(
+      panel.binding,
+      gpus,
+      pageSelection(snapshot, chosen).gpuIndex,
+    )
     if (resolution.status !== 'resolved') return resolution
 
     const multiGpu = gpus.length > 1
@@ -47,7 +54,7 @@ function useGpuPanel(panel: DashboardPanel): GpuPanelResolution {
       multiGpu,
       seriesFor: (metric: GpuSeriesMetric) => gpuSeries(metric, index, multiGpu),
     }
-  }, [snapshot, panel.binding])
+  }, [snapshot, chosen, panel.binding])
 }
 
 /**

--- a/frontend/src/hooks/PageSelectionProvider.tsx
+++ b/frontend/src/hooks/PageSelectionProvider.tsx
@@ -1,0 +1,27 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { withSelectedEngine, withSelectedGpu, type SelectedTargets } from '@/lib/dashboard/selection'
+import { PageSelectionContext, type PageSelectionValue } from './usePageSelection'
+
+/**
+ * Owns one page's selection.
+ *
+ * Session state, deliberately not part of the saved document: which GPU an
+ * operator is looking at right now is not an arrangement they authored, and
+ * writing it would make every glance at a second GPU a change to what everyone
+ * else sees. It resets per page because the provider sits inside the page, which
+ * is keyed by page id.
+ */
+export function PageSelectionProvider({ children }: { children: ReactNode }) {
+  const [chosen, setChosen] = useState<SelectedTargets>({})
+
+  const value = useMemo(
+    (): PageSelectionValue => ({
+      chosen,
+      selectGpu: (index) => setChosen((current) => withSelectedGpu(current, index)),
+      selectEngine: (endpoint) => setChosen((current) => withSelectedEngine(current, endpoint)),
+    }),
+    [chosen],
+  )
+
+  return <PageSelectionContext.Provider value={value}>{children}</PageSelectionContext.Provider>
+}

--- a/frontend/src/hooks/useLatencyMode.ts
+++ b/frontend/src/hooks/useLatencyMode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 import { parseLatencyMode, serializeLatencyMode, type LatencyMode } from '@/lib/latencyMode'
 
 const LATENCY_MODE_STORAGE_KEY = 'spark-dashboard:latency-mode'
@@ -7,34 +7,49 @@ const LATENCY_MODE_STORAGE_KEY = 'spark-dashboard:latency-mode'
  * Which latency statistic the dashboard shows — average, or one of the
  * histogram percentiles.
  *
- * A dashboard-wide preference rather than per-panel state: an operator who
- * reads p95 reads p95 everywhere, and comparing a p95 tile against an average
- * one is how a latency problem gets misread. It is stored under the key the
- * pre-grid dashboard has always used, so the setting survives the cutover.
+ * One setting for the whole dashboard, not per panel: comparing a p95 tile
+ * against an average one is how a tail-latency problem gets misread, so
+ * choosing p95 in one panel moves every other panel with it. Stored under the
+ * key the pre-grid dashboard has always used, so the setting survives the
+ * cutover.
  *
- * Each consumer holds its own copy of the current value and adopts the stored
- * one when it mounts; two latency panels on one page therefore agree from the
- * next reload rather than instantly. Making the choice reach a second panel
- * live is per-panel configuration's problem (#84), which may well make the mode
- * a panel setting outright.
+ * The choice lives outside React so every consumer reads one value; storage
+ * seeds it and records it for the next session. The listeners exist only to
+ * tell this tab's other panels that it changed, which storage events do not do
+ * for the tab that wrote them.
  */
 export function useLatencyMode(): [LatencyMode, (next: LatencyMode) => void] {
-  const [mode, setMode] = useState<LatencyMode>(readStoredLatencyMode)
+  const mode = useSyncExternalStore(subscribe, readStoredLatencyMode, readStoredLatencyMode)
+  return [mode, chooseLatencyMode]
+}
 
-  const chooseMode = useCallback((next: LatencyMode) => {
-    setMode(next)
-    if (typeof window === 'undefined') return
-    try {
-      window.localStorage.setItem(LATENCY_MODE_STORAGE_KEY, serializeLatencyMode(next))
-    } catch {
-      // ignore storage errors (private mode, quota, etc.)
-    }
-  }, [])
+const listeners = new Set<() => void>()
 
-  return [mode, chooseMode]
+/** The choice, held here **only** while storage cannot hold it. Null in the
+ *  normal case, so storage stays the one place the value lives. */
+let unstored: LatencyMode | null = null
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function chooseLatencyMode(next: LatencyMode): void {
+  try {
+    window.localStorage.setItem(LATENCY_MODE_STORAGE_KEY, serializeLatencyMode(next))
+    unstored = null
+  } catch {
+    // Storage errors (private mode, quota) cost the choice its persistence,
+    // not its effect: it still holds for the rest of this session.
+    unstored = next
+  }
+  for (const listener of listeners) listener()
 }
 
 function readStoredLatencyMode(): LatencyMode {
+  if (unstored !== null) return unstored
   if (typeof window === 'undefined') return parseLatencyMode(null)
   try {
     return parseLatencyMode(window.localStorage.getItem(LATENCY_MODE_STORAGE_KEY))

--- a/frontend/src/hooks/useLatencyMode.ts
+++ b/frontend/src/hooks/useLatencyMode.ts
@@ -1,0 +1,44 @@
+import { useCallback, useState } from 'react'
+import { parseLatencyMode, serializeLatencyMode, type LatencyMode } from '@/lib/latencyMode'
+
+const LATENCY_MODE_STORAGE_KEY = 'spark-dashboard:latency-mode'
+
+/**
+ * Which latency statistic the dashboard shows — average, or one of the
+ * histogram percentiles.
+ *
+ * A dashboard-wide preference rather than per-panel state: an operator who
+ * reads p95 reads p95 everywhere, and comparing a p95 tile against an average
+ * one is how a latency problem gets misread. It is stored under the key the
+ * pre-grid dashboard has always used, so the setting survives the cutover.
+ *
+ * Each consumer holds its own copy of the current value and adopts the stored
+ * one when it mounts; two latency panels on one page therefore agree from the
+ * next reload rather than instantly. Making the choice reach a second panel
+ * live is per-panel configuration's problem (#84), which may well make the mode
+ * a panel setting outright.
+ */
+export function useLatencyMode(): [LatencyMode, (next: LatencyMode) => void] {
+  const [mode, setMode] = useState<LatencyMode>(readStoredLatencyMode)
+
+  const chooseMode = useCallback((next: LatencyMode) => {
+    setMode(next)
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(LATENCY_MODE_STORAGE_KEY, serializeLatencyMode(next))
+    } catch {
+      // ignore storage errors (private mode, quota, etc.)
+    }
+  }, [])
+
+  return [mode, chooseMode]
+}
+
+function readStoredLatencyMode(): LatencyMode {
+  if (typeof window === 'undefined') return parseLatencyMode(null)
+  try {
+    return parseLatencyMode(window.localStorage.getItem(LATENCY_MODE_STORAGE_KEY))
+  } catch {
+    return parseLatencyMode(null)
+  }
+}

--- a/frontend/src/hooks/usePageSelection.ts
+++ b/frontend/src/hooks/usePageSelection.ts
@@ -1,0 +1,39 @@
+import { createContext, useContext } from 'react'
+import type { SelectedTargets } from '@/lib/dashboard/selection'
+
+/**
+ * What one page is pointed at, and how to point it somewhere else.
+ *
+ * Only the operator's explicit choice travels through the context; resolving it
+ * against the host is `pageSelection()`, which the panel hooks call because they
+ * already hold the snapshot. Keeping the context to the choice alone means a
+ * page that has never been pointed anywhere costs nothing and re-renders for
+ * nothing.
+ */
+export interface PageSelectionValue {
+  /** What the operator pointed this page at. Empty = follow the host. */
+  chosen: SelectedTargets
+  /** Point every following panel at one GPU; null goes back to the host default. */
+  selectGpu: (index: number | null) => void
+  /** Point every following panel at one engine; null goes back to the host default. */
+  selectEngine: (endpoint: string | null) => void
+}
+
+/**
+ * Following the host, with no way to change it. This is what a panel rendered
+ * outside a page gets — a spec, a future preview — so a panel never has to know
+ * whether it is on a page.
+ */
+const FOLLOW_THE_HOST: PageSelectionValue = {
+  chosen: {},
+  selectGpu: () => {},
+  selectEngine: () => {},
+}
+
+/** Exported for `PageSelectionProvider`, which cannot live in this file without
+ *  breaking fast refresh. Read the selection through `usePageSelection`. */
+export const PageSelectionContext = createContext<PageSelectionValue>(FOLLOW_THE_HOST)
+
+export function usePageSelection(): PageSelectionValue {
+  return useContext(PageSelectionContext)
+}

--- a/frontend/src/hooks/useSloSettings.ts
+++ b/frontend/src/hooks/useSloSettings.ts
@@ -5,11 +5,11 @@ const STORAGE_PREFIX = 'spark-dashboard:slo'
 
 /**
  * Build the localStorage key for an engine+model pair. Returns `null` when
- * no model is loaded — there is nothing to scope per-model settings to in
- * that case, so the hook stays read-only with the defaults.
+ * there is no engine or no model loaded — there is nothing to scope per-model
+ * settings to in that case, so the hook stays read-only with the defaults.
  */
-function storageKey(engineKey: string, modelName: string | null): string | null {
-  if (!modelName) return null
+function storageKey(engineKey: string | null, modelName: string | null): string | null {
+  if (!engineKey || !modelName) return null
   return `${STORAGE_PREFIX}:${engineKey}:${modelName}`
 }
 
@@ -66,10 +66,14 @@ function readFromStorage(key: string | null): SloThresholds | null {
 /**
  * Per-model SLO threshold state. Mirrors the localStorage pattern used by
  * the engine rotation, latency mode, and active tab settings (see
- * `EngineSection.tsx`). When the engine has no loaded model, returns the
- * defaults and a no-op setter — nothing to persist.
+ * `EngineSection.tsx`). When there is no engine, or it has no loaded model,
+ * returns the defaults and a no-op setter — nothing to persist.
+ *
+ * A null engine key is how a panel calls this before it knows whether its
+ * binding resolved: the hook has to run above that early return, so "no engine
+ * yet" needs to be sayable rather than stood in for.
  */
-export function useSloSettings(engineKey: string, modelName: string | null): {
+export function useSloSettings(engineKey: string | null, modelName: string | null): {
   thresholds: SloThresholds
   setThresholds: (next: SloThresholds) => void
   reset: () => void

--- a/frontend/src/lib/dashboard/bindings.test.ts
+++ b/frontend/src/lib/dashboard/bindings.test.ts
@@ -119,6 +119,19 @@ describe('resolveGpuBinding', () => {
     expect(resolveGpuBinding(FOLLOW, [], 0)).toEqual({ status: 'unselected' })
   })
 
+  it('reports a page with no GPU selected as having nothing selected', () => {
+    expect(resolveGpuBinding(FOLLOW, gpus, null)).toEqual({ status: 'unselected' })
+  })
+
+  it('still resolves a pin on a page with no GPU selected', () => {
+    // A pinned panel does not follow, so it has nothing to lose by the page
+    // pointing nowhere.
+    expect(resolveGpuBinding({ kind: 'gpu', index: 1 }, gpus, null)).toEqual({
+      status: 'resolved',
+      target: gpus[1],
+    })
+  })
+
   it('still reports a pin against an empty host as missing', () => {
     // A pin named something specific, so it is missing rather than unselected —
     // "nothing to follow" is only a state a following panel can be in.

--- a/frontend/src/lib/dashboard/bindings.ts
+++ b/frontend/src/lib/dashboard/bindings.ts
@@ -102,25 +102,29 @@ export function readBinding(raw: unknown): PanelBinding {
 /**
  * Resolves a GPU panel's binding against the GPUs on this host.
  *
- * `pageGpuIndex` is the page-level selection a following panel defers to. A
- * selection that is not on the host is reported as missing rather than nudged to
- * the primary GPU — the page label and the panel's data have to agree.
+ * `pageGpuIndex` is the page-level selection a following panel defers to, null
+ * when there is nothing selected. A selection that is not on the host is
+ * reported as missing rather than nudged to the primary GPU — the page label and
+ * the panel's data have to agree.
  */
 export function resolveGpuBinding<T extends GpuIdentity>(
   binding: PanelBinding,
   gpus: readonly T[],
-  pageGpuIndex: number,
+  pageGpuIndex: number | null,
 ): BindingResolution<T> {
   // Including a binding that names an engine: on a GPU panel that is a corrupt
   // document, and picking some GPU to show anyway is the prohibited failure.
   if (binding.kind !== 'follow' && binding.kind !== 'gpu') return { status: 'unreadable' }
 
+  const index = binding.kind === 'gpu' ? binding.index : pageGpuIndex
+
   // Only a following panel can have nothing to follow. A pin names a GPU, so an
   // empty host makes it missing rather than unselected — the operator asked for
   // something specific and it is not here.
-  if (binding.kind === 'follow' && gpus.length === 0) return { status: 'unselected' }
+  if (index === null || (binding.kind === 'follow' && gpus.length === 0)) {
+    return { status: 'unselected' }
+  }
 
-  const index = binding.kind === 'gpu' ? binding.index : pageGpuIndex
   const target = findGpuByIndex(gpus, index)
   return target ? { status: 'resolved', target } : { status: 'missing', requested: `GPU ${index}` }
 }

--- a/frontend/src/lib/dashboard/selection.test.ts
+++ b/frontend/src/lib/dashboard/selection.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NO_SELECTION,
+  pageSelection,
+  withSelectedEngine,
+  withSelectedGpu,
+} from './selection'
+import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '@/types/metrics'
+
+function gpu(index: number | null): GpuMetrics {
+  return {
+    index,
+    name: 'NVIDIA GB10',
+    utilization_percent: 10,
+    memory_total_bytes: null,
+    memory_used_bytes: null,
+    temperature_celsius: 40,
+    power_watts: 50,
+    power_limit_watts: null,
+    clock_graphics_mhz: null,
+    clock_sm_mhz: null,
+    clock_memory_mhz: null,
+    fan_speed_percent: null,
+  }
+}
+
+function engine(endpoint: string, status: EngineSnapshot['status'] = { type: 'Running' }): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status,
+    model: null,
+    metrics: null,
+    recent_requests: [],
+    deployment_mode: 'Native',
+  }
+}
+
+function snapshot(gpus: GpuMetrics[], engines: EngineSnapshot[]): Pick<
+  MetricsSnapshot,
+  'gpu' | 'gpus' | 'engines'
+> {
+  return { gpu: gpus[0], gpus, engines }
+}
+
+describe('pageSelection', () => {
+  it('follows the primary GPU and the running engine when the operator has chosen neither', () => {
+    // This is what makes the shipped preset work unmodified on any machine.
+    const host = snapshot([gpu(0), gpu(1)], [engine('http://localhost:8000')])
+
+    expect(pageSelection(host, {})).toEqual({
+      gpuIndex: 0,
+      engineEndpoint: 'http://localhost:8000',
+    })
+  })
+
+  it('prefers a running engine over a stopped one listed first', () => {
+    const host = snapshot(
+      [gpu(0)],
+      [engine('http://localhost:8000', { type: 'Stopped' }), engine('http://localhost:8001')],
+    )
+
+    expect(pageSelection(host, {}).engineEndpoint).toBe('http://localhost:8001')
+  })
+
+  it('falls back to the first engine when none is running', () => {
+    const host = snapshot(
+      [gpu(0)],
+      [
+        engine('http://localhost:8000', { type: 'Loading' }),
+        engine('http://localhost:8001', { type: 'Stopped' }),
+      ],
+    )
+
+    expect(pageSelection(host, {}).engineEndpoint).toBe('http://localhost:8000')
+  })
+
+  it('normalizes the index of a GPU reported without one', () => {
+    expect(pageSelection(snapshot([gpu(null)], []), {}).gpuIndex).toBe(0)
+  })
+
+  it('selects nothing for an engine the host is not running', () => {
+    // Engine panels degrade to an empty state here; the hardware panels beside
+    // them keep working, which is the point.
+    expect(pageSelection(snapshot([gpu(0)], []), {}).engineEndpoint).toBeNull()
+  })
+
+  it('honours what the operator chose over the host defaults', () => {
+    const host = snapshot(
+      [gpu(0), gpu(1)],
+      [engine('http://localhost:8000'), engine('http://localhost:8001')],
+    )
+
+    expect(
+      pageSelection(host, { gpuIndex: 1, engineEndpoint: 'http://localhost:8001' }),
+    ).toEqual({ gpuIndex: 1, engineEndpoint: 'http://localhost:8001' })
+  })
+
+  it('keeps a choice whose target has gone away', () => {
+    // Panels report it as missing. Nudging the selection back to whatever is
+    // present would hide from the operator that the engine they picked has
+    // stopped — and would show its numbers under the other engine's name.
+    const host = snapshot([gpu(0)], [engine('http://localhost:8000')])
+
+    expect(pageSelection(host, { gpuIndex: 3, engineEndpoint: 'http://localhost:9999' })).toEqual({
+      gpuIndex: 3,
+      engineEndpoint: 'http://localhost:9999',
+    })
+  })
+
+  it('has nothing to select before the first snapshot', () => {
+    expect(pageSelection(null, {})).toEqual(NO_SELECTION)
+  })
+
+  it('keeps a choice made before the first snapshot arrives', () => {
+    expect(pageSelection(null, { gpuIndex: 1 })).toEqual({
+      gpuIndex: 1,
+      engineEndpoint: null,
+    })
+  })
+})
+
+describe('choosing what a page points at', () => {
+  it('records a chosen GPU and engine', () => {
+    expect(withSelectedGpu({}, 2)).toEqual({ gpuIndex: 2 })
+    expect(withSelectedEngine({ gpuIndex: 2 }, 'http://localhost:8000')).toEqual({
+      gpuIndex: 2,
+      engineEndpoint: 'http://localhost:8000',
+    })
+  })
+
+  it('goes back to following the host when the choice is cleared', () => {
+    // Absent means "never chose", which is what a cleared selection has to
+    // become — storing a null would freeze the page on a host that changes.
+    expect(withSelectedGpu({ gpuIndex: 2, engineEndpoint: 'http://x:1' }, null)).toEqual({
+      engineEndpoint: 'http://x:1',
+    })
+    expect(withSelectedEngine({ gpuIndex: 2, engineEndpoint: 'http://x:1' }, null)).toEqual({
+      gpuIndex: 2,
+    })
+  })
+
+  it('leaves the selection it was given untouched', () => {
+    const chosen = { gpuIndex: 0 }
+    withSelectedGpu(chosen, 1)
+    expect(chosen).toEqual({ gpuIndex: 0 })
+  })
+})

--- a/frontend/src/lib/dashboard/selection.ts
+++ b/frontend/src/lib/dashboard/selection.ts
@@ -1,0 +1,108 @@
+/**
+ * The page-level selection: the GPU and the engine a page's `follow` panels
+ * point at.
+ *
+ * This is the other half of the binding model in `bindings.ts`. A pinned panel
+ * names its own target; every other panel defers to the selection here, which is
+ * what lets the shipped default preset be one static document that is right on a
+ * one-GPU laptop and on a four-GPU server. Change the selection and the whole
+ * page moves with it, coherently, because every following panel reads the same
+ * value.
+ *
+ * The selection has two layers. What the operator **chose** is stored sparsely —
+ * an absent key means they have never chosen, not that they chose nothing — and
+ * the host's own defaults fill the gaps. Keeping them apart matters on a machine
+ * whose engines come and go: an operator who chose nothing follows whatever is
+ * running, while an operator who chose engine B keeps pointing at B, and the
+ * panels say B is missing rather than quietly showing engine A.
+ */
+
+import { gpuIndexOf, snapshotGpus } from '@/lib/identity'
+import type { EngineSnapshot, MetricsSnapshot } from '@/types/metrics'
+
+/** What a page's `follow` panels resolve against. */
+export interface PageSelection {
+  /** The GPU index following panels show. Null when the host reports no GPU. */
+  gpuIndex: number | null
+  /** The endpoint following panels show. Null when no engine is running. */
+  engineEndpoint: string | null
+}
+
+/**
+ * What the operator explicitly pointed the page at. A key is present only once
+ * they have chosen; absent means "follow the host", which is where every page
+ * starts.
+ */
+export interface SelectedTargets {
+  readonly gpuIndex?: number
+  readonly engineEndpoint?: string
+}
+
+/** Nothing to point at: no snapshot, or a host with neither GPU nor engine. */
+export const NO_SELECTION: PageSelection = { gpuIndex: null, engineEndpoint: null }
+
+/**
+ * The selection a page resolves to on this host.
+ *
+ * An explicit choice is kept verbatim, including one naming a target that is no
+ * longer here — panels report that as missing, which is the whole point: the
+ * operator who changed an engine's port has to see which panels now point at
+ * nothing. Only an unchosen target falls back to the host's default.
+ */
+export function pageSelection(
+  snapshot: Pick<MetricsSnapshot, 'gpu' | 'gpus' | 'engines'> | null,
+  chosen: SelectedTargets,
+): PageSelection {
+  if (!snapshot) {
+    return {
+      gpuIndex: chosen.gpuIndex ?? null,
+      engineEndpoint: chosen.engineEndpoint ?? null,
+    }
+  }
+
+  return {
+    gpuIndex: chosen.gpuIndex ?? defaultGpuIndex(snapshot),
+    engineEndpoint: chosen.engineEndpoint ?? defaultEngineEndpoint(snapshot.engines),
+  }
+}
+
+/** Point the page at one GPU, or back at the host's default with null. */
+export function withSelectedGpu(chosen: SelectedTargets, index: number | null): SelectedTargets {
+  return index === null ? without(chosen, 'gpuIndex') : { ...chosen, gpuIndex: index }
+}
+
+/** Point the page at one engine, or back at the host's default with null. */
+export function withSelectedEngine(
+  chosen: SelectedTargets,
+  endpoint: string | null,
+): SelectedTargets {
+  return endpoint === null
+    ? without(chosen, 'engineEndpoint')
+    : { ...chosen, engineEndpoint: endpoint }
+}
+
+/**
+ * Clearing a choice drops the key rather than storing a null, because absent is
+ * what "never chose" looks like everywhere else — a null would freeze the page
+ * on a host whose GPUs or engines change under it.
+ */
+function without(chosen: SelectedTargets, key: keyof SelectedTargets): SelectedTargets {
+  const next: { gpuIndex?: number; engineEndpoint?: string } = { ...chosen }
+  delete next[key]
+  return next
+}
+
+/** The primary GPU: `snapshotGpus` always yields at least one. */
+function defaultGpuIndex(snapshot: Pick<MetricsSnapshot, 'gpu' | 'gpus'>): number {
+  return gpuIndexOf(snapshotGpus(snapshot)[0])
+}
+
+/**
+ * The engine an unconfigured page follows: the first one actually running, and
+ * only otherwise the first one detected. A host whose first-listed engine is
+ * stopped still has something worth watching on the others.
+ */
+function defaultEngineEndpoint(engines: readonly EngineSnapshot[]): string | null {
+  const running = engines.find((engine) => engine.status.type === 'Running')
+  return (running ?? engines[0])?.endpoint ?? null
+}

--- a/frontend/src/lib/engineMetrics.test.ts
+++ b/frontend/src/lib/engineMetrics.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { engineAvailability, engineMetricReader, type EngineReadable } from './engineMetrics'
+import type { EngineMetrics } from '@/types/metrics'
+
+function metrics(overrides: Partial<EngineMetrics> = {}): EngineMetrics {
+  return {
+    tokens_per_sec: 120,
+    avg_tokens_per_sec: 100,
+    per_request_tps: 40,
+    ttft_ms: 210,
+    active_requests: 3,
+    queued_requests: 1,
+    kv_cache_percent: 42,
+    kv_cache_is_estimated: false,
+    total_requests: 900,
+    e2e_latency_ms: 4200,
+    prompt_tokens_per_sec: 3000,
+    avg_prompt_tokens_per_sec: 2500,
+    per_request_prompt_tps: 800,
+    swapped_requests: 0,
+    prefix_cache_hit_rate: 55,
+    queue_time_ms: 12,
+    inter_token_latency_ms: 9,
+    preemptions_total: 0,
+    total_prompt_tokens: 1_000_000,
+    total_generation_tokens: 500_000,
+    prefix_cache_queries_total: 2_000_000,
+    avg_batch_size: 6.5,
+    ttft_percentiles: { p50_ms: 200, p95_ms: 400, p99_ms: 900 },
+    itl_percentiles: null,
+    e2e_percentiles: null,
+    ttft_goodput_pct: 99,
+    itl_goodput_pct: 98,
+    e2e_goodput_pct: 97,
+    ttft_buckets: null,
+    itl_buckets: null,
+    e2e_buckets: null,
+    tpot_ms: 8,
+    tpot_percentiles: null,
+    tpot_goodput_pct: 96,
+    tpot_buckets: null,
+    spec_decode_draft_tokens_total: null,
+    spec_decode_accepted_tokens_total: null,
+    spec_decode_drafts_total: null,
+    spec_decode_acceptance_rate: null,
+    spec_decode_acceptance_rate_live: null,
+    spec_decode_mean_acceptance_length: null,
+    ...overrides,
+  }
+}
+
+function engine(overrides: Partial<EngineReadable> = {}): EngineReadable {
+  return {
+    status: { type: 'Running' },
+    model: { name: 'Qwen/Qwen3-8B' } as EngineReadable['model'],
+    metrics: metrics(),
+    ...overrides,
+  }
+}
+
+describe('engineMetricReader', () => {
+  it('reads the fields an engine reports', () => {
+    const read = engineMetricReader(engine())
+
+    expect(read('tokens_per_sec')).toBe(120)
+    expect(read('ttft_percentiles')).toEqual({ p50_ms: 200, p95_ms: 400, p99_ms: 900 })
+  })
+
+  it('reads an absent metric as no value', () => {
+    const read = engineMetricReader(engine({ metrics: metrics({ tokens_per_sec: null }) }))
+
+    expect(read('tokens_per_sec')).toBeNull()
+    expect(read('itl_percentiles')).toBeNull()
+  })
+
+  it('reads nothing at all from an engine with no model loaded', () => {
+    // Its last metrics describe a model it is no longer serving; rendering them
+    // would put a finished run's numbers under an idle engine's name.
+    const read = engineMetricReader(engine({ model: null }))
+
+    expect(read('tokens_per_sec')).toBeNull()
+    expect(read('total_requests')).toBeNull()
+  })
+})
+
+describe('engineAvailability', () => {
+  it('is ready when the engine is serving a model and reporting', () => {
+    expect(engineAvailability(engine())).toEqual({ kind: 'ready' })
+  })
+
+  it('separates an engine that is starting from one that is not running', () => {
+    // The first resolves itself in a second; the second needs the operator to
+    // do something. A grid of dashes would say neither.
+    expect(engineAvailability(engine({ metrics: null }))).toEqual({ kind: 'starting' })
+    expect(engineAvailability(engine({ status: { type: 'Loading' }, metrics: null }))).toEqual({
+      kind: 'starting',
+    })
+    expect(engineAvailability(engine({ status: { type: 'Stopped' } }))).toEqual({
+      kind: 'offline',
+      detail: 'is not running.',
+    })
+  })
+
+  it('carries an engine’s own error message', () => {
+    expect(
+      engineAvailability(engine({ status: { type: 'Error', message: 'connection refused' } })),
+    ).toEqual({ kind: 'offline', detail: 'reported an error: connection refused' })
+  })
+
+  it('reports an engine with no model as offline rather than starting', () => {
+    expect(engineAvailability(engine({ model: null }))).toEqual({
+      kind: 'offline',
+      detail: 'has no model loaded.',
+    })
+  })
+})

--- a/frontend/src/lib/engineMetrics.ts
+++ b/frontend/src/lib/engineMetrics.ts
@@ -1,0 +1,68 @@
+/**
+ * Reading one engine's metrics, and deciding whether there are any to read.
+ *
+ * Both rules are shared rather than re-derived per card or panel, because both
+ * are easy to get subtly wrong in ways that show stale numbers: an engine whose
+ * model was unloaded still ships its last metrics, and an engine that has just
+ * started ships none at all while being perfectly healthy.
+ */
+
+import type { EngineMetrics, EngineSnapshot } from '@/types/metrics'
+
+/** The parts of an engine snapshot that decide what its metrics mean. */
+export type EngineReadable = Pick<EngineSnapshot, 'status' | 'model' | 'metrics'>
+
+/**
+ * The metric fields that carry a plain number — everything a tile can render
+ * directly, as opposed to the percentile structs and histogram buckets that a
+ * panel has to derive something from first.
+ */
+export type NumericEngineMetric = {
+  [K in keyof EngineMetrics]-?: EngineMetrics[K] extends number | null ? K : never
+}[keyof EngineMetrics]
+
+/** Reads one field of an engine's metrics; null when there is no value to read. */
+export type EngineMetricReader = <K extends keyof EngineMetrics>(
+  key: K,
+) => EngineMetrics[K] | null
+
+/**
+ * A reader over one engine's metrics.
+ *
+ * An engine with **no model loaded** reads as having no values at all. Its last
+ * metrics describe a model that is no longer being served, and showing them
+ * would put numbers from a finished run under the name of an idle engine.
+ */
+export function engineMetricReader(engine: EngineReadable): EngineMetricReader {
+  const metrics = engine.model === null ? null : engine.metrics
+  return (key) => metrics?.[key] ?? null
+}
+
+/** Whether an engine has metrics worth rendering, and why not when it has not. */
+export type EngineAvailability =
+  /** Serving, with metrics. */
+  | { kind: 'ready' }
+  /** Up, but no metrics have arrived yet — starting, or loading a model. */
+  | { kind: 'starting' }
+  /** Nothing to show, for a reason the operator can act on. `detail` completes
+   *  the sentence "<engine> …". */
+  | { kind: 'offline'; detail: string }
+
+/**
+ * What an engine can currently show.
+ *
+ * The distinction that matters is between an engine that is *fine and not ready
+ * yet* and one that is *not running*: the first resolves itself in a second, the
+ * second needs the operator to do something. A grid of dashes says neither.
+ */
+export function engineAvailability(engine: EngineReadable): EngineAvailability {
+  switch (engine.status.type) {
+    case 'Stopped':
+      return { kind: 'offline', detail: 'is not running.' }
+    case 'Error':
+      return { kind: 'offline', detail: `reported an error: ${engine.status.message}` }
+  }
+
+  if (engine.model === null) return { kind: 'offline', detail: 'has no model loaded.' }
+  return engine.metrics === null ? { kind: 'starting' } : { kind: 'ready' }
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,3 +1,4 @@
+import type { EngineIdentity } from '@/lib/identity'
 import type { EngineType } from '@/types/metrics'
 
 const KIB = 1024
@@ -149,6 +150,30 @@ export function engineDisplayName(engineType: EngineType): string {
     Vllm: 'vLLM',
   }
   return names[engineType]
+}
+
+/**
+ * The readable half of an engine endpoint — `host:port`, without the scheme or
+ * any path. Falls back to the endpoint as stored when it does not parse as a
+ * URL, because the operator has to be able to match it against what they
+ * configured.
+ */
+export function formatEndpoint(endpoint: string): string {
+  try {
+    return new URL(endpoint).host || endpoint
+  } catch {
+    return endpoint
+  }
+}
+
+/**
+ * How an engine reads in a panel label or a placeholder: its provider plus the
+ * host and port of the instance. Both halves are needed — a machine can run
+ * several engines of the same provider, which is exactly when a panel has to say
+ * which one it is showing.
+ */
+export function engineDescription(engine: EngineIdentity): string {
+  return `${engineDisplayName(engine.engine_type)} ${formatEndpoint(engine.endpoint)}`
 }
 
 /** Apply a formatter to a nullable metric, rendering '--' when absent.

--- a/frontend/src/lib/metricsHistoryStore.ts
+++ b/frontend/src/lib/metricsHistoryStore.ts
@@ -60,7 +60,7 @@ type EngineMetricsShape = NonNullable<MetricsSnapshot['engines'][number]['metric
  * buffer set is created from this table too, so the series names and the
  * field mapping cannot drift apart.
  */
-const ENGINE_SERIES: ReadonlyArray<readonly [string, (m: EngineMetricsShape) => number | null]> = [
+const ENGINE_SERIES = [
   ['tps', (m) => m.tokens_per_sec],
   ['avgTps', (m) => m.avg_tokens_per_sec],
   ['perReqTps', (m) => m.per_request_tps],
@@ -90,7 +90,20 @@ const ENGINE_SERIES: ReadonlyArray<readonly [string, (m: EngineMetricsShape) => 
   ['activeRequests', (m) => m.active_requests],
   ['queuedRequests', (m) => m.queued_requests],
   ['totalRequests', (m) => m.total_requests],
-]
+] as const satisfies ReadonlyArray<readonly [string, (m: EngineMetricsShape) => number | null]>
+
+/** The per-engine series, named by the table above so a panel cannot ask for
+ *  one that is never ingested. */
+export type EngineSeriesName = (typeof ENGINE_SERIES)[number][0]
+
+/**
+ * The series key for one engine's metric. `key` is an engine key as produced by
+ * `engineKey()` — one definition, because the ingest side and every panel that
+ * charts an engine must agree on it.
+ */
+export function engineSeries(name: EngineSeriesName, key: string): string {
+  return `${key}:${name}`
+}
 
 /** The series key of the event buffer, for subscriptions. */
 export const EVENTS_SERIES = 'events'

--- a/frontend/src/lib/slo.ts
+++ b/frontend/src/lib/slo.ts
@@ -25,6 +25,17 @@ export interface SloThresholds {
 }
 
 /**
+ * A threshold as it reads on a goodput tile's label. Seconds once the value is
+ * a clean multiple of one, milliseconds below that — so the default "5s" stays
+ * "5s" while a tuned 2500ms reads "2.5s" and an 800ms one stays in ms.
+ */
+export function formatSloThreshold(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`
+}
+
+/**
  * Conservative combined goodput approximation: the worst-performing of the
  * three independently-measured goodput fractions. The true joint
  * "all-three-met" rate would require correlated per-request data, which


### PR DESCRIPTION
Closes #81. Spec: #70. Decision record: #68.

The engine block's six metric tiles as individually placeable panels, plus the
binding machinery that makes one preset work on any machine.

## Panels

Seven components for the six tiles — cache and speculative decoding are one
tile on the old card and two panels here, because the point of the rework is
one panel per metric: an engine without speculative decoding should not spend
screen space on it, and one with it can give it a panel of its own. The panel
type vocabulary already split them (`328941a`), so #81's "six" is what is
stale, not the registry.

- `engine-prefill-throughput` / `engine-decode-throughput` — one component over
  two field sets, so the pair cannot drift apart
- `engine-latency` — TTFT, E2E, queue, ITL, TPOT, batch, all on one statistic
- `engine-slo-goodput` — recomputed from the engine's histogram buckets, so a
  tightened threshold actually moves the number
- `engine-requests`, `engine-cache`, `engine-spec-decode`

## Bindings

A page carries a selection; every `follow` panel defers to it, so a page moves
between GPUs or engines coherently rather than one panel at a time. What the
operator chose is stored sparsely and resolved against the host on read: a page
that was never pointed anywhere follows whatever is running, while a choice
whose target has gone away is kept verbatim so the panels report it as missing.
Nothing is ever substituted — a pin to a departed engine names the endpoint and
keeps its slot, and an engine that is merely starting is told apart from one
that is not running.

## Follow-up that needs an owner

`selectGpu`/`selectEngine` have no operator-facing control yet. #81 defers "the
UI for changing a binding" to #84, and a page-level selector is chrome that
lands beside the header tabs (#85) or in the palette (#84) — but no ticket
currently claims it, and until one does every page follows the host defaults.
Worth assigning before #86 makes the grid the default view.

## Verification

`npm run lint`, `npm run build`, `npm test -- --run` (479) and
`npm run test:browser` (9) all green. Not yet brought up against live engines —
#86 requires that anyway, but the multi-engine case is the one worth an early
look on real hardware.