### PR TITLE
feat(frontend): logs as a panel with a shared per-engine socket

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useMetrics } from './hooks/useMetrics'
 import { useMetricsHistory } from './hooks/useMetricsHistory'
 import { useMetricsIngest } from './hooks/useMetricsIngest'
 import { useRoute } from './hooks/useRoute'
+import { LogStreamProvider } from './hooks/LogStreamProvider'
 import { MetricsStoreProvider } from './hooks/MetricsStoreProvider'
 import { AppHeader } from './components/AppHeader'
 import { ConfigurationNotices } from './components/ConfigurationNotices'
@@ -129,16 +130,19 @@ function GridPageContent({ pageId }: { pageId: string }) {
   )
 }
 
-// The store provider sits above everything that reads metrics history, so the
-// grid pages and the current dashboard share one set of ring buffers. The root
-// URL keeps serving the pre-grid dashboard untouched until the #86 cutover;
-// grid pages are only reachable at their own URLs.
+// The store providers sit above everything that reads metrics history or log
+// streams, so the grid pages and the current dashboard share one set of ring
+// buffers and one connection per engine's logs. The root URL keeps serving the
+// pre-grid dashboard untouched until the #86 cutover; grid pages are only
+// reachable at their own URLs.
 function App() {
   const route = useRoute()
 
   return (
     <MetricsStoreProvider>
-      {route.kind === 'page' ? <GridPageContent pageId={route.pageId} /> : <AppContent />}
+      <LogStreamProvider>
+        {route.kind === 'page' ? <GridPageContent pageId={route.pageId} /> : <AppContent />}
+      </LogStreamProvider>
     </MetricsStoreProvider>
   )
 }

--- a/frontend/src/__tests__/App.gridPage.test.tsx
+++ b/frontend/src/__tests__/App.gridPage.test.tsx
@@ -102,13 +102,13 @@ describe('the grid page route', () => {
   })
 
   it('keeps the slot of a panel type this build has not implemented yet', async () => {
-    // The vocabulary names more panels than the registry implements — the log
-    // panel arrives with #82, and a preset written by a newer build can place
-    // one this build has never rendered. It keeps its slot rather than
-    // reflowing the arrangement around it.
+    // The vocabulary names more panels than the registry implements — the
+    // inference timeline is still to come — and a preset written by a newer
+    // build can place one this build has never rendered. It keeps its slot
+    // rather than reflowing the arrangement around it.
     const fetchMock = serveConfiguration({
       document: storedDocument([
-        { id: 'a', type: 'logs', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+        { id: 'a', type: 'inference-timeline', geometry: { x: 0, y: 0, w: 6, h: 4 } },
         { id: 'b', type: 'memory', geometry: { x: 6, y: 0, w: 6, h: 4 } },
       ]),
     })
@@ -118,7 +118,7 @@ describe('the grid page route', () => {
     await configurationSettles(fetchMock)
 
     expect(
-      within(screen.getByRole('region', { name: 'Logs' })).getByText(
+      within(screen.getByRole('region', { name: 'Inference Requests' })).getByText(
         'This panel is not available yet.',
       ),
     ).toBeInTheDocument()

--- a/frontend/src/__tests__/LogViewer.test.tsx
+++ b/frontend/src/__tests__/LogViewer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { LogViewer } from '../components/LogViewer'
+import { LogStreamProvider } from '../hooks/LogStreamProvider'
 import { MockWebSocket, substituteWebSocket } from '../test/websocket'
 import type { EngineSnapshot } from '../types/metrics'
 
@@ -20,6 +21,23 @@ const engine = (
 
 substituteWebSocket()
 
+type ViewerProps = Parameters<typeof LogViewer>[0]
+
+/**
+ * The drawer over a store of its own. The connection lives in the store now
+ * (shared per endpoint with the log panels), so the drawer needs a provider the
+ * way it needed a WebSocket before.
+ */
+function renderViewer(props: ViewerProps = {}) {
+  const wrap = (p: ViewerProps) => (
+    <LogStreamProvider>
+      <LogViewer {...p} />
+    </LogStreamProvider>
+  )
+  const result = render(wrap(props))
+  return { ...result, rerender: (next: ViewerProps) => result.rerender(wrap(next)) }
+}
+
 /** Expand the console (which lazily opens the socket) and return the socket. */
 function expand(): MockWebSocket {
   fireEvent.click(screen.getByText('▶ Console Logs'))
@@ -38,27 +56,27 @@ describe('LogViewer', () => {
   })
 
   it('renders collapsed by default', () => {
-    render(<LogViewer />)
+    renderViewer()
     expect(screen.getByText('▶ Console Logs')).toBeDefined()
     // Should not show the expanded log panel
     expect(screen.queryByText('▼ Console Logs')).toBeNull()
   })
 
   it('does not open a socket while collapsed (lazy connect)', () => {
-    render(<LogViewer />)
+    renderViewer()
     expect(MockWebSocket.instances).toHaveLength(0)
     expect(screen.getByText('click to stream')).toBeDefined()
   })
 
   it('connects on first expand', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     expect(MockWebSocket.instances).toHaveLength(1)
     expect(ws.url).toContain('/ws/logs')
   })
 
   it('closes the socket when collapsed again', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     fireEvent.click(screen.getByText('▼ Console Logs'))
@@ -67,14 +85,14 @@ describe('LogViewer', () => {
   })
 
   it('shows live state when connected', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     expect(screen.getByText('⏵ Live')).toBeDefined()
   })
 
   it('displays log messages from WebSocket', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     act(() => ws.receive('INFO: Server started on port 3000'))
@@ -82,7 +100,7 @@ describe('LogViewer', () => {
   })
 
   it('filters log lines by text', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     act(() => {
@@ -100,7 +118,7 @@ describe('LogViewer', () => {
   })
 
   it('shows paused state when pause button clicked', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     fireEvent.click(screen.getByText('⏵ Live'))
@@ -108,20 +126,20 @@ describe('LogViewer', () => {
   })
 
   it('shows waiting message when connected but no logs', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     expect(screen.getByText('Waiting for log output...')).toBeDefined()
   })
 
   it('shows connecting message before the socket opens', () => {
-    render(<LogViewer />)
+    renderViewer()
     expand()
     expect(screen.getByText('Connecting...')).toBeDefined()
   })
 
   it('shows the not-enabled hint when the handshake never succeeds', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     // Close without ever opening: /ws/logs is not registered on the backend.
     act(() => ws.close())
@@ -134,7 +152,7 @@ describe('LogViewer', () => {
   })
 
   it('reconnects after a dropped live connection', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     act(() => ws.close())
@@ -144,7 +162,7 @@ describe('LogViewer', () => {
   })
 
   it('highlights error lines in red', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     act(() => ws.receive('ERROR: critical failure'))
@@ -153,7 +171,7 @@ describe('LogViewer', () => {
   })
 
   it('highlights warning lines in yellow', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     act(() => ws.receive('WARN: deprecated function used'))
@@ -162,12 +180,10 @@ describe('LogViewer', () => {
   })
 
   it('passes the selected engine endpoint as ?engine=', () => {
-    render(
-      <LogViewer
-        engines={[engine('http://localhost:8000'), engine('http://localhost:8100')]}
-        selectedEndpoint="http://localhost:8100"
-      />,
-    )
+    renderViewer({
+      engines: [engine('http://localhost:8000'), engine('http://localhost:8100')],
+      selectedEndpoint: 'http://localhost:8100',
+    })
     const ws = expand()
     expect(ws.url).toContain(
       `/ws/logs?engine=${encodeURIComponent('http://localhost:8100')}`,
@@ -175,12 +191,10 @@ describe('LogViewer', () => {
   })
 
   it('falls back to the first Docker engine when no engine is selected', () => {
-    render(
-      <LogViewer
-        engines={[engine('http://localhost:8000', 'Native'), engine('http://localhost:8100')]}
-        selectedEndpoint={null}
-      />,
-    )
+    renderViewer({
+      engines: [engine('http://localhost:8000', 'Native'), engine('http://localhost:8100')],
+      selectedEndpoint: null,
+    })
     const ws = expand()
     expect(ws.url).toContain(
       `/ws/logs?engine=${encodeURIComponent('http://localhost:8100')}`,
@@ -189,15 +203,13 @@ describe('LogViewer', () => {
 
   it('reconnects and clears the buffer when the selected engine changes', () => {
     const engines = [engine('http://localhost:8000'), engine('http://localhost:8100')]
-    const { rerender } = render(
-      <LogViewer engines={engines} selectedEndpoint="http://localhost:8000" />,
-    )
+    const { rerender } = renderViewer({ engines, selectedEndpoint: 'http://localhost:8000' })
     const ws = expand()
     act(() => ws.connect())
     act(() => ws.receive('line from engine 8000'))
     expect(screen.getByText('line from engine 8000')).toBeDefined()
 
-    rerender(<LogViewer engines={engines} selectedEndpoint="http://localhost:8100" />)
+    rerender({ engines, selectedEndpoint: 'http://localhost:8100' })
 
     // A second socket is opened against the newly selected engine…
     expect(MockWebSocket.instances).toHaveLength(2)
@@ -209,7 +221,7 @@ describe('LogViewer', () => {
   })
 
   it('does not show the auto-scroll indicator while following the stream', () => {
-    render(<LogViewer />)
+    renderViewer()
     const ws = expand()
     act(() => ws.connect())
     act(() => {
@@ -223,7 +235,7 @@ describe('LogViewer', () => {
   })
 
   it('shows the auto-scroll indicator only after scrolling back, hides it at the bottom', () => {
-    const { container } = render(<LogViewer />)
+    const { container } = renderViewer()
     const ws = expand()
     act(() => ws.connect())
     act(() => ws.receive('line 1'))
@@ -249,9 +261,10 @@ describe('LogViewer', () => {
   })
 
   it('shows which engine is being streamed in the header', () => {
-    render(
-      <LogViewer engines={[engine('http://localhost:8000')]} selectedEndpoint="http://localhost:8000" />,
-    )
+    renderViewer({
+      engines: [engine('http://localhost:8000')],
+      selectedEndpoint: 'http://localhost:8000',
+    })
     expect(screen.getByText('http://localhost:8000')).toBeDefined()
   })
 })

--- a/frontend/src/__tests__/logStreamStore.test.ts
+++ b/frontend/src/__tests__/logStreamStore.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LogStreamStore } from '../lib/logStreamStore'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+
+substituteWebSocket()
+
+/** The socket opened most recently, which is the one a fresh stream owns. */
+function latest(): MockWebSocket {
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1]
+}
+
+const ALPHA = 'http://localhost:8000'
+const BETA = 'http://localhost:8001'
+
+describe('the log stream store', () => {
+  let store: LogStreamStore
+
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.useFakeTimers()
+    store = new LogStreamStore()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('opens no socket until something subscribes', () => {
+    expect(store.read(ALPHA)).toEqual({ status: 'connecting', lines: [] })
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  it('addresses the engine by endpoint in the socket URL', () => {
+    store.subscribe(ALPHA, () => {})
+
+    expect(latest().url).toContain(`/ws/logs?engine=${encodeURIComponent(ALPHA)}`)
+  })
+
+  it('opens exactly one socket for several subscribers of the same endpoint', () => {
+    store.subscribe(ALPHA, () => {})
+    store.subscribe(ALPHA, () => {})
+    store.subscribe(ALPHA, () => {})
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('opens one socket per distinct endpoint', () => {
+    store.subscribe(ALPHA, () => {})
+    store.subscribe(BETA, () => {})
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(MockWebSocket.instances[0].url).toContain(encodeURIComponent(ALPHA))
+    expect(MockWebSocket.instances[1].url).toContain(encodeURIComponent(BETA))
+  })
+
+  it('delivers a line to every subscriber of that endpoint, and to no other', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const other = vi.fn()
+    store.subscribe(ALPHA, first)
+    store.subscribe(ALPHA, second)
+    store.subscribe(BETA, other)
+
+    const alpha = MockWebSocket.instances[0]
+    alpha.connect()
+    other.mockClear()
+    alpha.receive('INFO: serving')
+
+    expect(first).toHaveBeenCalled()
+    expect(second).toHaveBeenCalled()
+    expect(other).not.toHaveBeenCalled()
+    expect(store.read(ALPHA).lines).toEqual(['INFO: serving'])
+    expect(store.read(BETA).lines).toEqual([])
+  })
+
+  it('keeps the socket open while another subscriber remains', () => {
+    const release = store.subscribe(ALPHA, () => {})
+    store.subscribe(ALPHA, () => {})
+    const socket = latest()
+    socket.connect()
+    socket.receive('INFO: still here')
+
+    release()
+
+    expect(socket.readyState).toBe(1)
+    expect(store.read(ALPHA).lines).toEqual(['INFO: still here'])
+  })
+
+  it('closes the socket when the last subscriber leaves', () => {
+    const release = store.subscribe(ALPHA, () => {})
+    const socket = latest()
+    socket.connect()
+
+    release()
+
+    expect(socket.readyState).toBe(3)
+    expect(store.read(ALPHA)).toEqual({ status: 'connecting', lines: [] })
+  })
+
+  it('forgets the buffer once the last subscriber leaves', () => {
+    const release = store.subscribe(ALPHA, () => {})
+    latest().connect()
+    latest().receive('INFO: from the previous viewer')
+    release()
+
+    store.subscribe(ALPHA, () => {})
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(store.read(ALPHA).lines).toEqual([])
+  })
+
+  it('reports a stream as connected once the handshake succeeds', () => {
+    store.subscribe(ALPHA, () => {})
+    expect(store.read(ALPHA).status).toBe('connecting')
+
+    latest().connect()
+
+    expect(store.read(ALPHA).status).toBe('connected')
+  })
+
+  it('marks the stream unavailable when the handshake never succeeds, and does not retry', () => {
+    store.subscribe(ALPHA, () => {})
+
+    // Closed without ever opening: /ws/logs is not registered, because the
+    // backend runs without --enable-log-viewer.
+    latest().close()
+
+    expect(store.read(ALPHA).status).toBe('unavailable')
+    vi.advanceTimersByTime(60_000)
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('reconnects after a live connection drops, keeping the lines it had', () => {
+    store.subscribe(ALPHA, () => {})
+    latest().connect()
+    latest().receive('INFO: before the restart')
+    latest().close()
+
+    expect(store.read(ALPHA).status).toBe('reconnecting')
+    expect(store.read(ALPHA).lines).toEqual(['INFO: before the restart'])
+
+    vi.advanceTimersByTime(2000)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(MockWebSocket.instances[1].url).toContain(encodeURIComponent(ALPHA))
+    latest().connect()
+    expect(store.read(ALPHA).status).toBe('connected')
+  })
+
+  it('does not reconnect after the last subscriber leaves mid-retry', () => {
+    const release = store.subscribe(ALPHA, () => {})
+    latest().connect()
+    latest().close()
+
+    release()
+    vi.advanceTimersByTime(10_000)
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('drops the oldest lines past the buffer cap', () => {
+    store.subscribe(ALPHA, () => {})
+    latest().connect()
+    for (let i = 0; i < 1010; i++) latest().receive(`line ${i}`)
+
+    const { lines } = store.read(ALPHA)
+    expect(lines).toHaveLength(1000)
+    expect(lines[0]).toBe('line 10')
+    expect(lines[999]).toBe('line 1009')
+  })
+
+  it('hands back the same stream value until something changes', () => {
+    // `useSyncExternalStore` re-renders whenever the read returns a new value,
+    // so an unchanged stream has to be the same object.
+    store.subscribe(ALPHA, () => {})
+    latest().connect()
+    const first = store.read(ALPHA)
+
+    expect(store.read(ALPHA)).toBe(first)
+
+    latest().receive('INFO: something new')
+    expect(store.read(ALPHA)).not.toBe(first)
+  })
+
+  it('hands back one shared empty stream for an endpoint nothing is watching', () => {
+    expect(store.read(ALPHA)).toBe(store.read(BETA))
+  })
+})

--- a/frontend/src/__tests__/logStreamStore.test.ts
+++ b/frontend/src/__tests__/logStreamStore.test.ts
@@ -23,6 +23,7 @@ describe('the log stream store', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    MockWebSocket.deferCloseEvents = false
   })
 
   it('opens no socket until something subscribes', () => {
@@ -156,6 +157,30 @@ describe('the log stream store', () => {
     vi.advanceTimersByTime(10_000)
 
     expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('ignores a close event that lands after the endpoint changed hands', () => {
+    // A real browser fires `close` on a later task than the `close()` call, so
+    // a panel removed and re-added — or one switching engines and back — can
+    // hand the endpoint to a new connection while the old one's event is still
+    // in flight. The stale connection must not reconnect: nothing would ever be
+    // able to close the socket it opened.
+    MockWebSocket.deferCloseEvents = true
+    const release = store.subscribe(ALPHA, () => {})
+    latest().connect()
+
+    release()
+    store.subscribe(ALPHA, () => {})
+    const replacement = latest()
+    MockWebSocket.flushCloseEvents()
+
+    vi.advanceTimersByTime(30_000)
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(store.read(ALPHA).status).toBe('connecting')
+
+    // The endpoint's own connection is untouched by the orphan's late event.
+    replacement.connect()
+    expect(store.read(ALPHA).status).toBe('connected')
   })
 
   it('drops the oldest lines past the buffer cap', () => {

--- a/frontend/src/__tests__/logsPanel.test.tsx
+++ b/frontend/src/__tests__/logsPanel.test.tsx
@@ -1,0 +1,426 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import { useEffect } from 'react'
+import { GridPanel } from '@/components/grid/GridPanel'
+import { LogStreamProvider } from '@/hooks/LogStreamProvider'
+import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
+import { PageSelectionProvider } from '@/hooks/PageSelectionProvider'
+import { useMetricsStore } from '@/hooks/useMetricsStore'
+import { usePageSelection } from '@/hooks/usePageSelection'
+import { FOLLOW } from '@/lib/dashboard/bindings'
+import { DEFAULT_TIME_WINDOW, type DashboardPanel } from '@/lib/dashboard/schema'
+import { MockWebSocket, substituteWebSocket } from '@/test/websocket'
+import type { EngineMetrics, EngineSnapshot, MetricsSnapshot } from '@/types/metrics'
+
+// The log panel (#82) through the real frame: the real registry, the real
+// binding resolution and the real shared stream store, with the log sockets
+// arriving through the substituted WebSocket. What is local to this spec is the
+// affordance that changes the page selection and the one that removes a panel —
+// both ship with edit mode (#83–#85), and the panel has to be right first.
+substituteWebSocket()
+
+const ALPHA = 'http://localhost:8000'
+const BETA = 'http://localhost:8001'
+
+function makeEngine(endpoint: string, overrides: Partial<EngineSnapshot> = {}): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status: { type: 'Running' },
+    model: {
+      name: 'Qwen/Qwen3-8B',
+      parameter_size: null,
+      quantization: null,
+      precision: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: { tokens_per_sec: 120 } as EngineMetrics,
+    recent_requests: [],
+    deployment_mode: 'Docker',
+    ...overrides,
+  }
+}
+
+function snapshot(engines: EngineSnapshot[]): MetricsSnapshot {
+  return {
+    timestamp_ms: 1000,
+    gpu: {
+      index: 0,
+      name: 'NVIDIA GB10',
+      utilization_percent: 11,
+      memory_total_bytes: null,
+      memory_used_bytes: null,
+      temperature_celsius: 40,
+      power_watts: 100,
+      power_limit_watts: 300,
+      clock_graphics_mhz: 2000,
+      clock_sm_mhz: null,
+      clock_memory_mhz: null,
+      fan_speed_percent: null,
+    },
+    cpu: { name: 'CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128,
+      used_bytes: 64,
+      available_bytes: 64,
+      cached_bytes: 8,
+      gpu_estimated_bytes: null,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: true,
+    },
+    disk: { name: 'disk', read_bytes_per_sec: 1, write_bytes_per_sec: 2 },
+    network: { name: 'net', rx_bytes_per_sec: 3, tx_bytes_per_sec: 4 },
+    engines,
+    gpu_events: [],
+  }
+}
+
+/** A log panel, following the page selection unless a binding is given. */
+function logPanel(id: string, title: string, overrides: Partial<DashboardPanel> = {}) {
+  return {
+    id,
+    title,
+    type: 'logs',
+    geometry: { x: 0, y: 0, w: 4, h: 4 },
+    binding: FOLLOW,
+    window: DEFAULT_TIME_WINDOW,
+    ...overrides,
+  } satisfies DashboardPanel
+}
+
+function Ingest({ engines }: { engines: EngineSnapshot[] }) {
+  const store = useMetricsStore()
+  useEffect(() => {
+    store.ingest(snapshot(engines))
+  }, [store, engines])
+  return null
+}
+
+/** Stand-in for the page's engine selector, which ships with #84/#85. */
+function SelectEngine({ endpoint }: { endpoint: string }) {
+  const { selectEngine } = usePageSelection()
+  return (
+    <button type="button" onClick={() => selectEngine(endpoint)}>
+      Select {endpoint}
+    </button>
+  )
+}
+
+function Page({
+  engines,
+  panels,
+}: {
+  engines: EngineSnapshot[]
+  panels: DashboardPanel[]
+}) {
+  return (
+    <MetricsStoreProvider>
+      <LogStreamProvider>
+        <Ingest engines={engines} />
+        <PageSelectionProvider>
+          <SelectEngine endpoint={BETA} />
+          {panels.map((panel) => (
+            <GridPanel key={panel.id} panel={panel} />
+          ))}
+        </PageSelectionProvider>
+      </LogStreamProvider>
+    </MetricsStoreProvider>
+  )
+}
+
+/** Every log socket opened so far, oldest first. */
+function sockets(): MockWebSocket[] {
+  return MockWebSocket.instances.filter((ws) => ws.url.includes('/ws/logs'))
+}
+
+/** The one socket streaming this endpoint. Fails the spec if there is not
+ *  exactly one — sharing is the point of the store. */
+function socketFor(endpoint: string): MockWebSocket {
+  const matching = sockets().filter((ws) => ws.url.includes(encodeURIComponent(endpoint)))
+  expect(matching, `sockets for ${endpoint}`).toHaveLength(1)
+  return matching[0]
+}
+
+function region(name: string): HTMLElement {
+  return screen.getByRole('region', { name })
+}
+
+function click(name: string) {
+  act(() => screen.getByRole('button', { name }).click())
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('the log panel', () => {
+  it('streams the engine it is bound to, addressing it by endpoint', () => {
+    render(
+      <Page
+        engines={[makeEngine(ALPHA), makeEngine(BETA)]}
+        panels={[logPanel('logs', 'Engine Logs')]}
+      />,
+    )
+
+    const socket = socketFor(ALPHA)
+    act(() => {
+      socket.connect()
+      socket.receive('INFO: alpha is serving')
+    })
+
+    expect(within(region('Engine Logs')).getByText('INFO: alpha is serving')).toBeInTheDocument()
+  })
+
+  it('opens one connection for two panels bound to the same engine', () => {
+    render(
+      <Page
+        engines={[makeEngine(ALPHA)]}
+        panels={[
+          logPanel('following', 'Following Logs'),
+          logPanel('pinned', 'Pinned Logs', { binding: { kind: 'engine', endpoint: ALPHA } }),
+        ]}
+      />,
+    )
+
+    // One socket, not two: the connection belongs to the endpoint, and both
+    // panels resolved to the same one.
+    expect(sockets()).toHaveLength(1)
+
+    const socket = socketFor(ALPHA)
+    act(() => {
+      socket.connect()
+      socket.receive('INFO: shared line')
+    })
+
+    // Both panels show it — one stream, read twice.
+    expect(within(region('Following Logs')).getByText('INFO: shared line')).toBeInTheDocument()
+    expect(within(region('Pinned Logs')).getByText('INFO: shared line')).toBeInTheDocument()
+  })
+
+  it('keeps streaming for the panel that remains when the other is removed', () => {
+    const engines = [makeEngine(ALPHA)]
+    const both = [
+      logPanel('following', 'Following Logs'),
+      logPanel('pinned', 'Pinned Logs', { binding: { kind: 'engine', endpoint: ALPHA } }),
+    ]
+    const { rerender } = render(<Page engines={engines} panels={both} />)
+
+    const socket = socketFor(ALPHA)
+    act(() => socket.connect())
+
+    rerender(<Page engines={engines} panels={[both[1]]} />)
+
+    // The socket the removed panel shared is still open, still the only one,
+    // and still feeding the panel that stayed.
+    expect(socket.readyState).toBe(1)
+    expect(sockets()).toHaveLength(1)
+    act(() => socket.receive('INFO: still streaming'))
+    expect(within(region('Pinned Logs')).getByText('INFO: still streaming')).toBeInTheDocument()
+  })
+
+  it('closes the connection once the last panel watching it is gone', () => {
+    const engines = [makeEngine(ALPHA)]
+    const panels = [logPanel('logs', 'Engine Logs')]
+    const { rerender } = render(<Page engines={engines} panels={panels} />)
+
+    const socket = socketFor(ALPHA)
+    act(() => socket.connect())
+
+    rerender(<Page engines={engines} panels={[]} />)
+
+    // Nothing is watching, so the backend can stop the container stream.
+    expect(socket.readyState).toBe(3)
+  })
+
+  it('streams each engine separately for panels bound to different engines', () => {
+    render(
+      <Page
+        engines={[makeEngine(ALPHA), makeEngine(BETA)]}
+        panels={[
+          logPanel('alpha', 'Alpha Logs', { binding: { kind: 'engine', endpoint: ALPHA } }),
+          logPanel('beta', 'Beta Logs', { binding: { kind: 'engine', endpoint: BETA } }),
+        ]}
+      />,
+    )
+
+    expect(sockets()).toHaveLength(2)
+    const alpha = socketFor(ALPHA)
+    const beta = socketFor(BETA)
+    act(() => {
+      alpha.connect()
+      beta.connect()
+      alpha.receive('INFO: from alpha')
+      beta.receive('INFO: from beta')
+    })
+
+    // Each panel shows its own engine's lines and nothing of the other's —
+    // logs are the one place where reading the wrong container is worst.
+    const alphaPanel = within(region('Alpha Logs'))
+    expect(alphaPanel.getByText('INFO: from alpha')).toBeInTheDocument()
+    expect(alphaPanel.queryByText('INFO: from beta')).not.toBeInTheDocument()
+
+    const betaPanel = within(region('Beta Logs'))
+    expect(betaPanel.getByText('INFO: from beta')).toBeInTheDocument()
+    expect(betaPanel.queryByText('INFO: from alpha')).not.toBeInTheDocument()
+  })
+
+  it('moves to the engine the page is pointed at, and leaves a pin alone', () => {
+    render(
+      <Page
+        engines={[makeEngine(ALPHA), makeEngine(BETA)]}
+        panels={[
+          logPanel('following', 'Following Logs'),
+          logPanel('pinned', 'Pinned Logs', { binding: { kind: 'engine', endpoint: ALPHA } }),
+        ]}
+      />,
+    )
+
+    const alpha = socketFor(ALPHA)
+    act(() => alpha.connect())
+    expect(sockets()).toHaveLength(1)
+
+    click(`Select ${BETA}`)
+
+    // The following panel opened Beta's stream; the pinned one is still holding
+    // Alpha's, so that connection stayed up rather than being torn down.
+    const beta = socketFor(BETA)
+    expect(alpha.readyState).toBe(1)
+    act(() => {
+      beta.connect()
+      beta.receive('INFO: from beta')
+      alpha.receive('INFO: from alpha')
+    })
+    expect(within(region('Following Logs')).getByText('INFO: from beta')).toBeInTheDocument()
+    expect(within(region('Pinned Logs')).getByText('INFO: from alpha')).toBeInTheDocument()
+  })
+
+  it('explains that a disabled log viewer is a deployment choice', () => {
+    render(<Page engines={[makeEngine(ALPHA)]} panels={[logPanel('logs', 'Engine Logs')]} />)
+
+    // Closed without ever opening: the backend runs without --enable-log-viewer,
+    // so /ws/logs was never registered.
+    act(() => socketFor(ALPHA).close())
+
+    expect(
+      within(region('Engine Logs')).getByText(/Log viewer not enabled on this server/),
+    ).toBeInTheDocument()
+    // Nothing to retry: the route does not exist on this deployment.
+    act(() => vi.advanceTimersByTime(30_000))
+    expect(sockets()).toHaveLength(1)
+  })
+
+  it('reconnects after a live connection drops, keeping the lines it had', () => {
+    render(<Page engines={[makeEngine(ALPHA)]} panels={[logPanel('logs', 'Engine Logs')]} />)
+
+    const socket = socketFor(ALPHA)
+    act(() => {
+      socket.connect()
+      socket.receive('INFO: before the restart')
+      socket.close()
+    })
+
+    const panel = within(region('Engine Logs'))
+    expect(panel.getByText('INFO: before the restart')).toBeInTheDocument()
+    act(() => vi.advanceTimersByTime(2000))
+    expect(sockets()).toHaveLength(2)
+  })
+
+  it('filters and pauses per panel, over the one shared stream', () => {
+    render(
+      <Page
+        engines={[makeEngine(ALPHA)]}
+        panels={[
+          logPanel('following', 'Following Logs'),
+          logPanel('pinned', 'Pinned Logs', { binding: { kind: 'engine', endpoint: ALPHA } }),
+        ]}
+      />,
+    )
+
+    const socket = socketFor(ALPHA)
+    act(() => {
+      socket.connect()
+      socket.receive('ERROR: cuda out of memory')
+      socket.receive('INFO: all good')
+    })
+
+    const following = within(region('Following Logs'))
+    fireEvent.change(following.getByPlaceholderText('Filter lines containing...'), {
+      target: { value: 'error' },
+    })
+
+    // Filtering is viewport state, not stream state: one panel narrows, the
+    // other keeps showing everything from the same buffer.
+    expect(following.getByText('ERROR: cuda out of memory')).toBeInTheDocument()
+    expect(following.queryByText('INFO: all good')).not.toBeInTheDocument()
+
+    const pinned = within(region('Pinned Logs'))
+    expect(pinned.getByText('INFO: all good')).toBeInTheDocument()
+
+    // Pause is per panel too.
+    fireEvent.click(following.getByText('⏵ Live'))
+    expect(following.getByText('⏸ Paused')).toBeInTheDocument()
+    expect(pinned.getByText('⏵ Live')).toBeInTheDocument()
+  })
+
+  it('streams an engine that is not serving, which is when logs matter most', () => {
+    // No model loaded and no metrics: every metric panel shows a notice here.
+    // The log panel is what says why, so it must stream anyway.
+    render(
+      <Page
+        engines={[makeEngine(ALPHA, { model: null, metrics: null })]}
+        panels={[logPanel('logs', 'Engine Logs')]}
+      />,
+    )
+
+    const socket = socketFor(ALPHA)
+    act(() => {
+      socket.connect()
+      socket.receive('ERROR: failed to load model weights')
+    })
+
+    expect(
+      within(region('Engine Logs')).getByText('ERROR: failed to load model weights'),
+    ).toBeInTheDocument()
+  })
+
+  it('opens no connection for a panel pinned to an engine that is gone', () => {
+    render(
+      <Page
+        engines={[makeEngine(ALPHA)]}
+        panels={[
+          logPanel('logs', 'Engine Logs', { binding: { kind: 'engine', endpoint: BETA } }),
+        ]}
+      />,
+    )
+
+    expect(sockets()).toHaveLength(0)
+    expect(within(region('Engine Logs')).getByText(`No engine at ${BETA} — repoint this panel.`))
+      .toBeInTheDocument()
+  })
+
+  it('opens no connection on a host running no engines', () => {
+    render(<Page engines={[]} panels={[logPanel('logs', 'Engine Logs')]} />)
+
+    expect(sockets()).toHaveLength(0)
+    expect(within(region('Engine Logs')).getByText('No inference engine running.')).toBeInTheDocument()
+  })
+
+  it('names the engine it is streaming on a host running several', () => {
+    render(
+      <Page
+        engines={[makeEngine(ALPHA), makeEngine(BETA)]}
+        panels={[logPanel('logs', 'Engine Logs')]}
+      />,
+    )
+
+    expect(within(region('Engine Logs')).getByText('vLLM localhost:8000')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/LogConsole.tsx
+++ b/frontend/src/components/LogConsole.tsx
@@ -80,10 +80,9 @@ export function LogConsole({ stream, label = null, leading }: LogConsoleProps) {
   return (
     <div
       onKeyDown={handleKeyDown}
-      // Inline rather than `h-full`: the console renders in the browser test
-      // project too, which runs no Tailwind build (same rule as GridPage).
-      style={{ height: '100%' }}
-      className="flex flex-col min-h-0 min-w-0 rounded-md border border-white/[0.04] overflow-hidden"
+      // Fills whatever box it is given — the drawer's fixed strip, or the panel
+      // the operator sized — with only the line area below scrolling.
+      className="h-full flex flex-col min-h-0 min-w-0 rounded-md border border-white/[0.04] overflow-hidden"
     >
       {/* Header bar */}
       <div className="shrink-0 flex items-center gap-2 px-2 py-1 bg-[#111115] flex-wrap">

--- a/frontend/src/components/LogConsole.tsx
+++ b/frontend/src/components/LogConsole.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import type { LogStream } from '@/lib/logStreamStore'
+
+interface LogConsoleProps {
+  /** The lines and connection state to render. Where they come from is the
+   *  caller's business — a log panel's binding, or the pre-grid drawer. */
+  stream: LogStream
+  /** Names the container being streamed. Null keeps the label out entirely. */
+  label?: string | null
+  /** Chrome belonging to the caller, placed first in the header row — the
+   *  pre-grid console's collapse toggle. */
+  leading?: ReactNode
+}
+
+/**
+ * The log console itself: the filter, the pause/live toggle, the auto-follow
+ * and the line colouring, over whatever stream it is handed.
+ *
+ * It is deliberately free of any connection logic. The socket belongs to
+ * `LogStreamStore`, shared per engine endpoint, so two consoles on one engine
+ * cost one connection and can still be filtered and paused independently —
+ * filtering and pausing are viewport state, not stream state.
+ *
+ * Fills its container, with only the line area scrolling, so it sits equally in
+ * a fixed-height drawer and in a grid panel the operator sized.
+ */
+export function LogConsole({ stream, label = null, leading }: LogConsoleProps) {
+  const { status, lines } = stream
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [paused, setPaused] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [excludeMode, setExcludeMode] = useState(false)
+  const filterRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll when new lines arrive (only if not paused)
+  useEffect(() => {
+    if (autoScroll && !paused && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [lines, autoScroll, paused])
+
+  const handleScroll = () => {
+    if (!containerRef.current) return
+    const el = containerRef.current
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50
+    setAutoScroll(atBottom)
+  }
+
+  // Filtered log lines — computed from the full buffer
+  const filteredLogs = useMemo(() => {
+    if (!filter.trim()) return lines
+    const lower = filter.toLowerCase()
+    return excludeMode
+      ? lines.filter((line) => !line.toLowerCase().includes(lower))
+      : lines.filter((line) => line.toLowerCase().includes(lower))
+  }, [lines, filter, excludeMode])
+
+  // Toggle pause/resume
+  const togglePause = () => {
+    const next = !paused
+    setPaused(next)
+    if (!next) {
+      // Unpausing: jump to bottom
+      setAutoScroll(true)
+      if (containerRef.current) {
+        containerRef.current.scrollTop = containerRef.current.scrollHeight
+      }
+    }
+  }
+
+  // Keyboard shortcut: Ctrl+F / Cmd+F to focus the filter input
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+      e.preventDefault()
+      filterRef.current?.focus()
+    }
+  }
+
+  return (
+    <div
+      onKeyDown={handleKeyDown}
+      // Inline rather than `h-full`: the console renders in the browser test
+      // project too, which runs no Tailwind build (same rule as GridPage).
+      style={{ height: '100%' }}
+      className="flex flex-col min-h-0 min-w-0 rounded-md border border-white/[0.04] overflow-hidden"
+    >
+      {/* Header bar */}
+      <div className="shrink-0 flex items-center gap-2 px-2 py-1 bg-[#111115] flex-wrap">
+        {leading}
+
+        {/* Connection indicator */}
+        <span
+          className={`inline-block w-1.5 h-1.5 rounded-full ${
+            status === 'connected'
+              ? 'bg-[#76B900]'
+              : status === 'reconnecting'
+                ? 'bg-yellow-400'
+                : 'bg-zinc-500'
+          }`}
+          title={status}
+        />
+
+        {/* Which engine's container is being streamed */}
+        {label && (
+          <span className="text-[10px] text-zinc-600 truncate max-w-[240px] shrink-0">{label}</span>
+        )}
+
+        {/* Pause/Resume button */}
+        <button
+          onClick={togglePause}
+          className={`text-[11px] px-2 py-0.5 rounded font-medium transition-colors shrink-0 ${
+            paused
+              ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30'
+              : 'text-zinc-400 hover:text-zinc-200'
+          }`}
+          title={paused ? 'Resume — jump to latest' : 'Pause — freeze viewport'}
+        >
+          {paused ? '⏸ Paused' : '⏵ Live'}
+        </button>
+
+        {/* Line count */}
+        <span className="text-[10px] text-zinc-600 shrink-0">
+          {filteredLogs.length}/{lines.length}
+        </span>
+
+        {/* Scroll-to-bottom button (only when not auto-scrolling) */}
+        {!autoScroll && !paused && (
+          <button
+            onClick={() => {
+              setAutoScroll(true)
+              if (containerRef.current) {
+                containerRef.current.scrollTop = containerRef.current.scrollHeight
+              }
+            }}
+            className="text-[10px] text-yellow-400 hover:text-yellow-300 shrink-0"
+          >
+            ↓ Auto-scroll
+          </button>
+        )}
+      </div>
+
+      {/* Filter bar */}
+      <div className="shrink-0 flex items-center gap-2 px-2 py-1 bg-[#0d0d11] border-y border-white/[0.04]">
+        <button
+          onClick={() => setExcludeMode(!excludeMode)}
+          className={`text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0 border transition-colors ${
+            excludeMode
+              ? 'bg-red-500/15 text-red-400 border-red-500/30'
+              : 'bg-blue-500/15 text-blue-400 border-blue-500/30'
+          }`}
+          title={
+            excludeMode
+              ? 'Exclude mode — hides matching lines'
+              : 'Filter mode — shows only matching lines'
+          }
+        >
+          {excludeMode ? 'Exclude' : 'Filter'}
+        </button>
+        <svg
+          className="w-3 h-3 text-zinc-500 shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+          />
+        </svg>
+        <input
+          ref={filterRef}
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={excludeMode ? 'Exclude lines containing...' : 'Filter lines containing...'}
+          className="flex-1 min-w-0 bg-transparent text-[11px] text-zinc-300 placeholder-zinc-600 outline-none border-none"
+        />
+        {filter && (
+          <button
+            onClick={() => setFilter('')}
+            className="text-[10px] text-zinc-500 hover:text-zinc-300 shrink-0"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Log content. Auto-follow must jump instantly: with smooth scrolling
+        * every appended line animates toward the bottom, and the scroll events
+        * fired mid-animation read as "not at bottom", flickering autoScroll
+        * (and the resume button) off and on with each batch. */}
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className={`flex-1 min-h-0 overflow-y-auto bg-black/60
+                   font-mono text-[11px] leading-[1.4] p-2 space-y-0.5 ${paused ? 'opacity-60' : ''}`}
+      >
+        {lines.length === 0 && <EmptyStream status={status} />}
+
+        {filteredLogs.length === 0 && lines.length > 0 && (
+          <div className="text-zinc-600 italic text-center pt-8">
+            No lines match &quot;{filter}&quot;
+          </div>
+        )}
+
+        {filteredLogs.map((line, i) => {
+          const isError =
+            line.toLowerCase().includes('error') || line.toLowerCase().includes('traceback')
+          const isWarning =
+            line.toLowerCase().includes('warn') || line.toLowerCase().includes('warning')
+          return (
+            <div
+              key={i}
+              className={`whitespace-pre-wrap break-all ${
+                isError ? 'text-red-400' : isWarning ? 'text-yellow-400' : 'text-zinc-300'
+              }`}
+            >
+              {line}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * What a console with no lines says. `unavailable` is the one that has to name
+ * itself as a deployment choice: the backend registers `/ws/logs` only when it
+ * is started with the flag, so nothing about the panel is broken and there is
+ * nothing to retry — there is a server to restart with one more argument.
+ */
+function EmptyStream({ status }: { status: LogStream['status'] }) {
+  return (
+    <div className="text-zinc-600 italic text-center pt-8">
+      {status === 'connected' && 'Waiting for log output...'}
+      {status === 'connecting' && 'Connecting...'}
+      {status === 'reconnecting' && 'Connection lost — reconnecting…'}
+      {status === 'unavailable' &&
+        'Log viewer not enabled on this server — start the dashboard with --enable-log-viewer (or SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1).'}
+    </div>
+  )
+}

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useLogStream } from '../hooks/useLogStream'
 import { findEngineByEndpoint } from '../lib/identity'
+import { BACKEND_DEFAULT_ENGINE } from '../lib/logStreamStore'
 import { LogConsole } from './LogConsole'
 import type { EngineSnapshot } from '../types/metrics'
 
@@ -38,13 +39,13 @@ export function LogViewer({
   const [collapsed, setCollapsed] = useState(true)
 
   // Engine whose container is streamed: the selected tab's engine when one is
-  // active and still present, otherwise the first Docker engine. The empty
-  // string asks the backend for its own default, which applies the same rule.
+  // active and still present, otherwise the first Docker engine — and, with no
+  // engines to choose from, whichever one the backend would pick itself.
   const targetEndpoint = useMemo(() => {
     if (selectedEndpoint && findEngineByEndpoint(engines, selectedEndpoint)) {
       return selectedEndpoint
     }
-    return engines.find((e) => e.deployment_mode === 'Docker')?.endpoint ?? ''
+    return engines.find((e) => e.deployment_mode === 'Docker')?.endpoint ?? BACKEND_DEFAULT_ENGINE
   }, [engines, selectedEndpoint])
 
   const targetEngine = findEngineByEndpoint(engines, targetEndpoint)

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,23 +1,25 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { useLogStream } from '../hooks/useLogStream'
 import { findEngineByEndpoint } from '../lib/identity'
+import { LogConsole } from './LogConsole'
 import type { EngineSnapshot } from '../types/metrics'
 
 /**
- * Scrollable log viewer that connects to the backend's /ws/logs WebSocket
- * endpoint and streams Docker container logs in real-time.
+ * The pre-grid dashboard's log drawer: a collapsible console at the foot of the
+ * page, streaming one engine's container logs.
  *
- * The stream follows the engine selected in the engine section: when an
- * engine tab is active its endpoint is passed as `?engine=` so the backend
- * streams that engine's container; on the Global tab the first Docker engine
- * is used (mirroring the backend's default). Switching engines reconnects
- * and clears the buffer — the old lines belong to another container.
+ * The stream follows the engine selected in the engine section: when an engine
+ * tab is active its endpoint is streamed; on the Global tab the first Docker
+ * engine is used (mirroring the backend's default). Switching engines switches
+ * streams — the old lines belong to another container.
  *
- * Features:
- * - Collapsible section at the bottom of the dashboard
- * - Pause/Resume button — freeze the viewport to read, unpause to catch up
- * - Text filter — type a keyword to only show lines containing it
- * - Auto-scroll to newest lines (pauses when scrolled up manually)
- * - Error/warning color highlighting
+ * The connection itself belongs to `LogStreamStore`, shared per endpoint with
+ * the log panels on the grid pages (#82). Collapsing unmounts the console, which
+ * releases the drawer's hold on the stream: with nothing else watching that
+ * endpoint the socket closes and the backend can stop the container stream.
+ *
+ * This drawer goes away at the #86 cutover, when the grid pages replace the
+ * fixed dashboard and logs are a panel like everything else.
  */
 interface LogViewerProps {
   /** Engine snapshots from the current metrics payload. */
@@ -28,176 +30,41 @@ interface LogViewerProps {
   onExpandChange?: (expanded: boolean) => void
 }
 
-/** Connection lifecycle of the log socket. `idle` while collapsed (lazy
- *  connect); `unavailable` when the handshake never succeeds — the backend
- *  runs without --enable-log-viewer, so /ws/logs is not registered. */
-type LogConnState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'unavailable'
-
-export function LogViewer({ engines = [], selectedEndpoint = null, onExpandChange }: LogViewerProps) {
-  const [logs, setLogs] = useState<string[]>([])
-  const [connState, setConnState] = useState<LogConnState>('idle')
-  const connected = connState === 'connected'
+export function LogViewer({
+  engines = [],
+  selectedEndpoint = null,
+  onExpandChange,
+}: LogViewerProps) {
   const [collapsed, setCollapsed] = useState(true)
-  const [autoScroll, setAutoScroll] = useState(true)
-  const [paused, setPaused] = useState(false)
-  const [filter, setFilter] = useState('')
-  const [excludeMode, setExcludeMode] = useState(false)
-  const filterRef = useRef<HTMLInputElement>(null)
-  const wsRef = useRef<WebSocket | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
 
   // Engine whose container is streamed: the selected tab's engine when one is
-  // active and still present, otherwise the first Docker engine (the backend
-  // applies the same default when no ?engine= is passed).
+  // active and still present, otherwise the first Docker engine. The empty
+  // string asks the backend for its own default, which applies the same rule.
   const targetEndpoint = useMemo(() => {
     if (selectedEndpoint && findEngineByEndpoint(engines, selectedEndpoint)) {
       return selectedEndpoint
     }
-    return engines.find((e) => e.deployment_mode === 'Docker')?.endpoint ?? null
+    return engines.find((e) => e.deployment_mode === 'Docker')?.endpoint ?? ''
   }, [engines, selectedEndpoint])
 
   const targetEngine = findEngineByEndpoint(engines, targetEndpoint)
-  const engineLabel = targetEngine
-    ? (targetEngine.model?.name ?? targetEngine.endpoint)
-    : null
-
-  // Identity of the connection the buffer belongs to: null while collapsed (no
-  // socket at all), otherwise the container being streamed.
-  const connectionKey = collapsed ? null : (targetEndpoint ?? '')
-  const [prevConnectionKey, setPrevConnectionKey] = useState<string | null>(null)
-
-  // Connecting fresh or to a different container: drop the previous lines. The
-  // buffer is derived from the connection identity, so it is reset during
-  // render — resetting it synchronously inside the socket effect below would
-  // paint one frame of the previous container's logs under the new label.
-  if (prevConnectionKey !== connectionKey) {
-    setPrevConnectionKey(connectionKey)
-    if (connectionKey !== null) {
-      setLogs([])
-      setConnState('connecting')
-    }
-  }
-
-  useEffect(() => {
-    // Lazy connect: no socket (and no backend Docker stream) until the console
-    // is first expanded. Collapsing tears the socket down again, which also
-    // lets the backend stop the container stream once its last viewer leaves.
-    if (collapsed) return
-
-    let disposed = false
-    let retryTimer: ReturnType<typeof setTimeout> | null = null
-    let everOpened = false
-
-    const connect = () => {
-      if (disposed) return
-      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-      const query = targetEndpoint ? `?engine=${encodeURIComponent(targetEndpoint)}` : ''
-      const ws = new WebSocket(`${protocol}//${window.location.host}/ws/logs${query}`)
-      wsRef.current = ws
-
-      ws.onopen = () => {
-        everOpened = true
-        setConnState('connected')
-      }
-
-      ws.onmessage = (event) => {
-        const text = event.data as string
-        setLogs((prev) => {
-          const next = [...prev, text]
-          return next.length > 1000 ? next.slice(-1000) : next
-        })
-      }
-
-      ws.onclose = () => {
-        wsRef.current = null
-        if (disposed) return
-        if (!everOpened) {
-          // Handshake never succeeded: /ws/logs is not registered (backend
-          // without --enable-log-viewer) or the server is unreachable. Don't
-          // retry a doomed endpoint; the next expand or engine switch retries.
-          setConnState('unavailable')
-          return
-        }
-        // Live connection dropped (backend restart, network): retry with a
-        // delay, like the metrics socket does.
-        setConnState('reconnecting')
-        retryTimer = setTimeout(connect, 2000)
-      }
-
-      ws.onerror = () => {
-        ws.close()
-      }
-    }
-
-    connect()
-
-    return () => {
-      disposed = true
-      if (retryTimer) clearTimeout(retryTimer)
-      wsRef.current?.close()
-      wsRef.current = null
-      setConnState('idle')
-    }
-  }, [collapsed, targetEndpoint])
-
-  // Auto-scroll when new logs arrive (only if not paused)
-  useEffect(() => {
-    if (autoScroll && !paused && containerRef.current) {
-      containerRef.current.scrollTop = containerRef.current.scrollHeight
-    }
-  }, [logs, autoScroll, paused])
-
-  const handleScroll = () => {
-    if (!containerRef.current) return
-    const el = containerRef.current
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50
-    setAutoScroll(atBottom)
-  }
-
-  // Filtered log lines — computed from the full buffer
-  const filteredLogs = useMemo(() => {
-    if (!filter.trim()) return logs
-    const lower = filter.toLowerCase()
-    return excludeMode
-      ? logs.filter((line) => !line.toLowerCase().includes(lower))
-      : logs.filter((line) => line.toLowerCase().includes(lower))
-  }, [logs, filter, excludeMode])
-
-  // Toggle pause/resume
-  const togglePause = () => {
-    const next = !paused
-    setPaused(next)
-    if (!next) {
-      // Unpausing: jump to bottom
-      setAutoScroll(true)
-      if (containerRef.current) {
-        containerRef.current.scrollTop = containerRef.current.scrollHeight
-      }
-    }
-  }
-
-  // Keyboard shortcut: Ctrl+F / Cmd+F to focus the filter input
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
-      e.preventDefault()
-      filterRef.current?.focus()
-    }
-  }
+  const engineLabel = targetEngine ? (targetEngine.model?.name ?? targetEngine.endpoint) : null
 
   if (collapsed) {
     return (
       <div className="shrink-0 mt-2">
         <button
-          onClick={() => { setCollapsed(false); onExpandChange?.(true) }}
-          className="w-full flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-zinc-400 
-                     bg-[#111115] rounded-md border border-white/[0.04] hover:border-zinc-700 
+          onClick={() => {
+            setCollapsed(false)
+            onExpandChange?.(true)
+          }}
+          className="w-full flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-zinc-400
+                     bg-[#111115] rounded-md border border-white/[0.04] hover:border-zinc-700
                      transition-colors duration-200"
         >
           ▶ Console Logs
           {engineLabel && (
-            <span className="text-[10px] text-zinc-600 truncate max-w-[240px]">
-              {engineLabel}
-            </span>
+            <span className="text-[10px] text-zinc-600 truncate max-w-[240px]">{engineLabel}</span>
           )}
           <span className="text-zinc-600 ml-auto">click to stream</span>
         </button>
@@ -206,148 +73,49 @@ export function LogViewer({ engines = [], selectedEndpoint = null, onExpandChang
   }
 
   return (
-    <div className="shrink-0 mt-2" onKeyDown={handleKeyDown}>
-      {/* Header bar */}
-      <div className="flex items-center gap-2 px-3 py-1.5 bg-[#111115] rounded-t-md border border-white/[0.04] border-b-0 flex-wrap">
+    // Fixed height: the drawer's console is a strip at the foot of a page it
+    // does not own, unlike a log panel, which fills the box the operator sized.
+    <div className="shrink-0 mt-2 h-60">
+      <ExpandedConsole
+        endpoint={targetEndpoint}
+        label={engineLabel}
+        onCollapse={() => {
+          setCollapsed(true)
+          onExpandChange?.(false)
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * The expanded drawer. Split out so the stream is subscribed by mounting: a
+ * collapsed drawer holds no connection at all (lazy connect), and expanding is
+ * what opens one.
+ */
+function ExpandedConsole({
+  endpoint,
+  label,
+  onCollapse,
+}: {
+  endpoint: string
+  label: string | null
+  onCollapse: () => void
+}) {
+  const stream = useLogStream(endpoint)
+
+  return (
+    <LogConsole
+      stream={stream}
+      label={label}
+      leading={
         <button
-          onClick={() => { setCollapsed(true); onExpandChange?.(false) }}
+          onClick={onCollapse}
           className="text-xs font-medium text-zinc-400 hover:text-zinc-200 transition-colors shrink-0"
         >
           ▼ Console Logs
         </button>
-
-        {/* Connection indicator */}
-        <span
-          className={`inline-block w-1.5 h-1.5 rounded-full ${
-            connected
-              ? 'bg-[#76B900]'
-              : connState === 'reconnecting'
-                ? 'bg-yellow-400'
-                : 'bg-zinc-500'
-          }`}
-          title={connState}
-        />
-
-        {/* Which engine's container is being streamed */}
-        {engineLabel && (
-          <span className="text-[10px] text-zinc-600 truncate max-w-[240px] shrink-0">
-            {engineLabel}
-          </span>
-        )}
-
-        {/* Pause/Resume button */}
-        <button
-          onClick={togglePause}
-          className={`text-[11px] px-2 py-0.5 rounded font-medium transition-colors shrink-0 ${
-            paused
-              ? 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30'
-              : 'text-zinc-400 hover:text-zinc-200'
-          }`}
-          title={paused ? 'Resume — jump to latest' : 'Pause — freeze viewport'}
-        >
-          {paused ? '⏸ Paused' : '⏵ Live'}
-        </button>
-
-        {/* Line count */}
-        <span className="text-[10px] text-zinc-600 shrink-0">
-          {filteredLogs.length}/{logs.length}
-        </span>
-
-        {/* Scroll-to-bottom button (only when not auto-scrolling) */}
-        {!autoScroll && !paused && (
-          <button
-            onClick={() => {
-              setAutoScroll(true)
-              if (containerRef.current) {
-                containerRef.current.scrollTop = containerRef.current.scrollHeight
-              }
-            }}
-            className="text-[10px] text-yellow-400 hover:text-yellow-300 shrink-0"
-          >
-            ↓ Auto-scroll
-          </button>
-        )}
-      </div>
-
-      {/* Filter bar */}
-      <div className="flex items-center gap-2 px-3 py-1 bg-[#0d0d11] border-x border-white/[0.04]">
-        <button
-          onClick={() => setExcludeMode(!excludeMode)}
-          className={`text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0 border transition-colors ${
-            excludeMode
-              ? 'bg-red-500/15 text-red-400 border-red-500/30'
-              : 'bg-blue-500/15 text-blue-400 border-blue-500/30'
-          }`}
-          title={excludeMode ? 'Exclude mode — hides matching lines' : 'Filter mode — shows only matching lines'}
-        >
-          {excludeMode ? 'Exclude' : 'Filter'}
-        </button>
-        <svg className="w-3 h-3 text-zinc-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-        </svg>
-        <input
-          ref={filterRef}
-          type="text"
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          placeholder={excludeMode ? 'Exclude lines containing...' : 'Filter lines containing...'}
-          className="flex-1 bg-transparent text-[11px] text-zinc-300 placeholder-zinc-600 outline-none border-none"
-        />
-        {filter && (
-          <button
-            onClick={() => setFilter('')}
-            className="text-[10px] text-zinc-500 hover:text-zinc-300 shrink-0"
-          >
-            ✕
-          </button>
-        )}
-      </div>
-
-      {/* Log content. Auto-follow must jump instantly: with smooth scrolling
-        * every appended line animates toward the bottom, and the scroll events
-        * fired mid-animation read as "not at bottom", flickering autoScroll
-        * (and the resume button) off and on with each batch. */}
-      <div
-        ref={containerRef}
-        onScroll={handleScroll}
-        className={`h-48 overflow-y-auto bg-black/60 rounded-b-md border border-white/[0.04]
-                   font-mono text-[11px] leading-[1.4] p-2 space-y-0.5 ${paused ? 'opacity-60' : ''}`}
-      >
-        {logs.length === 0 && (
-          <div className="text-zinc-600 italic text-center pt-8">
-            {connState === 'connected' && 'Waiting for log output...'}
-            {(connState === 'connecting' || connState === 'idle') && 'Connecting...'}
-            {connState === 'reconnecting' && 'Connection lost — reconnecting…'}
-            {connState === 'unavailable' &&
-              'Log viewer not enabled on this server — start the dashboard with --enable-log-viewer (or SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1).'}
-          </div>
-        )}
-
-        {filteredLogs.length === 0 && logs.length > 0 && (
-          <div className="text-zinc-600 italic text-center pt-8">
-            No lines match &quot;{filter}&quot;
-          </div>
-        )}
-
-        {filteredLogs.map((line, i) => {
-          const isError = line.toLowerCase().includes('error') || line.toLowerCase().includes('traceback')
-          const isWarning = line.toLowerCase().includes('warn') || line.toLowerCase().includes('warning')
-          return (
-            <div
-              key={i}
-              className={`whitespace-pre-wrap break-all ${
-                isError
-                  ? 'text-red-400'
-                  : isWarning
-                    ? 'text-yellow-400'
-                    : 'text-zinc-300'
-              }`}
-            >
-              {line}
-            </div>
-          )
-        })}
-      </div>
-    </div>
+      }
+    />
   )
 }

--- a/frontend/src/components/grid/panelRegistry.tsx
+++ b/frontend/src/components/grid/panelRegistry.tsx
@@ -4,11 +4,11 @@
  * The registry is keyed by the persisted panel-type vocabulary in
  * `lib/dashboard/panels`, and is deliberately allowed to lag it: a type the
  * vocabulary knows but no component implements yet renders as a placeholder
- * that keeps its grid slot. That is what lets the panel tickets (#81–#82) land
- * one at a time against a preset that already names every type.
+ * that keeps its grid slot. That is what lets the panel tickets land one at a
+ * time against a preset that already names every type.
  *
- * The eight hardware panels (#80) and the engine metric panels (#81) are
- * implemented; the log panel arrives with #82.
+ * The hardware panels (#80), the engine metric panels (#81) and the log panel
+ * (#82) are implemented; the remaining types still render as placeholders.
  */
 
 import type { ComponentType, ReactElement } from 'react'
@@ -29,6 +29,7 @@ import { GpuClockPanel } from './panels/GpuClockPanel'
 import { GpuPowerPanel } from './panels/GpuPowerPanel'
 import { GpuTemperaturePanel } from './panels/GpuTemperaturePanel'
 import { GpuUtilizationPanel } from './panels/GpuUtilizationPanel'
+import { LogsPanel } from './panels/LogsPanel'
 import { MemoryPanel } from './panels/MemoryPanel'
 import { NetworkIoPanel } from './panels/NetworkIoPanel'
 
@@ -54,6 +55,7 @@ const PANEL_CONTENT: Partial<Record<PanelType, ComponentType<PanelContentProps>>
   'engine-slo-goodput': EngineSloGoodputPanel,
   'engine-cache': EngineCachePanel,
   'engine-spec-decode': EngineSpecDecodePanel,
+  logs: LogsPanel,
 }
 
 /**

--- a/frontend/src/components/grid/panels/LogsPanel.tsx
+++ b/frontend/src/components/grid/panels/LogsPanel.tsx
@@ -1,0 +1,36 @@
+import { LogConsole } from '@/components/LogConsole'
+import { useLogStream } from '@/hooks/useLogStream'
+import { engineLabel } from './engineLabel'
+import { EnginePanelNotice } from './PanelNotice'
+import { useEngineTarget, type ResolvedEngineTarget } from './useEnginePanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * One engine's container logs, placeable and sizable like any other panel.
+ *
+ * The console used to be permanent chrome at the foot of the dashboard. It is a
+ * panel here because the two ends of the audience want opposite things: someone
+ * debugging a model that will not load wants a log panel filling a page of its
+ * own, and someone running a wall display wants none. A permanent exception
+ * would only have bred more of them.
+ *
+ * The connection is shared per engine endpoint (`LogStreamStore`), so several
+ * log panels on one engine cost the backend one docker-logs stream between them.
+ */
+export function LogsPanel({ panel }: PanelContentProps) {
+  // Deliberately the raw binding target rather than `useEnginePanel`: an engine
+  // that is starting or not serving has no metrics, and that is precisely when
+  // an operator opens its logs. Gating the panel on availability would hide the
+  // output that explains why the engine is in that state.
+  const target = useEngineTarget(panel)
+  if (target.status !== 'resolved') return <EnginePanelNotice resolution={target} />
+
+  // The stream is subscribed one component down, so switching engines remounts
+  // nothing and a panel bound to no engine holds no connection at all.
+  return <EngineLogs target={target} />
+}
+
+function EngineLogs({ target }: { target: ResolvedEngineTarget }) {
+  const stream = useLogStream(target.engine.endpoint)
+  return <LogConsole stream={stream} label={engineLabel(target)} />
+}

--- a/frontend/src/components/grid/panels/engineLabel.ts
+++ b/frontend/src/components/grid/panels/engineLabel.ts
@@ -1,5 +1,5 @@
 import { engineDescription } from '@/lib/format'
-import type { EnginePanelResolution } from './useEnginePanel'
+import type { ResolvedEngineTarget } from './useEnginePanel'
 
 /**
  * The engine a panel resolved to, named — or null on a host running a single
@@ -10,8 +10,6 @@ import type { EnginePanelResolution } from './useEnginePanel'
  * position on the page, and a panel that has followed the page selection
  * somewhere else would look identical to one that has not.
  */
-export function engineLabel(
-  resolution: Extract<EnginePanelResolution, { status: 'resolved' }>,
-): string | null {
+export function engineLabel(resolution: ResolvedEngineTarget): string | null {
   return resolution.multiEngine ? engineDescription(resolution.engine) : null
 }

--- a/frontend/src/components/grid/panels/useEnginePanel.ts
+++ b/frontend/src/components/grid/panels/useEnginePanel.ts
@@ -9,8 +9,9 @@ import { engineSeries, type DataPoint, type EngineSeriesName } from '@/lib/metri
 import type { DashboardPanel } from '@/lib/dashboard/schema'
 import type { EngineSnapshot } from '@/types/metrics'
 
-/** What an engine panel found at the other end of its binding. */
-export type EnginePanelResolution =
+/** Which engine a panel's binding names on this host, before anything is asked
+ *  about whether that engine is serving. */
+export type EngineTargetResolution =
   /** No snapshot has arrived yet; there are no engines to resolve against. */
   | { status: 'waiting' }
   | {
@@ -19,21 +20,58 @@ export type EnginePanelResolution =
       /** True when the host runs more than one engine, and a panel therefore has
        *  to name the one it is showing. */
       multiEngine: boolean
-      /** This engine's metrics, with the no-model rule applied. */
-      metric: EngineMetricReader
-      /** One of this engine's series over the panel's own time window. */
-      series: (name: EngineSeriesName) => DataPoint[]
     }
-  /** The engine resolved, and has no metrics yet — starting, or loading a model. */
-  | { status: 'starting'; engine: EngineSnapshot }
-  /** The engine resolved and is not serving; `detail` says why. */
-  | { status: 'offline'; engine: EngineSnapshot; detail: string }
   | { status: 'missing'; requested: string }
   | { status: 'unselected' }
   | { status: 'unreadable' }
 
+/** An engine a panel resolved its binding to. */
+export type ResolvedEngineTarget = Extract<EngineTargetResolution, { status: 'resolved' }>
+
+/** What an engine panel found at the other end of its binding. */
+export type EnginePanelResolution =
+  | (ResolvedEngineTarget & {
+      /** This engine's metrics, with the no-model rule applied. */
+      metric: EngineMetricReader
+      /** One of this engine's series over the panel's own time window. */
+      series: (name: EngineSeriesName) => DataPoint[]
+    })
+  /** The engine resolved, and has no metrics yet — starting, or loading a model. */
+  | { status: 'starting'; engine: EngineSnapshot }
+  /** The engine resolved and is not serving; `detail` says why. */
+  | { status: 'offline'; engine: EngineSnapshot; detail: string }
+  | Exclude<EngineTargetResolution, { status: 'resolved' }>
+
 /** Everything but a resolved engine — what a panel hands to `EnginePanelNotice`. */
 export type EnginePanelNoticeState = Exclude<EnginePanelResolution, { status: 'resolved' }>
+
+/**
+ * Which engine a panel's binding names, and nothing more.
+ *
+ * This is the whole of what a panel needs when the engine's *own* state is the
+ * thing it is there to show: the log panel streams a container that is starting,
+ * crash-looping or serving nothing, which is exactly when its logs matter most,
+ * so it must not be told "this engine has no metrics yet" instead. Panels that
+ * chart metrics use `useEnginePanel`, which adds that gate.
+ */
+export function useEngineTarget(panel: DashboardPanel): EngineTargetResolution {
+  const snapshot = useLatestSnapshot()
+  const { chosen } = usePageSelection()
+
+  return useMemo(() => {
+    if (!snapshot) return { status: 'waiting' }
+
+    const engines = snapshot.engines
+    const resolution = resolveEngineBinding(
+      panel.binding,
+      engines,
+      pageSelection(snapshot, chosen).engineEndpoint,
+    )
+    if (resolution.status !== 'resolved') return resolution
+
+    return { status: 'resolved', engine: resolution.target, multiEngine: engines.length > 1 }
+  }, [snapshot, chosen, panel.binding])
+}
 
 /**
  * What an engine panel renders on this host: its binding resolved against the
@@ -53,22 +91,13 @@ export type EnginePanelNoticeState = Exclude<EnginePanelResolution, { status: 'r
  */
 export function useEnginePanel(panel: DashboardPanel): EnginePanelResolution {
   const store = useMetricsStore()
-  const snapshot = useLatestSnapshot()
-  const { chosen } = usePageSelection()
+  const target = useEngineTarget(panel)
   const window = panel.window
 
   return useMemo(() => {
-    if (!snapshot) return { status: 'waiting' }
+    if (target.status !== 'resolved') return target
 
-    const engines = snapshot.engines
-    const resolution = resolveEngineBinding(
-      panel.binding,
-      engines,
-      pageSelection(snapshot, chosen).engineEndpoint,
-    )
-    if (resolution.status !== 'resolved') return resolution
-
-    const engine = resolution.target
+    const { engine } = target
     const availability = engineAvailability(engine)
     if (availability.kind === 'starting') return { status: 'starting', engine }
     if (availability.kind === 'offline') {
@@ -77,11 +106,9 @@ export function useEnginePanel(panel: DashboardPanel): EnginePanelResolution {
 
     const key = engineKey(engine)
     return {
-      status: 'resolved',
-      engine,
-      multiEngine: engines.length > 1,
+      ...target,
       metric: engineMetricReader(engine),
       series: (name) => store.getChartData(engineSeries(name, key), window),
     }
-  }, [store, snapshot, chosen, panel.binding, window])
+  }, [store, target, window])
 }

--- a/frontend/src/hooks/LogStreamProvider.tsx
+++ b/frontend/src/hooks/LogStreamProvider.tsx
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+import { LogStreamStore } from '@/lib/logStreamStore'
+import { LogStreamContext } from './useLogStream'
+
+/** Owns one `LogStreamStore` for the tree below it, so every log panel and the
+ *  pre-grid console share a connection per engine. The lazy initializer runs
+ *  once; the store is never replaced, so nothing re-renders for it. */
+export function LogStreamProvider({ children }: { children: React.ReactNode }) {
+  const [store] = useState(() => new LogStreamStore())
+  return <LogStreamContext.Provider value={store}>{children}</LogStreamContext.Provider>
+}

--- a/frontend/src/hooks/useLogStream.ts
+++ b/frontend/src/hooks/useLogStream.ts
@@ -1,0 +1,38 @@
+import { createContext, useCallback, useContext, useSyncExternalStore } from 'react'
+import { LogStreamStore, type LogStream } from '@/lib/logStreamStore'
+
+/**
+ * The log stream store, provided through context rather than a module singleton
+ * for the same reason the metrics store is: every test (and any future second
+ * root) gets its own, so no socket outlives the tree that opened it.
+ *
+ * Exported only for `LogStreamProvider`, which lives in its own file because a
+ * component and hooks cannot share one without breaking fast refresh.
+ */
+export const LogStreamContext = createContext<LogStreamStore | null>(null)
+
+export function useLogStreamStore(): LogStreamStore {
+  const store = useContext(LogStreamContext)
+  if (!store) {
+    throw new Error('useLogStream requires a <LogStreamProvider> above it')
+  }
+  return store
+}
+
+/**
+ * One engine's live logs, for as long as this component is mounted.
+ *
+ * Mounting is the subscription: the first component to want an endpoint opens
+ * its socket and the last one to unmount closes it. A component that should not
+ * be streaming — a collapsed console, a panel bound to nothing — must therefore
+ * not call this hook, rather than call it and ignore the result.
+ */
+export function useLogStream(endpoint: string): LogStream {
+  const store = useLogStreamStore()
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribe(endpoint, listener),
+    [store, endpoint],
+  )
+  const read = useCallback(() => store.read(endpoint), [store, endpoint])
+  return useSyncExternalStore(subscribe, read)
+}

--- a/frontend/src/lib/dashboard/preset.test.ts
+++ b/frontend/src/lib/dashboard/preset.test.ts
@@ -42,6 +42,17 @@ describe('the default preset', () => {
     }
   })
 
+  it('places no log panel', () => {
+    // A stock install would otherwise open on a prominent panel explaining that
+    // the log viewer is not enabled — the deployment default — which reads as a
+    // broken dashboard. Logs are opt-in, placed by the operator who wants them.
+    for (const page of defaultDashboardDocument().pages) {
+      for (const panel of page.panels) {
+        expect(panel.type, panel.id).not.toBe('logs')
+      }
+    }
+  })
+
   it('gives every panel on a page a distinct identifier', () => {
     for (const page of defaultDashboardDocument().pages) {
       const ids = page.panels.map((panel) => panel.id)

--- a/frontend/src/lib/logStreamStore.ts
+++ b/frontend/src/lib/logStreamStore.ts
@@ -1,0 +1,162 @@
+/**
+ * The live container logs of every engine something on screen is watching.
+ *
+ * The dashboard's log console used to be one fixed drawer, so one socket was
+ * all it could ever need. Logs are a panel now (#82): a page can hold several,
+ * a debugging page can hold several of the same engine at different filters, and
+ * a wall display can hold none. Left to themselves, N panels would open N
+ * sockets to the same container and multiply the backend's docker-logs streams
+ * for nothing.
+ *
+ * So the connection belongs to the **endpoint**, not to the panel. Panels
+ * subscribe; the first subscriber of an endpoint opens the socket, the last one
+ * to leave closes it. Two panels on one engine share a socket and a buffer —
+ * closing one leaves the other streaming — and two panels on two engines are two
+ * independent streams.
+ *
+ * This is an external store for React's `useSyncExternalStore` (the same shape
+ * as `MetricsHistoryStore`): `read` returns a value that only changes when the
+ * stream does, so a panel re-renders for its own engine's lines and for nothing
+ * else.
+ */
+
+/** How many lines a stream keeps. Beyond this the oldest are dropped. */
+const LINE_LIMIT = 1000
+
+/** How long to wait before retrying a live connection that dropped. */
+const RECONNECT_DELAY_MS = 2000
+
+/**
+ * Where a stream is in its connection lifecycle.
+ *
+ * `unavailable` is the deployment-configuration case rather than a failure: the
+ * handshake never succeeded because the backend runs without
+ * `--enable-log-viewer`, so `/ws/logs` is not a registered route. It is kept
+ * apart from `reconnecting` because retrying a route that does not exist is a
+ * loop that can never end.
+ */
+export type LogStreamStatus = 'connecting' | 'connected' | 'reconnecting' | 'unavailable'
+
+/** One engine's log stream as a viewer sees it. */
+export interface LogStream {
+  readonly status: LogStreamStatus
+  readonly lines: readonly string[]
+}
+
+/** What every endpoint reads as before anything subscribes to it. A shared
+ *  constant, so an unwatched endpoint never looks like it changed. */
+const NO_STREAM: LogStream = { status: 'connecting', lines: [] }
+
+/** One endpoint's socket, buffer and subscribers. */
+interface Connection {
+  socket: WebSocket | null
+  retry: ReturnType<typeof setTimeout> | null
+  /** Whether the socket ever opened — what tells a dropped connection apart
+   *  from a route the backend never registered. */
+  everOpened: boolean
+  stream: LogStream
+  listeners: Set<() => void>
+}
+
+export class LogStreamStore {
+  private connections = new Map<string, Connection>()
+
+  /**
+   * Watch one engine's logs, holding the connection open for as long as the
+   * returned release function has not been called.
+   *
+   * The endpoint is the engine's, exactly as the metrics snapshot reports it;
+   * the empty string asks the backend for its own default container, which is
+   * what the pre-grid console does on a host it has not been pointed at.
+   */
+  subscribe(endpoint: string, listener: () => void): () => void {
+    let connection = this.connections.get(endpoint)
+    if (!connection) {
+      connection = {
+        socket: null,
+        retry: null,
+        everOpened: false,
+        stream: NO_STREAM,
+        listeners: new Set(),
+      }
+      this.connections.set(endpoint, connection)
+      this.connect(endpoint, connection)
+    }
+    connection.listeners.add(listener)
+
+    return () => {
+      connection.listeners.delete(listener)
+      // The last viewer left: close the socket so the backend can stop the
+      // container stream too, and drop the buffer with it. Lines held for a
+      // panel nobody is looking at would be stale by the time one is.
+      if (connection.listeners.size === 0) {
+        this.close(endpoint, connection)
+      }
+    }
+  }
+
+  /**
+   * The endpoint's stream. Stable between changes, so it can be the
+   * `getSnapshot` of a `useSyncExternalStore` subscription.
+   */
+  read(endpoint: string): LogStream {
+    return this.connections.get(endpoint)?.stream ?? NO_STREAM
+  }
+
+  private connect(endpoint: string, connection: Connection): void {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const query = endpoint ? `?engine=${encodeURIComponent(endpoint)}` : ''
+    const socket = new WebSocket(`${protocol}//${window.location.host}/ws/logs${query}`)
+    connection.socket = socket
+
+    socket.onopen = () => {
+      connection.everOpened = true
+      this.update(connection, { status: 'connected' })
+    }
+
+    socket.onmessage = (event) => {
+      const line = event.data as string
+      const lines = [...connection.stream.lines, line]
+      this.update(connection, {
+        lines: lines.length > LINE_LIMIT ? lines.slice(-LINE_LIMIT) : lines,
+      })
+    }
+
+    socket.onclose = () => {
+      connection.socket = null
+      // Released while the socket was closing; there is nobody to reconnect for.
+      if (!this.connections.has(endpoint)) return
+
+      if (!connection.everOpened) {
+        this.update(connection, { status: 'unavailable' })
+        return
+      }
+      // A live connection dropped — a backend restart, a network blip. Retry on
+      // a delay, the way the metrics socket does, and keep the lines: they are
+      // the same container's, and they are what the operator was reading.
+      this.update(connection, { status: 'reconnecting' })
+      connection.retry = setTimeout(() => {
+        connection.retry = null
+        this.connect(endpoint, connection)
+      }, RECONNECT_DELAY_MS)
+    }
+
+    socket.onerror = () => {
+      socket.close()
+    }
+  }
+
+  private close(endpoint: string, connection: Connection): void {
+    this.connections.delete(endpoint)
+    if (connection.retry) clearTimeout(connection.retry)
+    connection.retry = null
+    connection.socket?.close()
+    connection.socket = null
+  }
+
+  /** Replace the stream value and tell this endpoint's subscribers. */
+  private update(connection: Connection, change: Partial<LogStream>): void {
+    connection.stream = { ...connection.stream, ...change }
+    for (const listener of connection.listeners) listener()
+  }
+}

--- a/frontend/src/lib/logStreamStore.ts
+++ b/frontend/src/lib/logStreamStore.ts
@@ -47,6 +47,14 @@ export interface LogStream {
  *  constant, so an unwatched endpoint never looks like it changed. */
 const NO_STREAM: LogStream = { status: 'connecting', lines: [] }
 
+/**
+ * The endpoint that asks the backend for whichever container it would pick
+ * itself — the first Docker engine. Sending no `?engine=` at all is how the
+ * `/ws/logs` route spells that, so the empty endpoint is a real address here
+ * rather than a missing one.
+ */
+export const BACKEND_DEFAULT_ENGINE = ''
+
 /** One endpoint's socket, buffer and subscribers. */
 interface Connection {
   socket: WebSocket | null
@@ -65,9 +73,9 @@ export class LogStreamStore {
    * Watch one engine's logs, holding the connection open for as long as the
    * returned release function has not been called.
    *
-   * The endpoint is the engine's, exactly as the metrics snapshot reports it;
-   * the empty string asks the backend for its own default container, which is
-   * what the pre-grid console does on a host it has not been pointed at.
+   * The endpoint is the engine's, exactly as the metrics snapshot reports it,
+   * or `BACKEND_DEFAULT_ENGINE` to let the backend pick — which is what the
+   * pre-grid console does on a host it has not been pointed at.
    */
   subscribe(endpoint: string, listener: () => void): () => void {
     let connection = this.connections.get(endpoint)
@@ -124,8 +132,14 @@ export class LogStreamStore {
 
     socket.onclose = () => {
       connection.socket = null
-      // Released while the socket was closing; there is nobody to reconnect for.
-      if (!this.connections.has(endpoint)) return
+      // This connection is no longer the endpoint's. A real browser fires
+      // `close` on a later task, so between `close()` and this handler the last
+      // subscriber may have left and a new one taken the endpoint over — a
+      // panel removed and re-added, a following panel switching engines and
+      // back. Testing that *some* connection exists for the endpoint would let
+      // this orphan schedule a retry that nothing can ever cancel, leaving a
+      // duplicate stream open for the life of the page.
+      if (this.connections.get(endpoint) !== connection) return
 
       if (!connection.everOpened) {
         this.update(connection, { status: 'unavailable' })

--- a/frontend/src/test/websocket.ts
+++ b/frontend/src/test/websocket.ts
@@ -9,6 +9,19 @@
  */
 export class MockWebSocket {
   static instances: MockWebSocket[] = []
+
+  /**
+   * Whether `close()` delivers its event on a later turn, the way a real
+   * browser does, instead of synchronously inside the call.
+   *
+   * Off by default: firing it synchronously keeps the specs that only care
+   * about a socket having closed readable. Turn it on for the specs that care
+   * about what happens *between* asking a socket to close and its handler
+   * running, and drain the queue with `flushCloseEvents()`.
+   */
+  static deferCloseEvents = false
+  private static pendingCloses: MockWebSocket[] = []
+
   url: string
   onopen: ((ev: Event) => void) | null = null
   onmessage: ((ev: MessageEvent) => void) | null = null
@@ -23,7 +36,18 @@ export class MockWebSocket {
 
   close() {
     this.readyState = 3
+    if (MockWebSocket.deferCloseEvents) {
+      MockWebSocket.pendingCloses.push(this)
+      return
+    }
     if (this.onclose) this.onclose(new CloseEvent('close'))
+  }
+
+  /** Deliver every close event `deferCloseEvents` has held back, oldest first. */
+  static flushCloseEvents() {
+    const pending = MockWebSocket.pendingCloses
+    MockWebSocket.pendingCloses = []
+    for (const socket of pending) socket.onclose?.(new CloseEvent('close'))
   }
 
   send() {}


### PR DESCRIPTION
Closes #82.

The log console becomes a panel like everything else — sizable, placeable, or absent entirely. Someone debugging a model that will not load wants a large log panel on a dedicated page; someone running a wall display wants none. A permanent chrome exception would breed more exceptions.

## What changed

**`LogStreamStore`** — connections keyed by engine endpoint, refcounted by subscribers. The first subscriber of an endpoint opens the socket, the last one to leave closes it, so N log panels on one engine cost the backend one `docker logs` stream instead of N. It is an external store for `useSyncExternalStore`, so `read()` is stable between changes and a panel re-renders for its own engine's lines and nothing else. Provided through context like the metrics store, so no socket outlives the tree that opened it.

**`LogConsole`** — the filter/exclude, pause/live, auto-follow, Ctrl+F and line colouring lifted out of `LogViewer` unchanged. It renders whatever stream it is handed and fills its container, so the same console sits in the drawer and in a grid panel.

**`LogsPanel`** — registered for the `logs` type, so it places, sizes and removes through the same `GridPanel` frame as everything else.

**`LogViewer`** — the pre-grid drawer now consumes the shared store instead of owning a socket, so it and any panel on the same engine share one connection while both surfaces coexist until the #86 cutover.

## Design note: no availability gate

The panel resolves its binding with a new `useEngineTarget` rather than `useEnginePanel`, deliberately. An engine that is starting or serving nothing has no metrics — and that is exactly when an operator opens its logs. Gating the panel on availability would hide the output that explains why the engine is in that state.

## Acceptance criteria

- [x] A log panel can be placed, sized and removed like any other panel
- [x] Two log panels bound to the same engine open exactly one connection; closing one leaves the other streaming
- [x] Two log panels bound to different engines each stream their own engine
- [x] With the log viewer disabled server-side, the panel explains that it is a deployment configuration choice
- [x] Filter, pause/live and reconnect behaviours still work
- [x] `npm run lint && npm run build && npm test -- --run` green

The default preset still places no log panel, so a stock install does not open on a prominent "log viewer not enabled" panel. That is now asserted rather than merely true.

## A bug worth calling out

Two independent reviews caught the same race, fixed in `632b9c1`. The socket close handler asked whether *some* connection existed for the endpoint, not whether it was *this* one. Browsers fire `close` on a later task than the `close()` call, so between the two the last subscriber could leave and a new one take the endpoint over — a panel removed and re-added, a following panel switching engines and back. The orphan then passed the guard, scheduled a retry and opened a second socket for an endpoint nothing reads and `close()` could never reach: a duplicate container stream for the life of the page, invisible to the refcount.

The mock socket fired `close` synchronously, which is why no spec caught it, so it grew an opt-in deferred mode that delivers the event on a later turn the way a browser does. I confirmed the new spec fails against the old guard (a third, orphaned socket) before restoring the fix.

## Testing

509 unit specs green (16 store, 13 panel through the real registry, binding resolution and store), plus lint, build and the 9 browser specs.

Verified on the DGX Spark against a real backend with `--enable-log-viewer` and a Docker-deployed vLLM engine: the `/ws/logs` route streams real container logs end to end. Everything in the suite is against a mock socket, so that path had not otherwise been exercised.

**Metrics contract:** unchanged. No Rust metric types, TS types or formatters touched, so those obligations are N/A here.

## Known gap

"A log panel can be **sized**" has no automated assertion. The console makes no measurement-driven decision, and the browser test project runs without a Tailwind build, so a spec there would prove nothing about flex or scrolling — it is verified by eye instead.