### PR TITLE
feat(frontend): explicit edit mode with drag, resize, save and discard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,8 +9,11 @@ import { MetricsStoreProvider } from './hooks/MetricsStoreProvider'
 import { AppHeader } from './components/AppHeader'
 import { ConfigurationNotices } from './components/ConfigurationNotices'
 import { Dashboard } from './components/views/Dashboard'
-import { GridPage } from './components/grid/GridPage'
+import { GridPageEditor } from './components/grid/GridPageEditor'
 import { LogViewer } from './components/LogViewer'
+import { withPagePanels } from './lib/dashboard/editing'
+import type { SaveOutcome } from './lib/dashboard/client'
+import type { DashboardPanel } from './lib/dashboard/schema'
 import type { GpuEvent, InferenceRequest } from './types/events'
 
 function AppContent() {
@@ -96,11 +99,22 @@ function AppContent() {
 function GridPageContent({ pageId }: { pageId: string }) {
   const { metrics, connectionStatus, isStale } = useMetrics()
   useMetricsIngest(metrics)
-  const { document, notices: configurationNotices } = useDashboardConfiguration()
+  const { document, notices: configurationNotices, readOnly, save } = useDashboardConfiguration()
 
   // Null document means the load has not resolved; rendering nothing beats
   // flashing the preset past an operator whose real page is milliseconds away.
   const page = document?.pages.find((candidate) => candidate.id === pageId)
+
+  // The whole document is written, not the page: it is one instance-scoped
+  // configuration, and a save has to carry the pages the operator was not
+  // editing along with the one they were.
+  const savePanels = useCallback(
+    (panels: DashboardPanel[]) =>
+      document
+        ? save(withPagePanels(document, pageId, panels))
+        : Promise.resolve<SaveOutcome['status']>('failed'),
+    [document, pageId, save],
+  )
 
   return (
     <div className="h-dvh flex flex-col bg-[#08080a] overflow-hidden">
@@ -111,7 +125,7 @@ function GridPageContent({ pageId }: { pageId: string }) {
       <main className="flex-1 min-h-0 p-3 lg:p-4 2xl:p-5 min-[1920px]:p-6">
         {document &&
           (page ? (
-            <GridPage key={page.id} page={page} />
+            <GridPageEditor key={page.id} page={page} readOnly={readOnly} onSave={savePanels} />
           ) : (
             <div className="h-full flex items-center justify-center">
               <div className="text-center">

--- a/frontend/src/__tests__/App.editMode.test.tsx
+++ b/frontend/src/__tests__/App.editMode.test.tsx
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+import {
+  configurationResponse,
+  configurationWrites,
+  serveConfiguration,
+  type FetchMock,
+} from '../test/configurationServer'
+import { gridSubstitute } from '../test/gridSubstitute'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+import type { MetricsSnapshot } from '../types/metrics'
+
+// Edit mode (#83) through the application seam: real routing, real
+// configuration loading and saving over the fetch stub, real panels reading the
+// real store. The grid library is the shared jsdom substitute, which records
+// what the grid was mounted with and lets a spec report the geometry a drag
+// would have produced. Whether a real drag produces it — and what the operator
+// sees when the page has no room — is the browser suite (#87); jsdom has no
+// layout engine to drag in.
+substituteWebSocket()
+
+const GIB = 1_073_741_824
+
+function storedDocument(panels: unknown[]): string {
+  return JSON.stringify({
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [{ id: 'watch', name: 'Watch', panels }],
+  })
+}
+
+/** Two panels side by side, filling the top half of the page. */
+function twoPanels(): unknown[] {
+  return [
+    { id: 'cpu', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+    { id: 'mem', type: 'memory', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+  ]
+}
+
+function snapshot(cpuPercent: number, timestampMs: number): MetricsSnapshot {
+  return {
+    timestamp_ms: timestampMs,
+    gpu: {
+      index: 0,
+      name: 'NVIDIA GB10',
+      utilization_percent: 40,
+      memory_total_bytes: 96 * GIB,
+      memory_used_bytes: 24 * GIB,
+      temperature_celsius: 55,
+      power_watts: 180,
+      power_limit_watts: 300,
+      clock_graphics_mhz: 1900,
+      clock_sm_mhz: 1900,
+      clock_memory_mhz: 8000,
+      fan_speed_percent: 30,
+    },
+    // The per-core value is held fixed so the aggregate is the only number the
+    // CPU panel shows that this spec moves.
+    cpu: { name: 'Grace CPU', aggregate_percent: cpuPercent, per_core: [{ id: 0, usage_percent: 7 }] },
+    memory: {
+      total_bytes: 128 * GIB,
+      display_total_bytes: 128 * GIB,
+      used_bytes: 64 * GIB,
+      available_bytes: 64 * GIB,
+      cached_bytes: 8 * GIB,
+      gpu_estimated_bytes: 24 * GIB,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: true,
+    },
+    disk: { name: 'nvme0n1', read_bytes_per_sec: 0, write_bytes_per_sec: 0 },
+    network: { name: 'enp1s0', rx_bytes_per_sec: 0, tx_bytes_per_sec: 0 },
+    engines: [],
+    gpu_events: [],
+  }
+}
+
+function receive(metrics: MetricsSnapshot) {
+  act(() => MockWebSocket.instances[0].receive(JSON.stringify(metrics)))
+}
+
+async function configurationSettles(fetchMock: FetchMock) {
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+  await act(() => configurationResponse(fetchMock))
+}
+
+/** Opens the page at its own URL and settles the configuration it loads. */
+async function openPage(fetchMock: FetchMock) {
+  window.history.replaceState(null, '', '/pages/watch')
+  render(<App />)
+  await configurationSettles(fetchMock)
+}
+
+const editLayout = () => screen.getByRole('button', { name: 'Edit layout' })
+const saveLayout = () => screen.getByRole('button', { name: 'Save layout' })
+const discard = () => screen.getByRole('button', { name: 'Discard' })
+
+/** The geometry the grid holds for one panel, as the document would store it. */
+function placement(id: string) {
+  return gridSubstitute.geometry().get(id)
+}
+
+/** The panels of the one page in the single write the spec expects. */
+function savedPanels(fetchMock: FetchMock): Array<Record<string, unknown>> {
+  const writes = configurationWrites(fetchMock)
+  expect(writes).toHaveLength(1)
+  return JSON.parse(writes[0]).pages[0].panels
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  gridSubstitute.reset()
+})
+
+describe('entering and leaving edit mode', () => {
+  it('leaves the page static until the operator asks to edit it', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()) })
+    await openPage(fetchMock)
+
+    // Nothing drags, and no layout change has anywhere to be reported to.
+    expect(gridSubstitute.options().staticGrid).toBe(true)
+    expect(gridSubstitute.acceptsLayoutChanges()).toBe(false)
+    expect(screen.queryByRole('button', { name: 'Save layout' })).not.toBeInTheDocument()
+
+    await userEvent.click(editLayout())
+
+    expect(gridSubstitute.options().staticGrid).toBe(false)
+    expect(gridSubstitute.acceptsLayoutChanges()).toBe(true)
+    // The row cap becomes the engine's business for the session, which is what
+    // makes running out of room a state rather than a scrollbar.
+    expect(gridSubstitute.options().maxRow).toBe(8)
+  })
+
+  it('puts the page back to static when the session ends', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()) })
+    await openPage(fetchMock)
+
+    await userEvent.click(editLayout())
+    await userEvent.click(discard())
+
+    expect(gridSubstitute.options().staticGrid).toBe(true)
+    expect(gridSubstitute.options().maxRow).toBe(0)
+    expect(editLayout()).toBeInTheDocument()
+  })
+})
+
+describe('saving and discarding a rearranged page', () => {
+  it('writes the new layout on an explicit save, and a reload comes back to it', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()) })
+    await openPage(fetchMock)
+
+    await userEvent.click(editLayout())
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 0, y: 4, w: 12, h: 4 }]))
+
+    expect(placement('mem')).toEqual({ x: 0, y: 4, w: 12, h: 4 })
+
+    await userEvent.click(saveLayout())
+
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    const written = savedPanels(fetchMock)
+    expect(written.map((panel) => [panel.id, panel.geometry])).toEqual([
+      ['cpu', { x: 0, y: 0, w: 6, h: 4 }],
+      ['mem', { x: 0, y: 4, w: 12, h: 4 }],
+    ])
+    // The session is over — saved work is not still pending.
+    expect(editLayout()).toBeInTheDocument()
+
+    // A reload against what was stored lands on the arrangement that was saved.
+    screen.getByRole('region', { name: 'Memory' })
+    const reloaded = serveConfiguration({ document: JSON.stringify(JSON.parse(configurationWrites(fetchMock)[0])) })
+    gridSubstitute.reset()
+    await openPage(reloaded)
+
+    expect(placement('mem')).toEqual({ x: 0, y: 4, w: 12, h: 4 })
+  })
+
+  it('discards the session without ever telling the server', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()) })
+    await openPage(fetchMock)
+
+    await userEvent.click(editLayout())
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 0, y: 4, w: 12, h: 4 }]))
+    await userEvent.click(discard())
+
+    expect(configurationWrites(fetchMock)).toEqual([])
+    // The page is back to the stored arrangement, panel for panel.
+    expect(placement('mem')).toEqual({ x: 6, y: 0, w: 6, h: 4 })
+  })
+
+  it('writes nothing while the operator is still dragging', async () => {
+    // Intermediate positions are not shared state: the configuration is one
+    // document for the whole instance, and every save replaces it.
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()) })
+    await openPage(fetchMock)
+
+    await userEvent.click(editLayout())
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 0, y: 4, w: 6, h: 4 }]))
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 3, y: 4, w: 6, h: 4 }]))
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 6, y: 4, w: 6, h: 4 }]))
+
+    expect(configurationWrites(fetchMock)).toEqual([])
+  })
+
+  it('normalizes what the grid reports before it is stored', async () => {
+    // The library omits values equal to its own defaults, so a 1×1 panel comes
+    // back with neither width nor height. What lands on disk describes itself.
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()) })
+    await openPage(fetchMock)
+
+    await userEvent.click(editLayout())
+    act(() =>
+      gridSubstitute.moved([{ id: 'mem', x: 11, y: 7 } as unknown as Parameters<typeof gridSubstitute.moved>[0][0]]),
+    )
+    await userEvent.click(saveLayout())
+
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    expect(savedPanels(fetchMock)[1].geometry).toEqual({ x: 11, y: 7, w: 1, h: 1 })
+  })
+})
+
+describe('a save the server would not take', () => {
+  it('says so and keeps the session open, so the work is still there to retry', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()), putStatus: 500 })
+    await openPage(fetchMock)
+
+    await userEvent.click(editLayout())
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 0, y: 4, w: 12, h: 4 }]))
+    await userEvent.click(saveLayout())
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/saving the dashboard configuration failed/i),
+    )
+    // Still editing, still holding the rearranged layout.
+    expect(saveLayout()).toBeInTheDocument()
+    expect(placement('mem')).toEqual({ x: 0, y: 4, w: 12, h: 4 })
+  })
+})
+
+describe('a read-only instance', () => {
+  it('cannot save what it lets the operator rearrange', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()), readOnly: true })
+    await openPage(fetchMock)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/dashboard is read-only/i)
+
+    await userEvent.click(editLayout())
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 0, y: 4, w: 12, h: 4 }]))
+
+    expect(saveLayout()).toBeDisabled()
+    await userEvent.click(saveLayout())
+
+    expect(configurationWrites(fetchMock)).toEqual([])
+  })
+})
+
+describe('a page being edited holds still', () => {
+  // The socket renders its first snapshot at once and batches the rest onto a
+  // two-second flush, so every snapshot after the first needs the clock moved.
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function cpuReads(): string {
+    return within(screen.getByRole('region', { name: 'CPU' }))
+      .getByTestId('arc-value')
+      .closest('svg')!
+      .querySelector('text')!.textContent!
+  }
+
+  it('keeps rendering the snapshot it had, then catches up when the session ends', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(twoPanels()) })
+
+    // Opened by hand rather than through `openPage`: waiting on a real clock
+    // is the one thing a frozen clock cannot do. The configuration request goes
+    // out with the mount effect, so there is nothing to wait *for* — only its
+    // answer to settle.
+    window.history.replaceState(null, '', '/pages/watch')
+    render(<App />)
+    await act(() => configurationResponse(fetchMock))
+    await act(async () => {})
+
+    receive(snapshot(37, 1000))
+
+    expect(cpuReads()).toBe('37')
+
+    fireEvent.click(editLayout())
+    receive(snapshot(88, 2000))
+    act(() => void vi.advanceTimersByTime(2000))
+
+    // Still 37: a panel that redraws under the cursor is a panel that moves
+    // while it is being aimed at.
+    expect(cpuReads()).toBe('37')
+
+    fireEvent.click(discard())
+
+    expect(cpuReads()).toBe('88')
+  })
+})

--- a/frontend/src/__tests__/App.editMode.test.tsx
+++ b/frontend/src/__tests__/App.editMode.test.tsx
@@ -210,9 +210,7 @@ describe('saving and discarding a rearranged page', () => {
     await openPage(fetchMock)
 
     await userEvent.click(editLayout())
-    act(() =>
-      gridSubstitute.moved([{ id: 'mem', x: 11, y: 7 } as unknown as Parameters<typeof gridSubstitute.moved>[0][0]]),
-    )
+    act(() => gridSubstitute.moved([{ id: 'mem', x: 11, y: 7 }]))
     await userEvent.click(saveLayout())
 
     await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))

--- a/frontend/src/__tests__/browser/editMode.browser.test.tsx
+++ b/frontend/src/__tests__/browser/editMode.browser.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import { act, render, waitFor } from '@testing-library/react'
+import { GridPageEditor } from '@/components/grid/GridPageEditor'
+import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
+import { FOLLOW } from '@/lib/dashboard/bindings'
+import type { PanelGeometry } from '@/lib/dashboard/grid'
+import { DEFAULT_TIME_WINDOW, type DashboardPage } from '@/lib/dashboard/schema'
+import type { PanelType } from '@/lib/dashboard/panels'
+
+// Out of room, in a real layout engine (#83). Everything about this is
+// measurement: the engine refuses a move by simulating it and keeping the old
+// layout, and telling that apart from a drag the operator simply took back
+// needs the pixels the panel was left on. jsdom measures every box as 0×0, so
+// this can only be shown here.
+//
+// Deliberately one case. Drag, resize, save-reload and stacking are the #87
+// suite; this is the criterion that is #83's own, and the fiddliest interaction
+// in the rework.
+//
+// The drag is driven with **mouse** events, not pointer events: the library
+// binds mousedown on the item's content and then move and release on the
+// document. Pointer-based helpers silently do nothing, which looks exactly like
+// a library defect.
+
+function page(panels: Array<[string, PanelType, PanelGeometry]>): DashboardPage {
+  return {
+    id: 'p',
+    name: 'P',
+    panels: panels.map(([id, type, geometry]) => ({
+      id,
+      type,
+      geometry,
+      binding: FOLLOW,
+      window: DEFAULT_TIME_WINDOW,
+    })),
+  }
+}
+
+function Harness({ content, width = 800 }: { content: DashboardPage; width?: number }) {
+  return (
+    <MetricsStoreProvider>
+      <div style={{ width, height: 480 }}>
+        <GridPageEditor page={content} readOnly={false} onSave={async () => 'saved' as const} />
+      </div>
+    </MetricsStoreProvider>
+  )
+}
+
+/** Drags an element by a pixel offset, the way the library listens for it. */
+function dragBy(element: Element, dx: number, dy: number) {
+  const box = element.getBoundingClientRect()
+  const from = { clientX: box.left + box.width / 2, clientY: box.top + box.height / 2 }
+  const at = (fraction: number) => ({
+    clientX: from.clientX + dx * fraction,
+    clientY: from.clientY + dy * fraction,
+    bubbles: true,
+    button: 0,
+  })
+
+  element.dispatchEvent(new MouseEvent('mousedown', { ...from, bubbles: true, button: 0 }))
+  // Several moves: the library needs to pass its own start threshold before it
+  // is dragging at all, and the last one is what the drop is judged against.
+  for (const fraction of [0.1, 0.4, 0.7, 1]) {
+    document.dispatchEvent(new MouseEvent('mousemove', at(fraction)))
+  }
+  document.dispatchEvent(new MouseEvent('mouseup', at(1)))
+}
+
+describe('a move the page has no room for', () => {
+  it('is refused, and says so instead of snapping back in silence', async () => {
+    // A page filled to its cap, and filled unevenly, so there is nothing the
+    // engine could swap or push to make the move work.
+    const content = page([
+      ['top', 'cpu-utilization', { x: 0, y: 0, w: 12, h: 4 }],
+      ['bottom', 'memory', { x: 0, y: 4, w: 6, h: 4 }],
+      ['beside', 'gpu-utilization', { x: 6, y: 4, w: 6, h: 4 }],
+    ])
+    const { container, getByRole, queryByRole } = render(<Harness content={content} />)
+
+    await waitFor(() => expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(3))
+    act(() => getByRole('button', { name: 'Edit layout' }).click())
+    await waitFor(() => expect(getByRole('button', { name: 'Save layout' })).toBeTruthy())
+
+    // Nothing has been refused yet, so nothing is being said about room.
+    expect(queryByRole('alert')).toBeNull()
+
+    // Wait for the measured row height before dragging in row-sized units: the
+    // grid is 8 rows of a divided container, so until it has been measured a
+    // pixel offset means a different number of rows than the drag intends.
+    const item = container.querySelector('[gs-id="bottom"]')!
+    await waitFor(() => {
+      const grid = container.querySelector('.grid-stack')!.getBoundingClientRect()
+      expect(item.getBoundingClientRect().bottom - grid.top).toBeLessThanOrEqual(grid.height + 1)
+    })
+
+    // Half its own height is two of the four rows it covers: enough to run the
+    // page past its cap, whatever the measured row height turned out to be.
+    const bottom = item.querySelector('.grid-stack-item-content')!
+    act(() => dragBy(bottom, 0, item.getBoundingClientRect().height / 2))
+
+    await waitFor(() => {
+      expect(getByRole('alert').textContent).toMatch(/No room for “Memory” there/)
+      expect(getByRole('alert').textContent).toMatch(/8 rows tall and full/)
+    })
+
+    // And the panel is still where it was: a refused move changes nothing.
+    expect(container.querySelector('[gs-id="bottom"]')?.getAttribute('gs-y')).toBe('4')
+  })
+
+  it('says nothing when the page reflowed around the drop, which is most drags', async () => {
+    // The engine swaps and pushes neighbours out of the way, so a panel rarely
+    // ends on the exact cells it was dropped on. That is a successful drag, and
+    // an operator who is told the page is full after every one of them stops
+    // reading the message that matters.
+    const content = page([
+      ['top', 'cpu-utilization', { x: 0, y: 0, w: 12, h: 4 }],
+      ['bottom', 'memory', { x: 0, y: 4, w: 12, h: 4 }],
+    ])
+    const { container, getByRole, queryByRole } = render(<Harness content={content} />)
+
+    await waitFor(() => expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(2))
+    act(() => getByRole('button', { name: 'Edit layout' }).click())
+
+    const item = container.querySelector('[gs-id="bottom"]')!
+    await waitFor(() => {
+      const grid = container.querySelector('.grid-stack')!.getBoundingClientRect()
+      expect(item.getBoundingClientRect().bottom - grid.top).toBeLessThanOrEqual(grid.height + 1)
+    })
+
+    // Upward, onto the panel above: room the page does have, once the engine
+    // has moved the other one.
+    act(() => dragBy(item.querySelector('.grid-stack-item-content')!, 0, -item.getBoundingClientRect().height / 2))
+
+    await waitFor(() => {
+      expect(container.querySelector('[gs-id="bottom"]')?.getAttribute('gs-y')).not.toBe('4')
+    })
+    expect(queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('a page narrow enough to have stacked', () => {
+  it('is not offered for rearranging, because the stack is not what anyone authored', async () => {
+    // Below the breakpoint the engine derives a single column from the desktop
+    // layout. Dragging there would author cells in a grid one column wide, and
+    // saving them would overwrite the arrangement being displayed.
+    const content = page([
+      ['top', 'cpu-utilization', { x: 0, y: 0, w: 6, h: 4 }],
+      ['bottom', 'memory', { x: 6, y: 0, w: 6, h: 4 }],
+    ])
+    const { getByText, queryByRole } = render(<Harness content={content} width={360} />)
+
+    await waitFor(() => {
+      expect(getByText(/Rearranging needs a wider window/)).toBeTruthy()
+    })
+    expect(queryByRole('button', { name: 'Edit layout' })).toBeNull()
+  })
+})

--- a/frontend/src/__tests__/browser/editMode.browser.test.tsx
+++ b/frontend/src/__tests__/browser/editMode.browser.test.tsx
@@ -49,7 +49,29 @@ function Harness({ content, width = 800 }: { content: DashboardPage; width?: num
 /** Drags an element by a pixel offset, the way the library listens for it. */
 function dragBy(element: Element, dx: number, dy: number) {
   const box = element.getBoundingClientRect()
-  const from = { clientX: box.left + box.width / 2, clientY: box.top + box.height / 2 }
+  dragFrom(element, { clientX: box.left + box.width / 2, clientY: box.top + box.height / 2 }, dx, dy)
+}
+
+/**
+ * Pulls a panel's bottom-right corner by a pixel offset.
+ *
+ * The grab starts at the panel's own corner rather than at the handle's box: the
+ * library autohides the handle, so it measures 0×0 until hovered, and a resize
+ * that begins at the origin is one the library reads as dragging the corner in
+ * from the far left — it shrinks the panel sideways instead.
+ */
+function resizeBy(item: HTMLElement, dx: number, dy: number) {
+  const box = item.getBoundingClientRect()
+  const handle = item.querySelector('.ui-resizable-se')!
+  dragFrom(handle, { clientX: box.right, clientY: box.bottom }, dx, dy)
+}
+
+function dragFrom(
+  element: Element,
+  from: { clientX: number; clientY: number },
+  dx: number,
+  dy: number,
+) {
   const at = (fraction: number) => ({
     clientX: from.clientX + dx * fraction,
     clientY: from.clientY + dy * fraction,
@@ -64,6 +86,29 @@ function dragBy(element: Element, dx: number, dy: number) {
     document.dispatchEvent(new MouseEvent('mousemove', at(fraction)))
   }
   document.dispatchEvent(new MouseEvent('mouseup', at(1)))
+}
+
+/**
+ * The named item, once the grid has actually been measured.
+ *
+ * Every drag here is expressed in the item's own height, so a drag started
+ * before the ResizeObserver has fired covers a different number of rows than it
+ * means to — which looks exactly like the feature not working. A four-row panel
+ * in an eight-row grid is half the grid tall; the pre-measurement fallback row
+ * height is not.
+ */
+async function measuredItem(container: HTMLElement, id: string): Promise<HTMLElement> {
+  const item = container.querySelector(`[gs-id="${id}"]`) as HTMLElement
+
+  await waitFor(() => {
+    const grid = container.querySelector('.grid-stack')!.getBoundingClientRect()
+    // Half the grid, less a margin's worth. The item's own size lags the row
+    // height by a frame, so "taller than the fallback" is not enough of a
+    // condition — it passes while the panel is still catching up.
+    expect(item.getBoundingClientRect().height).toBeGreaterThan(grid.height * 0.45)
+  })
+
+  return item
 }
 
 describe('a move the page has no room for', () => {
@@ -84,23 +129,14 @@ describe('a move the page has no room for', () => {
     // Nothing has been refused yet, so nothing is being said about room.
     expect(queryByRole('alert')).toBeNull()
 
-    // Wait for the measured row height before dragging in row-sized units: the
-    // grid is 8 rows of a divided container, so until it has been measured a
-    // pixel offset means a different number of rows than the drag intends.
-    const item = container.querySelector('[gs-id="bottom"]')!
-    await waitFor(() => {
-      const grid = container.querySelector('.grid-stack')!.getBoundingClientRect()
-      expect(item.getBoundingClientRect().bottom - grid.top).toBeLessThanOrEqual(grid.height + 1)
-    })
-
     // Half its own height is two of the four rows it covers: enough to run the
     // page past its cap, whatever the measured row height turned out to be.
-    const bottom = item.querySelector('.grid-stack-item-content')!
-    act(() => dragBy(bottom, 0, item.getBoundingClientRect().height / 2))
+    const item = await measuredItem(container, 'bottom')
+    act(() => dragBy(item.querySelector('.grid-stack-item-content')!, 0, item.offsetHeight / 2))
 
     await waitFor(() => {
       expect(getByRole('alert').textContent).toMatch(/No room for “Memory” there/)
-      expect(getByRole('alert').textContent).toMatch(/8 rows tall and full/)
+      expect(getByRole('alert').textContent).toMatch(/8 rows tall/)
     })
 
     // And the panel is still where it was: a refused move changes nothing.
@@ -121,20 +157,76 @@ describe('a move the page has no room for', () => {
     await waitFor(() => expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(2))
     act(() => getByRole('button', { name: 'Edit layout' }).click())
 
-    const item = container.querySelector('[gs-id="bottom"]')!
-    await waitFor(() => {
-      const grid = container.querySelector('.grid-stack')!.getBoundingClientRect()
-      expect(item.getBoundingClientRect().bottom - grid.top).toBeLessThanOrEqual(grid.height + 1)
-    })
-
     // Upward, onto the panel above: room the page does have, once the engine
     // has moved the other one.
-    act(() => dragBy(item.querySelector('.grid-stack-item-content')!, 0, -item.getBoundingClientRect().height / 2))
+    const item = await measuredItem(container, 'bottom')
+    act(() => dragBy(item.querySelector('.grid-stack-item-content')!, 0, -item.offsetHeight / 2))
 
     await waitFor(() => {
       expect(container.querySelector('[gs-id="bottom"]')?.getAttribute('gs-y')).not.toBe('4')
     })
     expect(queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('a resize the page has no room for', () => {
+  it('is refused with the same message a move gets', async () => {
+    // The bottom panel already reaches the last row, so there is nothing below
+    // it to grow into.
+    const content = page([
+      ['top', 'cpu-utilization', { x: 0, y: 0, w: 12, h: 4 }],
+      ['bottom', 'memory', { x: 0, y: 4, w: 6, h: 4 }],
+      ['beside', 'gpu-utilization', { x: 6, y: 4, w: 6, h: 4 }],
+    ])
+    const { container, getByRole } = render(<Harness content={content} />)
+
+    await waitFor(() => expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(3))
+    act(() => getByRole('button', { name: 'Edit layout' }).click())
+
+    // The corner the library makes resizable in edit mode, pulled down by half
+    // the panel — two more rows the page does not have.
+    const item = await measuredItem(container, 'bottom')
+    act(() => resizeBy(item, 0, item.offsetHeight / 2))
+
+    await waitFor(() => {
+      expect(getByRole('alert').textContent).toMatch(/No room for “Memory” there/)
+    })
+    // Still four of the page's eight rows: it had nothing to give. Measured
+    // against the grid rather than in pixels, since the row height is whatever
+    // dividing the container came to.
+    const grid = container.querySelector('.grid-stack')!.getBoundingClientRect()
+    expect(item.offsetHeight).toBeLessThan(grid.height * 0.6)
+  })
+})
+
+describe('a session open when the window narrows', () => {
+  it('is suspended rather than ended: nothing drags, nothing saves, the work survives', async () => {
+    const content = page([
+      ['top', 'cpu-utilization', { x: 0, y: 0, w: 6, h: 4 }],
+      ['bottom', 'memory', { x: 6, y: 0, w: 6, h: 4 }],
+    ])
+    const { container, getByRole, rerender } = render(<Harness content={content} />)
+
+    await waitFor(() => expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(2))
+    act(() => getByRole('button', { name: 'Edit layout' }).click())
+    await waitFor(() => {
+      expect(container.querySelector('.grid-stack')?.classList.contains('grid-stack-static')).toBe(
+        false,
+      )
+    })
+
+    rerender(<Harness content={content} width={360} />)
+
+    await waitFor(() => {
+      // Static again, so the stacked column cannot be dragged into an
+      // arrangement that has nothing to do with the desktop one…
+      expect(container.querySelector('.grid-stack')?.classList.contains('grid-stack-static')).toBe(
+        true,
+      )
+      // …and it cannot be written either, while the session itself is still open.
+      expect(getByRole('button', { name: 'Save layout' })).toBeDisabled()
+    })
+    expect(getByRole('button', { name: 'Discard' })).toBeTruthy()
   })
 })
 

--- a/frontend/src/__tests__/liveMotion.test.tsx
+++ b/frontend/src/__tests__/liveMotion.test.tsx
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import { useState, type ReactNode } from 'react'
+import { AnimatedCounter } from '@/components/engines/AnimatedCounter'
+import { LiveMotionContext, useHeldWhileFrozen } from '@/hooks/useLiveMotion'
+import { useTabRotation } from '@/hooks/useTabRotation'
+
+// What "the dashboard holds still" means, at the three places motion comes
+// from. Edit mode is what freezes them in the product (#83); here each is
+// driven directly, because the point is that any page can hold still and none
+// of them knows what an edit session is.
+
+function Motion({ live, children }: { live: boolean; children: ReactNode }) {
+  return <LiveMotionContext.Provider value={live}>{children}</LiveMotionContext.Provider>
+}
+
+describe('a frozen counter', () => {
+  beforeEach(() => {
+    // A tween would need frames; a frozen counter must need none, so the queue
+    // stays unflushed on purpose and anything animating would be caught here.
+    vi.stubGlobal('requestAnimationFrame', () => 1)
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows the new number at once instead of counting up to it', () => {
+    const { rerender } = render(
+      <Motion live={false}>
+        <AnimatedCounter value={1000} format={String} />
+      </Motion>,
+    )
+
+    rerender(
+      <Motion live={false}>
+        <AnimatedCounter value={9000} format={String} />
+      </Motion>,
+    )
+
+    expect(screen.getByText('9000')).toBeInTheDocument()
+  })
+
+  it('lands on its target when the dashboard freezes mid-count', () => {
+    const { rerender } = render(
+      <Motion live>
+        <AnimatedCounter value={1000} format={String} />
+      </Motion>,
+    )
+    rerender(
+      <Motion live>
+        <AnimatedCounter value={9000} format={String} />
+      </Motion>,
+    )
+    // Mid-tween: no frame has run, so the counter still reads where it started.
+    expect(screen.getByText('1000')).toBeInTheDocument()
+
+    rerender(
+      <Motion live={false}>
+        <AnimatedCounter value={9000} format={String} />
+      </Motion>,
+    )
+
+    expect(screen.getByText('9000')).toBeInTheDocument()
+  })
+})
+
+describe('frozen tab rotation', () => {
+  function Rotation({ intervalMs = 1000 }: { intervalMs?: number }) {
+    const [tab, setTab] = useState('a')
+    useTabRotation({
+      order: ['a', 'b'],
+      activeTab: tab,
+      onAdvance: setTab,
+      intervalMs,
+      enabled: true,
+    })
+    return <span>{tab}</span>
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not advance while the dashboard is held still, and picks up again after', () => {
+    const { rerender } = render(
+      <Motion live={false}>
+        <Rotation />
+      </Motion>,
+    )
+
+    act(() => void vi.advanceTimersByTime(5000))
+    expect(screen.getByText('a')).toBeInTheDocument()
+
+    rerender(
+      <Motion live>
+        <Rotation />
+      </Motion>,
+    )
+    act(() => void vi.advanceTimersByTime(1000))
+
+    expect(screen.getByText('b')).toBeInTheDocument()
+  })
+})
+
+describe('a value held while the dashboard is frozen', () => {
+  function Held({ live, value }: { live: boolean; value: string }) {
+    return (
+      <Motion live={live}>
+        <Reader value={value} />
+      </Motion>
+    )
+  }
+
+  function Reader({ value }: { value: string }) {
+    return <span>{useHeldWhileFrozen(value)}</span>
+  }
+
+  it('keeps what was on screen when motion stopped, then catches up', () => {
+    const { rerender } = render(<Held live value="first" />)
+    expect(screen.getByText('first')).toBeInTheDocument()
+
+    // Frozen: the panel still re-renders — its geometry moves under the drag —
+    // but what it renders is the value it had when the freeze began.
+    rerender(<Held live={false} value="first" />)
+    rerender(<Held live={false} value="second" />)
+    expect(screen.getByText('first')).toBeInTheDocument()
+
+    rerender(<Held live value="second" />)
+    expect(screen.getByText('second')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/logsPanel.test.tsx
+++ b/frontend/src/__tests__/logsPanel.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { useEffect } from 'react'
 import { GridPanel } from '@/components/grid/GridPanel'
 import { LogStreamProvider } from '@/hooks/LogStreamProvider'
+import { LiveMotionContext } from '@/hooks/useLiveMotion'
 import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
 import { PageSelectionProvider } from '@/hooks/PageSelectionProvider'
 import { useMetricsStore } from '@/hooks/useMetricsStore'
@@ -112,20 +113,25 @@ function SelectEngine({ endpoint }: { endpoint: string }) {
 function Page({
   engines,
   panels,
+  live = true,
 }: {
   engines: EngineSnapshot[]
   panels: DashboardPanel[]
+  /** False stands in for a page being edited, which holds every panel still. */
+  live?: boolean
 }) {
   return (
     <MetricsStoreProvider>
       <LogStreamProvider>
         <Ingest engines={engines} />
-        <PageSelectionProvider>
-          <SelectEngine endpoint={BETA} />
-          {panels.map((panel) => (
-            <GridPanel key={panel.id} panel={panel} />
-          ))}
-        </PageSelectionProvider>
+        <LiveMotionContext.Provider value={live}>
+          <PageSelectionProvider>
+            <SelectEngine endpoint={BETA} />
+            {panels.map((panel) => (
+              <GridPanel key={panel.id} panel={panel} />
+            ))}
+          </PageSelectionProvider>
+        </LiveMotionContext.Provider>
       </LogStreamProvider>
     </MetricsStoreProvider>
   )
@@ -177,6 +183,33 @@ describe('the log panel', () => {
     })
 
     expect(within(region('Engine Logs')).getByText('INFO: alpha is serving')).toBeInTheDocument()
+  })
+
+  it('holds still while the page is being edited, then catches up', () => {
+    // The console scrolling under a panel the operator is dragging is the same
+    // problem as a chart redrawing under it. The socket stays open throughout —
+    // dropping it would lose the output produced while the page was rearranged,
+    // which is the output most worth having.
+    const props = { engines: [makeEngine(ALPHA)], panels: [logPanel('logs', 'Engine Logs')] }
+    const { rerender } = render(<Page {...props} />)
+
+    const socket = socketFor(ALPHA)
+    act(() => {
+      socket.connect()
+      socket.receive('INFO: before the edit')
+    })
+
+    rerender(<Page {...props} live={false} />)
+    act(() => socket.receive('INFO: during the edit'))
+
+    const panel = () => within(region('Engine Logs'))
+    expect(panel().getByText('INFO: before the edit')).toBeInTheDocument()
+    expect(panel().queryByText('INFO: during the edit')).not.toBeInTheDocument()
+    expect(sockets()).toHaveLength(1)
+
+    rerender(<Page {...props} />)
+
+    expect(panel().getByText('INFO: during the edit')).toBeInTheDocument()
   })
 
   it('opens one connection for two panels bound to the same engine', () => {

--- a/frontend/src/components/engines/AnimatedCounter.tsx
+++ b/frontend/src/components/engines/AnimatedCounter.tsx
@@ -33,6 +33,20 @@ function easeOut(t: number): number {
   return 1 - Math.pow(1 - t, 3)
 }
 
+/**
+ * Whether to jump straight to the target instead of tweening: nothing to count,
+ * a counter that reset, or a dashboard that is not supposed to be moving at all.
+ * A null `from` — nothing to count *from* — always snaps and is the caller's to
+ * check, so that both callers keep the narrowing they need afterwards.
+ *
+ * One predicate, asked twice — once during render to place the value, once in
+ * the effect to decide whether to start a tween — and the two must never
+ * disagree, or the counter animates from a number it already snapped past.
+ */
+function shouldSnap(from: number, value: number, live: boolean): boolean {
+  return from === value || !live || prefersReducedMotion() || value < from
+}
+
 export function AnimatedCounter({
   value,
   format,
@@ -65,18 +79,7 @@ export function AnimatedCounter({
   if (prevValue !== value) {
     setPrevValue(value)
     const from = display
-    // No previous numeric value, reduced motion, or a counter reset
-    // (target below current) -> snap, never animate downward.
-    if (
-      value === null ||
-      from === null ||
-      from === value ||
-      !live ||
-      prefersReducedMotion() ||
-      value < from
-    ) {
-      setDisplay(value)
-    }
+    if (value === null || from === null || shouldSnap(from, value, live)) setDisplay(value)
   }
 
   useEffect(() => {
@@ -98,7 +101,7 @@ export function AnimatedCounter({
 
     const from = displayRef.current
     // Snapped during render — nothing left to animate.
-    if (from === null || from === value || !live || prefersReducedMotion() || value < from) {
+    if (from === null || shouldSnap(from, value, live)) {
       cancel()
       return
     }

--- a/frontend/src/components/engines/AnimatedCounter.tsx
+++ b/frontend/src/components/engines/AnimatedCounter.tsx
@@ -7,10 +7,13 @@
  *   restart; we snap straight to a lower target instead of animating
  *   backward, then resume count-up from there.
  * - Honors `prefers-reduced-motion`: snaps directly to the value, no tween.
+ * - Honors a frozen dashboard the same way: a page being edited holds still, so
+ *   the counter lands on its target instead of counting under the operator.
  * - `null` renders as `--` with no animation.
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { useLiveMotion } from '@/hooks/useLiveMotion'
 
 interface AnimatedCounterProps {
   value: number | null
@@ -36,10 +39,19 @@ export function AnimatedCounter({
   className,
   durationMs = 550,
 }: AnimatedCounterProps) {
+  const live = useLiveMotion()
   const [display, setDisplay] = useState<number | null>(value)
   const displayRef = useRef<number | null>(value)
   const rafRef = useRef<number | null>(null)
   const [prevValue, setPrevValue] = useState<number | null>(value)
+  const [prevLive, setPrevLive] = useState(live)
+
+  // Freezing mid-tween lands on the target rather than stalling the counter
+  // between two numbers, which reads as a hung dashboard.
+  if (prevLive !== live) {
+    setPrevLive(live)
+    if (!live) setDisplay(value)
+  }
 
   // A target we snap to rather than animate towards is derived state, so it is
   // applied during render. Doing it from the effect below would commit one
@@ -59,6 +71,7 @@ export function AnimatedCounter({
       value === null ||
       from === null ||
       from === value ||
+      !live ||
       prefersReducedMotion() ||
       value < from
     ) {
@@ -85,7 +98,7 @@ export function AnimatedCounter({
 
     const from = displayRef.current
     // Snapped during render — nothing left to animate.
-    if (from === null || from === value || prefersReducedMotion() || value < from) {
+    if (from === null || from === value || !live || prefersReducedMotion() || value < from) {
       cancel()
       return
     }
@@ -109,7 +122,7 @@ export function AnimatedCounter({
     cancel()
     rafRef.current = requestAnimationFrame(tick)
     return cancel
-  }, [value, durationMs])
+  }, [value, durationMs, live])
 
   return (
     <span className={className}>

--- a/frontend/src/components/grid/EditModeBar.tsx
+++ b/frontend/src/components/grid/EditModeBar.tsx
@@ -1,0 +1,129 @@
+import { GRID_MAX_ROWS } from '@/lib/dashboard/grid'
+
+interface EditModeBarProps {
+  editing: boolean
+  /** No save can succeed on this instance; the standing banner says why. */
+  readOnly: boolean
+  /** A save is in flight, so the session must not be written twice. */
+  saving: boolean
+  /**
+   * The page is stacked into one column, where a drag would author a layout
+   * that has nothing to do with the desktop arrangement being edited.
+   */
+  narrow: boolean
+  /** The panel whose last drop the page had no room for, by title. */
+  refusedPanel: string | null
+  onBegin: () => void
+  onSave: () => void
+  onDiscard: () => void
+}
+
+/**
+ * The one affordance that turns a page from something you read into something
+ * you rearrange, and the only place a layout is written from.
+ *
+ * Edit mode is explicit because the alternative is not: with panels that are
+ * interactive on every pixel — chart tooltips, log filters, engine tabs — an
+ * always-draggable grid fights all of them, and a stray drag would rewrite a
+ * configuration everyone on this instance shares. For the same reason there is
+ * no autosave: an intermediate drag position must never become what a colleague
+ * loads.
+ */
+export function EditModeBar({
+  editing,
+  readOnly,
+  saving,
+  narrow,
+  refusedPanel,
+  onBegin,
+  onSave,
+  onDiscard,
+}: EditModeBarProps) {
+  return (
+    <div className="shrink-0 flex items-center justify-between gap-3 pb-2 min-h-7">
+      <Status editing={editing} narrow={narrow} readOnly={readOnly} refusedPanel={refusedPanel} />
+
+      <div className="flex items-center gap-2">
+        {editing ? (
+          <>
+            <BarButton onClick={onDiscard} disabled={saving}>
+              Discard
+            </BarButton>
+            <BarButton primary onClick={onSave} disabled={readOnly || saving}>
+              {saving ? 'Saving…' : 'Save layout'}
+            </BarButton>
+          </>
+        ) : (
+          !narrow && <BarButton onClick={onBegin}>Edit layout</BarButton>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Status({
+  editing,
+  narrow,
+  readOnly,
+  refusedPanel,
+}: Pick<EditModeBarProps, 'editing' | 'narrow' | 'readOnly' | 'refusedPanel'>) {
+  // The refusal outranks everything else the bar could be saying: it is the
+  // answer to what the operator just tried to do. It is an alert rather than a
+  // quiet status because the alternative — a panel that slides back with no
+  // explanation — reads as a broken drag rather than as a full page.
+  if (refusedPanel) {
+    return (
+      <p role="alert" className="text-xs text-amber-300 truncate">
+        No room for “{refusedPanel}” there. This page is {GRID_MAX_ROWS} rows tall and full — make
+        a panel smaller to free up space.
+      </p>
+    )
+  }
+
+  if (narrow) {
+    return (
+      <p className="text-xs text-zinc-500 truncate">
+        Panels are stacked to fit this screen. Rearranging needs a wider window.
+      </p>
+    )
+  }
+
+  if (!editing) return <span />
+
+  return (
+    <p className="text-xs text-zinc-400 truncate">
+      {readOnly
+        ? 'This dashboard is read-only, so a rearranged layout cannot be saved.'
+        : 'Drag a panel to move it, or its bottom-right corner to resize it. Nothing is saved until you save.'}
+    </p>
+  )
+}
+
+function BarButton({
+  primary = false,
+  disabled = false,
+  onClick,
+  children,
+}: {
+  primary?: boolean
+  disabled?: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`text-[10px] uppercase tracking-wider px-2 py-1 rounded border transition-colors ${
+        disabled
+          ? 'border-white/[0.04] text-zinc-600 cursor-not-allowed opacity-60'
+          : primary
+            ? 'bg-[#76B900]/20 hover:bg-[#76B900]/30 border-[#76B900]/40 text-[#cfe98a]'
+            : 'border-white/[0.08] text-zinc-300 hover:bg-white/[0.06]'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/components/grid/EditModeBar.tsx
+++ b/frontend/src/components/grid/EditModeBar.tsx
@@ -11,7 +11,8 @@ interface EditModeBarProps {
    * that has nothing to do with the desktop arrangement being edited.
    */
   narrow: boolean
-  /** The panel whose last drop the page had no room for, by title. */
+  /** The panel whose last drop the grid would not take, by the title the
+   *  operator reads. */
   refusedPanel: string | null
   onBegin: () => void
   onSave: () => void
@@ -49,7 +50,11 @@ export function EditModeBar({
             <BarButton onClick={onDiscard} disabled={saving}>
               Discard
             </BarButton>
-            <BarButton primary onClick={onSave} disabled={readOnly || saving}>
+            {/* Narrow suspends the session rather than ending it: the stacked
+                column is not the layout being edited, so there is nothing there
+                worth writing, and the work survives until the window is wide
+                again. */}
+            <BarButton primary onClick={onSave} disabled={readOnly || saving || narrow}>
               {saving ? 'Saving…' : 'Save layout'}
             </BarButton>
           </>
@@ -70,12 +75,17 @@ function Status({
   // The refusal outranks everything else the bar could be saying: it is the
   // answer to what the operator just tried to do. It is an alert rather than a
   // quiet status because the alternative — a panel that slides back with no
-  // explanation — reads as a broken drag rather than as a full page.
+  // explanation — reads as a broken drag rather than as a page with no room.
+  //
+  // It says only what is certain. The grid refuses a drop it cannot fit under
+  // the row cap *and* one the panels around it cannot make way for, and this
+  // side cannot tell which — so the wording covers both and the advice works
+  // for either.
   if (refusedPanel) {
     return (
       <p role="alert" className="text-xs text-amber-300 truncate">
-        No room for “{refusedPanel}” there. This page is {GRID_MAX_ROWS} rows tall and full — make
-        a panel smaller to free up space.
+        No room for “{refusedPanel}” there. The page is {GRID_MAX_ROWS} rows tall and the panels
+        around it cannot make way — try somewhere else, or make one of them smaller.
       </p>
     )
   }

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -1,9 +1,16 @@
 import 'gridstack/dist/gridstack.css'
-import { useMemo } from 'react'
-import { GridStack, GridStackItem, type GridStackOptions } from 'gridstack/dist/react'
+import { useCallback, useMemo, useRef } from 'react'
+import {
+  GridStack,
+  GridStackItem,
+  type GridItemHTMLElement,
+  type GridStackNode,
+  type GridStackOptions,
+} from 'gridstack/dist/react'
 import { PageSelectionProvider } from '@/hooks/PageSelectionProvider'
 import { useElementSize } from '@/hooks/useElementSize'
-import { GRID_COLUMNS, GRID_MAX_ROWS } from '@/lib/dashboard/grid'
+import { judgeDrop, requestedCells, type LayoutChange } from '@/lib/dashboard/editing'
+import { readGeometry, GRID_COLUMNS, GRID_MAX_ROWS, type PanelGeometry } from '@/lib/dashboard/grid'
 import type { DashboardPage } from '@/lib/dashboard/schema'
 import { GridPanel } from './GridPanel'
 
@@ -24,6 +31,17 @@ export const SINGLE_COLUMN_BREAKPOINT = 640
  */
 const FALLBACK_CELL_HEIGHT = 80
 
+/** What an edit session wants to hear from the grid. Absent means read-only
+ *  viewing, which is what the dashboard is nearly all of the time. */
+export interface GridEditing {
+  /** Where the engine has put panels, after a drop it accepted. */
+  onLayoutChange: (changes: LayoutChange[]) => void
+  /** A drag or resize has begun, so whatever the operator was told last is spent. */
+  onGestureStart: () => void
+  /** The named panel asked for a placement the page had no room for. */
+  onOutOfRoom: (panelId: string) => void
+}
+
 /**
  * One dashboard page as a grid of panels.
  *
@@ -33,10 +51,11 @@ const FALLBACK_CELL_HEIGHT = 80
  * panels into a single column and the container scrolls instead — the one place
  * scrolling is the design.
  *
- * The grid is static here: rendering from the stored document is this ticket
- * (#79); dragging, resizing and saving are edit mode (#83).
+ * The grid is static unless an edit session is passed (#83), which is what keeps
+ * every panel interaction — chart tooltips, log filters, engine tabs — working
+ * the rest of the time.
  */
-export function GridPage({ page }: { page: DashboardPage }) {
+export function GridPage({ page, editing }: { page: DashboardPage; editing?: GridEditing }) {
   const [containerRef, { width, height }] = useElementSize<HTMLDivElement>()
   const narrow = width > 0 && width <= SINGLE_COLUMN_BREAKPOINT
   const cellHeight = height > 0 ? Math.floor(height / GRID_MAX_ROWS) : FALLBACK_CELL_HEIGHT
@@ -48,22 +67,74 @@ export function GridPage({ page }: { page: DashboardPage }) {
         columnMax: GRID_COLUMNS,
         breakpoints: [{ w: SINGLE_COLUMN_BREAKPOINT, c: 1 }],
       },
-      // `maxRow` is deliberately NOT set on the engine here. The engine clamps
+      // The cap is the engine's only while an edit session is open, and only on
+      // a desktop-width grid. Outside one it must stay off: the engine clamps
       // every node into the cap when it re-adds them during a column change,
-      // and the single-column stack legitimately needs more rows than the cap
-      // — setting it would mangle the phone layout. A static grid cannot
-      // violate the cap anyway: `readGeometry` clamps persisted geometry into
-      // `GRID_MAX_ROWS` on read. Edit mode (#83) wires the cap into the engine
-      // (`maxRow` + `willItFit`) for the desktop-only edit session, where
-      // "will one more fit" is actually a question.
+      // and the single-column stack legitimately needs more rows than the cap.
+      // Zero, not undefined — `updateOptions` ignores an absent maxRow, so
+      // leaving edit mode has to say the cap is gone in as many words.
+      maxRow: editing && !narrow ? GRID_MAX_ROWS : 0,
       cellHeight,
       margin: 3,
       // Authored gaps are authored. Without floating, the engine compacts
       // everything upward on load and quietly rewrites the operator's layout.
       float: true,
-      staticGrid: true,
+      staticGrid: !editing,
     }),
-    [cellHeight],
+    [cellHeight, editing, narrow],
+  )
+
+  // The drag or resize under way: where the panel started, and the last thing
+  // the operator asked for before the engine decided whether to grant it.
+  const gesture = useRef<{ before: PanelGeometry; requested: PanelGeometry | null } | null>(null)
+
+  const trackGesture = useCallback((_event: Event, element: GridItemHTMLElement) => {
+    const grid = element.gridstackNode?.grid
+    if (!gesture.current || !grid?.el) return
+    gesture.current.requested = requestedCells(
+      element.getBoundingClientRect(),
+      grid.el.getBoundingClientRect(),
+      { width: grid.cellWidth(), height: grid.getCellHeight(true) },
+    )
+  }, [])
+
+  const beginGesture = useCallback(
+    (event: Event, element: GridItemHTMLElement) => {
+      if (!element.gridstackNode) return
+      gesture.current = { before: readGeometry(element.gridstackNode), requested: null }
+      editing?.onGestureStart()
+      trackGesture(event, element)
+    },
+    [editing, trackGesture],
+  )
+
+  const endGesture = useCallback(
+    (_event: Event, element: GridItemHTMLElement) => {
+      const attempt = gesture.current
+      gesture.current = null
+
+      const node = element.gridstackNode
+      if (!attempt || !node || node.id === undefined) return
+      if (judgeDrop(attempt.before, attempt.requested, readGeometry(node)) === 'out-of-room') {
+        editing?.onOutOfRoom(String(node.id))
+      }
+    },
+    [editing],
+  )
+
+  const handleChange = useCallback(
+    (_event: Event, nodes: GridStackNode[]) => {
+      // A collapsed grid reports one-column coordinates. They are derived, they
+      // are not what the operator authored, and recording them would let a save
+      // overwrite a desktop layout with a phone's.
+      if (narrow) return
+      editing?.onLayoutChange(
+        nodes
+          .filter((node) => node.id !== undefined)
+          .map((node) => ({ id: String(node.id), geometry: readGeometry(node) })),
+      )
+    },
+    [narrow, editing],
   )
 
   return (
@@ -79,10 +150,19 @@ export function GridPage({ page }: { page: DashboardPage }) {
           on this page reads the same GPU and engine, and a page mounted at
           another id starts from the host's defaults again. */}
       <PageSelectionProvider>
-        <GridStack options={options}>
+        <GridStack
+          options={options}
+          onChange={editing ? handleChange : undefined}
+          onDragStart={editing ? beginGesture : undefined}
+          onDrag={editing ? trackGesture : undefined}
+          onDragStop={editing ? endGesture : undefined}
+          onResizeStart={editing ? beginGesture : undefined}
+          onResize={editing ? trackGesture : undefined}
+          onResizeStop={editing ? endGesture : undefined}
+        >
           {page.panels.map((panel) => (
             <GridStackItem key={panel.id} id={panel.id} options={panel.geometry}>
-              <GridPanel panel={panel} />
+              <GridPanel panel={panel} editing={Boolean(editing)} />
             </GridStackItem>
           ))}
         </GridStack>

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -9,20 +9,16 @@ import {
 } from 'gridstack/dist/react'
 import { PageSelectionProvider } from '@/hooks/PageSelectionProvider'
 import { useElementSize } from '@/hooks/useElementSize'
-import { judgeDrop, requestedCells, type LayoutChange } from '@/lib/dashboard/editing'
+import {
+  judgeDrop,
+  requestedCells,
+  type Gesture,
+  type LayoutChange,
+} from '@/lib/dashboard/editing'
 import { readGeometry, GRID_COLUMNS, GRID_MAX_ROWS, type PanelGeometry } from '@/lib/dashboard/grid'
 import type { DashboardPage } from '@/lib/dashboard/schema'
+import { isNarrow, SINGLE_COLUMN_BREAKPOINT } from './breakpoint'
 import { GridPanel } from './GridPanel'
-
-/**
- * Container width in px at or below which the grid collapses to one column.
- * The collapse is the engine's own responsive path, driven by the grid
- * element's measured size (`breakpointForWindow` defaults to false): gridstack
- * caches the authored 12-column layout before collapsing and restores it
- * verbatim on the way back, which the #68 spike confirmed is lossless. Never
- * persist what the collapsed grid looks like.
- */
-export const SINGLE_COLUMN_BREAKPOINT = 640
 
 /**
  * Row height until the container has been measured. jsdom never measures, so
@@ -30,6 +26,22 @@ export const SINGLE_COLUMN_BREAKPOINT = 640
  * because fit-to-viewport replaces it on the first ResizeObserver tick.
  */
 const FALLBACK_CELL_HEIGHT = 80
+
+/**
+ * Where the pointer was when the grid raised a gesture event.
+ *
+ * The library hands its own synthetic event to the callback, carrying the
+ * pointer coordinates copied off the mouse event underneath. Null for anything
+ * without them, which is what keeps a missing coordinate from reading as a drag
+ * back to the top-left corner.
+ */
+function pointerAt(event: Event): { x: number; y: number } | null {
+  const { clientX, clientY } = event as MouseEvent
+
+  return typeof clientX === 'number' && typeof clientY === 'number'
+    ? { x: clientX, y: clientY }
+    : null
+}
 
 /** What an edit session wants to hear from the grid. Absent means read-only
  *  viewing, which is what the dashboard is nearly all of the time. */
@@ -57,8 +69,12 @@ export interface GridEditing {
  */
 export function GridPage({ page, editing }: { page: DashboardPage; editing?: GridEditing }) {
   const [containerRef, { width, height }] = useElementSize<HTMLDivElement>()
-  const narrow = width > 0 && width <= SINGLE_COLUMN_BREAKPOINT
+  const narrow = isNarrow(width)
   const cellHeight = height > 0 ? Math.floor(height / GRID_MAX_ROWS) : FALLBACK_CELL_HEIGHT
+  // A session survives the window narrowing, but nothing may be rearranged
+  // while it does: the collapsed column is derived from the layout being
+  // edited, so a drag there would author cells in a grid one column wide.
+  const draggable = Boolean(editing) && !narrow
 
   const options = useMemo(
     (): GridStackOptions => ({
@@ -73,60 +89,68 @@ export function GridPage({ page, editing }: { page: DashboardPage; editing?: Gri
       // and the single-column stack legitimately needs more rows than the cap.
       // Zero, not undefined — `updateOptions` ignores an absent maxRow, so
       // leaving edit mode has to say the cap is gone in as many words.
-      maxRow: editing && !narrow ? GRID_MAX_ROWS : 0,
+      maxRow: draggable ? GRID_MAX_ROWS : 0,
       cellHeight,
       margin: 3,
       // Authored gaps are authored. Without floating, the engine compacts
       // everything upward on load and quietly rewrites the operator's layout.
       float: true,
-      staticGrid: !editing,
+      staticGrid: !draggable,
     }),
-    [cellHeight, editing, narrow],
+    [cellHeight, draggable],
   )
 
-  // The drag or resize under way: where the panel started, and the last thing
-  // the operator asked for before the engine decided whether to grant it.
-  const gesture = useRef<{ before: PanelGeometry; requested: PanelGeometry | null } | null>(null)
-
-  const trackGesture = useCallback((_event: Event, element: GridItemHTMLElement) => {
-    const grid = element.gridstackNode?.grid
-    if (!gesture.current || !grid?.el) return
-    gesture.current.requested = requestedCells(
-      element.getBoundingClientRect(),
-      grid.el.getBoundingClientRect(),
-      { width: grid.cellWidth(), height: grid.getCellHeight(true) },
-    )
-  }, [])
+  // The gesture under way: what it is doing, where the panel started, and where
+  // the pointer was when it began.
+  const gesture = useRef<{
+    kind: Gesture
+    before: PanelGeometry
+    from: { x: number; y: number }
+  } | null>(null)
 
   const beginGesture = useCallback(
-    (event: Event, element: GridItemHTMLElement) => {
-      if (!element.gridstackNode) return
-      gesture.current = { before: readGeometry(element.gridstackNode), requested: null }
+    (kind: Gesture) => (event: Event, element: GridItemHTMLElement) => {
+      const node = element.gridstackNode
+      const from = pointerAt(event)
+      gesture.current = node && from ? { kind, before: readGeometry(node), from } : null
       editing?.onGestureStart()
-      trackGesture(event, element)
     },
-    [editing, trackGesture],
+    [editing],
   )
 
   const endGesture = useCallback(
-    (_event: Event, element: GridItemHTMLElement) => {
+    (event: Event, element: GridItemHTMLElement) => {
       const attempt = gesture.current
       gesture.current = null
 
       const node = element.gridstackNode
-      if (!attempt || !node || node.id === undefined) return
-      if (judgeDrop(attempt.before, attempt.requested, readGeometry(node)) === 'out-of-room') {
+      const to = pointerAt(event)
+      const grid = node?.grid
+      if (!attempt || !to || !grid || node.id === undefined) return
+
+      const requested = requestedCells(
+        attempt.kind,
+        attempt.before,
+        { dx: to.x - attempt.from.x, dy: to.y - attempt.from.y },
+        { width: grid.cellWidth(), height: grid.getCellHeight(true) },
+      )
+
+      if (judgeDrop(attempt.before, requested, readGeometry(node)) === 'out-of-room') {
         editing?.onOutOfRoom(String(node.id))
       }
     },
     [editing],
   )
 
+  const beginMove = useMemo(() => beginGesture('move'), [beginGesture])
+  const beginResize = useMemo(() => beginGesture('resize'), [beginGesture])
+
   const handleChange = useCallback(
     (_event: Event, nodes: GridStackNode[]) => {
-      // A collapsed grid reports one-column coordinates. They are derived, they
-      // are not what the operator authored, and recording them would let a save
-      // overwrite a desktop layout with a phone's.
+      // Belt and braces with the static grid above: a collapsed grid reports
+      // one-column coordinates, which are derived rather than authored, and
+      // recording them would let a save overwrite a desktop layout with a
+      // phone's.
       if (narrow) return
       editing?.onLayoutChange(
         nodes
@@ -152,13 +176,11 @@ export function GridPage({ page, editing }: { page: DashboardPage; editing?: Gri
       <PageSelectionProvider>
         <GridStack
           options={options}
-          onChange={editing ? handleChange : undefined}
-          onDragStart={editing ? beginGesture : undefined}
-          onDrag={editing ? trackGesture : undefined}
-          onDragStop={editing ? endGesture : undefined}
-          onResizeStart={editing ? beginGesture : undefined}
-          onResize={editing ? trackGesture : undefined}
-          onResizeStop={editing ? endGesture : undefined}
+          onChange={draggable ? handleChange : undefined}
+          onDragStart={draggable ? beginMove : undefined}
+          onDragStop={draggable ? endGesture : undefined}
+          onResizeStart={draggable ? beginResize : undefined}
+          onResizeStop={draggable ? endGesture : undefined}
         >
           {page.panels.map((panel) => (
             <GridStackItem key={panel.id} id={panel.id} options={panel.geometry}>

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -2,17 +2,18 @@ import { useCallback, useMemo, useState } from 'react'
 import { LiveMotionContext } from '@/hooks/useLiveMotion'
 import { useElementSize } from '@/hooks/useElementSize'
 import type { SaveOutcome } from '@/lib/dashboard/client'
-import { applyLayoutChanges } from '@/lib/dashboard/editing'
-import { panelTitle, type DashboardPage, type DashboardPanel } from '@/lib/dashboard/schema'
+import { applyLayoutChanges, refusedPanelTitle } from '@/lib/dashboard/editing'
+import type { DashboardPage, DashboardPanel } from '@/lib/dashboard/schema'
 import { EditModeBar } from './EditModeBar'
-import { GridPage, SINGLE_COLUMN_BREAKPOINT, type GridEditing } from './GridPage'
+import { isNarrow } from './breakpoint'
+import { GridPage, type GridEditing } from './GridPage'
 
 /** An edit session: the page as the operator is rearranging it, and whatever
  *  the grid last refused them. */
 interface EditSession {
   panels: DashboardPanel[]
   /** Id of the panel whose last drop had nowhere to go. */
-  refused: string | null
+  refusedPanelId: string | null
 }
 
 interface GridPageEditorProps {
@@ -38,8 +39,11 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
   const [saving, setSaving] = useState(false)
   const [containerRef, { width }] = useElementSize<HTMLDivElement>()
   // Below the breakpoint the grid stacks into one derived column, which is not
-  // an arrangement anyone authored and must never be saved as one.
-  const narrow = width > 0 && width <= SINGLE_COLUMN_BREAKPOINT
+  // an arrangement anyone authored and must never be saved as one. A session
+  // open when the window narrows is suspended rather than ended: the grid goes
+  // static and saving is withheld, so the work is still there when the window
+  // is wide again.
+  const narrow = isNarrow(width)
 
   const onLayoutChange = useCallback<GridEditing['onLayoutChange']>((changes) => {
     setSession((current) =>
@@ -49,11 +53,13 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
 
   const onGestureStart = useCallback(() => {
     // What the operator was told last was about the drag before this one.
-    setSession((current) => (current?.refused ? { ...current, refused: null } : current))
+    setSession((current) =>
+      current?.refusedPanelId ? { ...current, refusedPanelId: null } : current,
+    )
   }, [])
 
   const onOutOfRoom = useCallback((panelId: string) => {
-    setSession((current) => (current ? { ...current, refused: panelId } : current))
+    setSession((current) => (current ? { ...current, refusedPanelId: panelId } : current))
   }, [])
 
   // One object for the life of the editor, so a drag does not re-bind the
@@ -79,27 +85,36 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
     if (status === 'saved') setSession(null)
   }, [session, saving, onSave])
 
-  const refusedPanel = session?.refused
-    ? (shown.panels.find((panel) => panel.id === session.refused) ?? null)
-    : null
+  const refusedPanel = useMemo(
+    () => refusedPanelTitle(shown.panels, session?.refusedPanelId ?? null),
+    [shown, session?.refusedPanelId],
+  )
 
   return (
-    <div ref={containerRef} className="h-full flex flex-col min-h-0">
+    <div
+      ref={containerRef}
+      // Inline rather than Tailwind, for the same reason `GridPage` measures
+      // itself inline: the height it hands down is what the grid divides into
+      // rows, so the column has to hold up in the browser test project too,
+      // which runs no Tailwind build.
+      style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column' }}
+    >
       <EditModeBar
         editing={session !== null}
         readOnly={readOnly}
         saving={saving}
         narrow={narrow}
-        refusedPanel={refusedPanel && panelTitle(refusedPanel)}
-        onBegin={() => setSession({ panels: page.panels, refused: null })}
+        refusedPanel={refusedPanel}
+        onBegin={() => setSession({ panels: page.panels, refusedPanelId: null })}
         onSave={() => void save()}
         onDiscard={() => setSession(null)}
       />
 
       {/* Everything below holds still while the page is being edited: no tab
-          rotation, no counting, no chart redrawing under a panel in flight. */}
+          rotation, no counting, no chart or log redrawing under a panel in
+          flight. */}
       <LiveMotionContext.Provider value={session === null}>
-        <div className="flex-1 min-h-0">
+        <div style={{ flex: 1, minHeight: 0 }}>
           <GridPage page={shown} editing={session ? editingApi : undefined} />
         </div>
       </LiveMotionContext.Provider>

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useMemo, useState } from 'react'
+import { LiveMotionContext } from '@/hooks/useLiveMotion'
+import { useElementSize } from '@/hooks/useElementSize'
+import type { SaveOutcome } from '@/lib/dashboard/client'
+import { applyLayoutChanges } from '@/lib/dashboard/editing'
+import { panelTitle, type DashboardPage, type DashboardPanel } from '@/lib/dashboard/schema'
+import { EditModeBar } from './EditModeBar'
+import { GridPage, SINGLE_COLUMN_BREAKPOINT, type GridEditing } from './GridPage'
+
+/** An edit session: the page as the operator is rearranging it, and whatever
+ *  the grid last refused them. */
+interface EditSession {
+  panels: DashboardPanel[]
+  /** Id of the panel whose last drop had nowhere to go. */
+  refused: string | null
+}
+
+interface GridPageEditorProps {
+  page: DashboardPage
+  /** Nothing can be written on this instance; the standing banner says why. */
+  readOnly: boolean
+  onSave: (panels: DashboardPanel[]) => Promise<SaveOutcome['status']>
+}
+
+/**
+ * A page, plus the ability to rearrange it.
+ *
+ * The session is a working copy that lives only here: the grid moves panels
+ * inside it, and the stored configuration is untouched until the operator saves.
+ * That is what makes discarding free, and it is the only thing standing between
+ * an experimental drag and a layout every colleague on this instance loads.
+ *
+ * There is no undo. Discarding the session is the substitute — an undo stack
+ * over a grid that reflows on collision is far deeper than what it would buy.
+ */
+export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) {
+  const [session, setSession] = useState<EditSession | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [containerRef, { width }] = useElementSize<HTMLDivElement>()
+  // Below the breakpoint the grid stacks into one derived column, which is not
+  // an arrangement anyone authored and must never be saved as one.
+  const narrow = width > 0 && width <= SINGLE_COLUMN_BREAKPOINT
+
+  const onLayoutChange = useCallback<GridEditing['onLayoutChange']>((changes) => {
+    setSession((current) =>
+      current ? { ...current, panels: applyLayoutChanges(current.panels, changes) } : current,
+    )
+  }, [])
+
+  const onGestureStart = useCallback(() => {
+    // What the operator was told last was about the drag before this one.
+    setSession((current) => (current?.refused ? { ...current, refused: null } : current))
+  }, [])
+
+  const onOutOfRoom = useCallback((panelId: string) => {
+    setSession((current) => (current ? { ...current, refused: panelId } : current))
+  }, [])
+
+  // One object for the life of the editor, so a drag does not re-bind the
+  // grid's event handlers on every cell it crosses.
+  const editingApi = useMemo(
+    (): GridEditing => ({ onLayoutChange, onGestureStart, onOutOfRoom }),
+    [onLayoutChange, onGestureStart, onOutOfRoom],
+  )
+
+  const shown = useMemo(
+    () => (session ? { ...page, panels: session.panels } : page),
+    [page, session],
+  )
+
+  const save = useCallback(async () => {
+    if (!session || saving) return
+    setSaving(true)
+    const status = await onSave(session.panels)
+    setSaving(false)
+    // A save the server did not take leaves the session open: the work is still
+    // in the browser, and closing edit mode here would throw it away on the one
+    // occasion the operator most needs to try again.
+    if (status === 'saved') setSession(null)
+  }, [session, saving, onSave])
+
+  const refusedPanel = session?.refused
+    ? (shown.panels.find((panel) => panel.id === session.refused) ?? null)
+    : null
+
+  return (
+    <div ref={containerRef} className="h-full flex flex-col min-h-0">
+      <EditModeBar
+        editing={session !== null}
+        readOnly={readOnly}
+        saving={saving}
+        narrow={narrow}
+        refusedPanel={refusedPanel && panelTitle(refusedPanel)}
+        onBegin={() => setSession({ panels: page.panels, refused: null })}
+        onSave={() => void save()}
+        onDiscard={() => setSession(null)}
+      />
+
+      {/* Everything below holds still while the page is being edited: no tab
+          rotation, no counting, no chart redrawing under a panel in flight. */}
+      <LiveMotionContext.Provider value={session === null}>
+        <div className="flex-1 min-h-0">
+          <GridPage page={shown} editing={session ? editingApi : undefined} />
+        </div>
+      </LiveMotionContext.Provider>
+    </div>
+  )
+}

--- a/frontend/src/components/grid/GridPanel.tsx
+++ b/frontend/src/components/grid/GridPanel.tsx
@@ -9,9 +9,10 @@ import { renderPanelContent } from './panelRegistry'
  * page or silently vanish, because the layout around it is something the
  * operator authored.
  *
- * In edit mode the frame is the handle: it says so, and its contents stop
- * taking the pointer, so a drag that starts on a chart moves the panel instead
- * of chasing a tooltip.
+ * In edit mode the frame says it is draggable, and its contents stop taking the
+ * pointer — the drag would start either way, since the grid listens on the frame
+ * and the event bubbles, but a chart that pops a tooltip under a panel in flight
+ * is noise the operator did not ask for.
  */
 export function GridPanel({
   panel,

--- a/frontend/src/components/grid/GridPanel.tsx
+++ b/frontend/src/components/grid/GridPanel.tsx
@@ -8,17 +8,31 @@ import { renderPanelContent } from './panelRegistry'
  * a placeholder says why — a panel must keep its slot rather than break the
  * page or silently vanish, because the layout around it is something the
  * operator authored.
+ *
+ * In edit mode the frame is the handle: it says so, and its contents stop
+ * taking the pointer, so a drag that starts on a chart moves the panel instead
+ * of chasing a tooltip.
  */
-export function GridPanel({ panel }: { panel: DashboardPanel }) {
+export function GridPanel({
+  panel,
+  editing = false,
+}: {
+  panel: DashboardPanel
+  editing?: boolean
+}) {
   return (
     <section
       aria-label={panelTitle(panel)}
-      className="h-full min-h-0 flex flex-col rounded-md border border-white/[0.04] bg-[#151519] px-2 py-1.5 overflow-hidden"
+      className={`h-full min-h-0 flex flex-col rounded-md border bg-[#151519] px-2 py-1.5 overflow-hidden ${
+        editing
+          ? 'border-[#76B900]/40 cursor-move select-none'
+          : 'border-white/[0.04]'
+      }`}
     >
       <h3 className="shrink-0 text-[11px] font-semibold text-zinc-200 truncate">
         {panelTitle(panel)}
       </h3>
-      <div className="flex-1 min-h-0 min-w-0">
+      <div className={`flex-1 min-h-0 min-w-0 ${editing ? 'pointer-events-none' : ''}`}>
         {renderPanelContent(panel) ?? <PanelPlaceholder type={panel.type} />}
       </div>
     </section>

--- a/frontend/src/components/grid/breakpoint.ts
+++ b/frontend/src/components/grid/breakpoint.ts
@@ -1,0 +1,26 @@
+/**
+ * When a page is showing the collapsed single column rather than the layout the
+ * operator authored.
+ *
+ * Its own module because two components have to mean exactly the same thing by
+ * it: the grid, which goes static and drops its row cap when the column
+ * collapses, and the edit bar above it, which withholds saving for as long as
+ * that is true. Two answers to this question would leave a stacked grid
+ * draggable and a phone layout saveable over a desktop one.
+ */
+
+/**
+ * Container width in px at or below which the grid collapses to one column.
+ * The collapse is the engine's own responsive path, driven by the grid
+ * element's measured size (`breakpointForWindow` defaults to false): gridstack
+ * caches the authored 12-column layout before collapsing and restores it
+ * verbatim on the way back, which the #68 spike confirmed is lossless. Never
+ * persist what the collapsed grid looks like.
+ */
+export const SINGLE_COLUMN_BREAKPOINT = 640
+
+/** Zero width is not narrow — it is unmeasured, which is what jsdom and the
+ *  first frame before layout both report. */
+export function isNarrow(width: number): boolean {
+  return width > 0 && width <= SINGLE_COLUMN_BREAKPOINT
+}

--- a/frontend/src/hooks/useLiveMotion.ts
+++ b/frontend/src/hooks/useLiveMotion.ts
@@ -1,0 +1,47 @@
+/**
+ * Whether the dashboard is moving.
+ *
+ * Everything below a page that is being edited holds still: tab rotation stops,
+ * counters stop counting, and panels keep rendering the last snapshot they got.
+ * Dragging a panel whose contents rotate and re-draw underneath the cursor is
+ * disorienting, and a chart that redraws mid-drag looks like the drag doing it.
+ *
+ * Motion is live by default, so nothing outside an edit session — the root
+ * dashboard, a panel rendered in a spec — has to know this exists.
+ */
+
+import { createContext, useContext, useState } from 'react'
+
+/**
+ * Exported for the edit session that suspends motion; read it through
+ * `useLiveMotion`. A provider and hooks cannot share a file without breaking
+ * fast refresh, so the provider is wherever the session lives.
+ */
+export const LiveMotionContext = createContext(true)
+
+/** True while the dashboard is allowed to move. */
+export function useLiveMotion(): boolean {
+  return useContext(LiveMotionContext)
+}
+
+/**
+ * The live value while the dashboard is moving, and the value as of the moment
+ * motion stopped while it is frozen.
+ *
+ * A frozen panel still re-renders — its geometry changes under the operator's
+ * drag — so unsubscribing from a store is not on its own enough to hold what is
+ * on screen. The latch is adjusted during render rather than from an effect,
+ * which is the same rule the rotation and counter state follow: doing it in an
+ * effect commits one frame of the value that was supposed to be frozen out.
+ */
+export function useHeldWhileFrozen<T>(live: T): T {
+  const frozen = !useLiveMotion()
+  const [held, setHeld] = useState({ frozen, value: live })
+
+  if (held.frozen !== frozen) {
+    setHeld({ frozen, value: live })
+    return live
+  }
+
+  return frozen ? held.value : live
+}

--- a/frontend/src/hooks/useLogStream.ts
+++ b/frontend/src/hooks/useLogStream.ts
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useSyncExternalStore } from 'react'
 import { LogStreamStore, type LogStream } from '@/lib/logStreamStore'
+import { useHeldWhileFrozen } from './useLiveMotion'
 
 /**
  * The log stream store, provided through context rather than a module singleton
@@ -26,6 +27,12 @@ export function useLogStreamStore(): LogStreamStore {
  * its socket and the last one to unmount closes it. A component that should not
  * be streaming — a collapsed console, a panel bound to nothing — must therefore
  * not call this hook, rather than call it and ignore the result.
+ *
+ * A frozen dashboard holds the lines it had rather than dropping the
+ * subscription: unsubscribing here would close the engine's socket and lose the
+ * output produced while a page was being rearranged. The store keeps filling; a
+ * log panel simply stops scrolling under the operator's cursor until the session
+ * ends.
  */
 export function useLogStream(endpoint: string): LogStream {
   const store = useLogStreamStore()
@@ -34,5 +41,5 @@ export function useLogStream(endpoint: string): LogStream {
     [store, endpoint],
   )
   const read = useCallback(() => store.read(endpoint), [store, endpoint])
-  return useSyncExternalStore(subscribe, read)
+  return useHeldWhileFrozen(useSyncExternalStore(subscribe, read))
 }

--- a/frontend/src/hooks/useMetricsStore.ts
+++ b/frontend/src/hooks/useMetricsStore.ts
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from 'react'
 import { MetricsHistoryStore, type DataPoint } from '@/lib/metricsHistoryStore'
+import { useHeldWhileFrozen, useLiveMotion } from './useLiveMotion'
 import { DEFAULT_TIME_WINDOW } from '@/lib/dashboard/schema'
 import type { TimeWindow } from '@/types/events'
 import type { MetricsSnapshot } from '@/types/metrics'
@@ -27,22 +28,29 @@ export function useMetricsStore(): MetricsHistoryStore {
  * One chart series over the given time window, re-rendering only when that
  * series gains data. This is the subscription a panel uses: a snapshot that
  * changes other series does not touch this component.
+ *
+ * Frozen while a page is being edited: ingestion carries on filling the ring
+ * buffers, and the panel simply keeps drawing the window it had. Freezing the
+ * reader rather than the writer is what leaves no gap in the history once the
+ * operator saves and the dashboard starts moving again.
  */
 export function useMetricSeries(
   series: string,
   window: TimeWindow = DEFAULT_TIME_WINDOW,
 ): DataPoint[] {
   const store = useMetricsStore()
+  const live = useLiveMotion()
   const subscribe = useCallback(
-    (listener: () => void) => store.subscribe(series, listener),
-    [store, series],
+    (listener: () => void) => (live ? store.subscribe(series, listener) : noop),
+    [store, series, live],
   )
   const getVersion = useCallback(() => store.seriesVersion(series), [store, series])
   const version = useSyncExternalStore(subscribe, getVersion)
-  return useMemo(() => {
+  const data = useMemo(() => {
     void version // the series changed; re-read the window
     return store.getChartData(series, window)
   }, [store, series, window, version])
+  return useHeldWhileFrozen(data)
 }
 
 /**
@@ -50,11 +58,21 @@ export function useMetricSeries(
  * subscription for a panel's *current-value* display — a gauge, a rate pair, a
  * segment split — which needs more of the snapshot than any one series holds
  * and legitimately changes every second. Null until the first snapshot lands.
+ *
+ * Frozen while a page is being edited, for the same reason and in the same way
+ * as a series.
  */
 export function useLatestSnapshot(): MetricsSnapshot | null {
   const store = useMetricsStore()
-  const subscribe = useCallback((listener: () => void) => store.subscribeAll(listener), [store])
+  const live = useLiveMotion()
+  const subscribe = useCallback(
+    (listener: () => void) => (live ? store.subscribeAll(listener) : noop),
+    [store, live],
+  )
   const getVersion = useCallback(() => store.ingestVersion(), [store])
   useSyncExternalStore(subscribe, getVersion)
-  return store.latest()
+  return useHeldWhileFrozen(store.latest())
 }
+
+/** Unsubscribing from a store that is not being listened to. */
+function noop(): void {}

--- a/frontend/src/hooks/useTabRotation.ts
+++ b/frontend/src/hooks/useTabRotation.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useLiveMotion } from './useLiveMotion'
 
 export const ROTATION_INTERVAL_MS = 10_000
 
@@ -49,7 +50,12 @@ export function useTabRotation({
   // of tabs actually changes, not on every new array reference from metrics.
   const orderKey = useMemo(() => order.join(' '), [order])
 
-  const active = enabled && intervalMs > 0 && order.length > 1
+  // A frozen dashboard does not rotate: a page being edited must hold still, and
+  // advancing the tab under a panel the operator is dragging would move the very
+  // thing they are aiming at. Resuming starts a fresh cycle rather than
+  // continuing a countdown that ran out while the page was held.
+  const live = useLiveMotion()
+  const active = enabled && live && intervalMs > 0 && order.length > 1
 
   // A new rotation cycle starts whenever any input to the timer changes. That
   // makes `cycle` derived state, so it is adjusted during render rather than

--- a/frontend/src/lib/dashboard/editing.test.ts
+++ b/frontend/src/lib/dashboard/editing.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { FOLLOW } from './bindings'
-import { applyLayoutChanges, judgeDrop, requestedCells, withPagePanels } from './editing'
+import {
+  applyLayoutChanges,
+  judgeDrop,
+  refusedPanelTitle,
+  requestedCells,
+  withPagePanels,
+} from './editing'
 import { GRID_COLUMNS, GRID_MAX_ROWS, type PanelGeometry } from './grid'
 import { DEFAULT_TIME_WINDOW, type DashboardDocument, type DashboardPanel } from './schema'
 
@@ -82,54 +88,48 @@ describe('putting a page’s panels back into the document', () => {
   })
 })
 
-describe('what a drag or resize in progress is asking for', () => {
+describe('what a finished drag or resize was asking for', () => {
   const cell = { width: 50, height: 30 }
-  const grid = { left: 100, top: 200, width: 600, height: 240 }
+  const from = at(3, 2, 4, 2)
 
-  it('reads the element’s pixels as whole cells', () => {
-    const requested = requestedCells(
-      { left: 100 + 3 * 50, top: 200 + 2 * 30, width: 4 * 50, height: 2 * 30 },
-      grid,
-      cell,
-    )
+  it('moves the panel by the cells the pointer crossed', () => {
+    expect(requestedCells('move', from, { dx: 2 * 50, dy: 3 * 30 }, cell)).toEqual(at(5, 5, 4, 2))
+  })
 
-    expect(requested).toEqual(at(3, 2, 4, 2))
+  it('grows the panel by the cells the pointer crossed', () => {
+    expect(requestedCells('resize', from, { dx: 1 * 50, dy: 2 * 30 }, cell)).toEqual(at(3, 2, 5, 4))
   })
 
   it('rounds to the nearest cell, the way a dropped panel snaps', () => {
-    const requested = requestedCells(
-      { left: 100 + 3 * 50 + 12, top: 200 + 2 * 30 - 11, width: 4 * 50, height: 2 * 30 },
-      grid,
-      cell,
+    expect(requestedCells('move', from, { dx: 2 * 50 + 12, dy: 3 * 30 - 11 }, cell)).toEqual(
+      at(5, 5, 4, 2),
     )
-
-    expect(requested).toEqual(at(3, 2, 4, 2))
+    expect(requestedCells('move', from, { dx: 14, dy: -9 }, cell)).toEqual(from)
   })
 
   it('keeps a request that runs past the bottom of the grid, because that is the interesting one', () => {
     // Clamping here would hide exactly what the row cap exists to surface.
-    const requested = requestedCells(
-      { left: 100, top: 200 + 7 * 30, width: 2 * 50, height: 4 * 30 },
-      grid,
-      cell,
-    )
+    const moved = requestedCells('move', from, { dx: 0, dy: 5 * 30 }, cell)!
+    const grown = requestedCells('resize', from, { dx: 0, dy: 5 * 30 }, cell)!
 
-    expect(requested).toEqual(at(0, 7, 2, 4))
-    expect(requested!.y + requested!.h).toBeGreaterThan(GRID_MAX_ROWS)
+    expect(moved.y + moved.h).toBeGreaterThan(GRID_MAX_ROWS)
+    expect(grown.y + grown.h).toBeGreaterThan(GRID_MAX_ROWS)
   })
 
   it('never asks for a negative cell or an empty panel', () => {
-    const requested = requestedCells({ left: 0, top: 0, width: 4, height: 3 }, grid, cell)
-
-    expect(requested).toEqual(at(0, 0, 1, 1))
+    expect(requestedCells('move', from, { dx: -20 * 50, dy: -20 * 30 }, cell)).toEqual(
+      at(0, 0, 4, 2),
+    )
+    expect(requestedCells('resize', from, { dx: -20 * 50, dy: -20 * 30 }, cell)).toEqual(
+      at(3, 2, 1, 1),
+    )
   })
 
   it('knows nothing when the grid has not been measured', () => {
     // jsdom measures every box as 0×0, and so does the first frame before
     // layout. Guessing there would accuse the grid of refusing a drop that
     // never happened.
-    expect(requestedCells({ left: 0, top: 0, width: 0, height: 0 }, grid, { width: 0, height: 0 }))
-      .toBeNull()
+    expect(requestedCells('move', from, { dx: 0, dy: 0 }, { width: 0, height: 0 })).toBeNull()
   })
 })
 
@@ -172,5 +172,21 @@ describe('judging what the grid did with a drop', () => {
 
   it('says nothing when there was no measurable request', () => {
     expect(judgeDrop(from, null, from)).toBe('granted')
+  })
+})
+
+describe('naming the panel a refusal is about', () => {
+  it('uses the title the operator reads, renamed or not', () => {
+    const titled = { ...panel('a', at(0, 0, 6, 4)), title: 'RAM, big' }
+
+    expect(refusedPanelTitle([titled], 'a')).toBe('RAM, big')
+    expect(refusedPanelTitle([panel('a', at(0, 0, 6, 4))], 'a')).toBe('Memory')
+  })
+
+  it('has nothing to say when nothing stands refused', () => {
+    const panels = [panel('a', at(0, 0, 6, 4))]
+
+    expect(refusedPanelTitle(panels, null)).toBeNull()
+    expect(refusedPanelTitle(panels, 'a-panel-since-removed')).toBeNull()
   })
 })

--- a/frontend/src/lib/dashboard/editing.test.ts
+++ b/frontend/src/lib/dashboard/editing.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import { FOLLOW } from './bindings'
+import { applyLayoutChanges, judgeDrop, requestedCells, withPagePanels } from './editing'
+import { GRID_COLUMNS, GRID_MAX_ROWS, type PanelGeometry } from './grid'
+import { DEFAULT_TIME_WINDOW, type DashboardDocument, type DashboardPanel } from './schema'
+
+function panel(id: string, geometry: PanelGeometry): DashboardPanel {
+  return { id, type: 'memory', geometry, binding: FOLLOW, window: DEFAULT_TIME_WINDOW }
+}
+
+const at = (x: number, y: number, w: number, h: number): PanelGeometry => ({ x, y, w, h })
+
+describe('applying a layout change', () => {
+  it('moves the panel the change names and leaves the others alone', () => {
+    const panels = [panel('a', at(0, 0, 6, 4)), panel('b', at(6, 0, 6, 4))]
+
+    const moved = applyLayoutChanges(panels, [{ id: 'b', geometry: at(0, 4, 6, 4) }])
+
+    expect(moved.map((p) => [p.id, p.geometry])).toEqual([
+      ['a', at(0, 0, 6, 4)],
+      ['b', at(0, 4, 6, 4)],
+    ])
+  })
+
+  it('keeps everything the panel is besides its geometry', () => {
+    const titled = { ...panel('a', at(0, 0, 6, 4)), title: 'RAM, big', window: '15m' as const }
+
+    const [moved] = applyLayoutChanges([titled], [{ id: 'a', geometry: at(2, 2, 4, 2) }])
+
+    expect(moved).toEqual({ ...titled, geometry: at(2, 2, 4, 2) })
+  })
+
+  it('reads a sparse geometry the way the grid library writes one', () => {
+    // The library omits values equal to its defaults, so a 1×1 panel arrives
+    // with neither width nor height. Normalizing here is what keeps the
+    // document dense enough for a later migration to read without guessing.
+    const [moved] = applyLayoutChanges(
+      [panel('a', at(0, 0, 6, 4))],
+      [{ id: 'a', geometry: { x: 3, y: 2 } as PanelGeometry }],
+    )
+
+    expect(moved.geometry).toEqual(at(3, 2, 1, 1))
+  })
+
+  it('ignores a change naming a panel this page does not have', () => {
+    const panels = [panel('a', at(0, 0, 6, 4))]
+
+    expect(applyLayoutChanges(panels, [{ id: 'ghost', geometry: at(0, 4, 6, 4) }])).toBe(panels)
+  })
+
+  it('hands back the very same list when nothing actually moved', () => {
+    // Identity is the signal a caller uses to leave its state untouched, so a
+    // change event that repeats the current geometry costs no re-render.
+    const panels = [panel('a', at(0, 0, 6, 4))]
+
+    expect(applyLayoutChanges(panels, [{ id: 'a', geometry: at(0, 0, 6, 4) }])).toBe(panels)
+    expect(applyLayoutChanges(panels, [])).toBe(panels)
+  })
+})
+
+describe('putting a page’s panels back into the document', () => {
+  const document = (): DashboardDocument => ({
+    version: 1,
+    pages: [
+      { id: 'one', name: 'One', panels: [panel('a', at(0, 0, 6, 4))] },
+      { id: 'two', name: 'Two', panels: [panel('b', at(0, 0, 6, 4))] },
+    ],
+  })
+
+  it('replaces only the named page’s panels', () => {
+    const next = withPagePanels(document(), 'two', [panel('b', at(6, 0, 6, 4))])
+
+    expect(next.pages[0]).toEqual(document().pages[0])
+    expect(next.pages[1].panels[0].geometry).toEqual(at(6, 0, 6, 4))
+    expect(next.pages[1].name).toBe('Two')
+  })
+
+  it('leaves a document with no such page exactly as it was', () => {
+    const before = document()
+
+    expect(withPagePanels(before, 'gone', [])).toEqual(document())
+  })
+})
+
+describe('what a drag or resize in progress is asking for', () => {
+  const cell = { width: 50, height: 30 }
+  const grid = { left: 100, top: 200, width: 600, height: 240 }
+
+  it('reads the element’s pixels as whole cells', () => {
+    const requested = requestedCells(
+      { left: 100 + 3 * 50, top: 200 + 2 * 30, width: 4 * 50, height: 2 * 30 },
+      grid,
+      cell,
+    )
+
+    expect(requested).toEqual(at(3, 2, 4, 2))
+  })
+
+  it('rounds to the nearest cell, the way a dropped panel snaps', () => {
+    const requested = requestedCells(
+      { left: 100 + 3 * 50 + 12, top: 200 + 2 * 30 - 11, width: 4 * 50, height: 2 * 30 },
+      grid,
+      cell,
+    )
+
+    expect(requested).toEqual(at(3, 2, 4, 2))
+  })
+
+  it('keeps a request that runs past the bottom of the grid, because that is the interesting one', () => {
+    // Clamping here would hide exactly what the row cap exists to surface.
+    const requested = requestedCells(
+      { left: 100, top: 200 + 7 * 30, width: 2 * 50, height: 4 * 30 },
+      grid,
+      cell,
+    )
+
+    expect(requested).toEqual(at(0, 7, 2, 4))
+    expect(requested!.y + requested!.h).toBeGreaterThan(GRID_MAX_ROWS)
+  })
+
+  it('never asks for a negative cell or an empty panel', () => {
+    const requested = requestedCells({ left: 0, top: 0, width: 4, height: 3 }, grid, cell)
+
+    expect(requested).toEqual(at(0, 0, 1, 1))
+  })
+
+  it('knows nothing when the grid has not been measured', () => {
+    // jsdom measures every box as 0×0, and so does the first frame before
+    // layout. Guessing there would accuse the grid of refusing a drop that
+    // never happened.
+    expect(requestedCells({ left: 0, top: 0, width: 0, height: 0 }, grid, { width: 0, height: 0 }))
+      .toBeNull()
+  })
+})
+
+describe('judging what the grid did with a drop', () => {
+  const from = at(0, 4, 6, 4)
+
+  it('is granted when the panel landed where it was asked to', () => {
+    expect(judgeDrop(from, at(3, 2, 6, 4), at(3, 2, 6, 4))).toBe('granted')
+  })
+
+  it('is out of room when the panel was asked to move and did not', () => {
+    expect(judgeDrop(from, at(0, 6, 6, 4), from)).toBe('out-of-room')
+  })
+
+  it('is out of room when a resize was refused outright', () => {
+    expect(judgeDrop(from, at(0, 4, 6, 6), from)).toBe('out-of-room')
+  })
+
+  it('is granted when the engine reflowed the page around the drop', () => {
+    // Landing on a neighbour makes the engine swap or push it, so the cells the
+    // panel ends on are routinely not the ones it was dropped on. Calling that
+    // a full page would put a refusal in front of nearly every successful drag.
+    expect(judgeDrop(from, at(0, 0, 6, 4), at(0, 1, 6, 4))).toBe('granted')
+  })
+
+  it('is granted when the operator put the panel back where it came from', () => {
+    expect(judgeDrop(from, from, from)).toBe('granted')
+  })
+
+  it('does not call the grid’s own edges a refusal', () => {
+    // Dragging past the left or right edge is the operator meeting the frame,
+    // not the page being full: the grid keeps the panel inside its columns and
+    // that is the placement they got.
+    const wide = at(GRID_COLUMNS - 4, 0, 4, 2)
+    expect(judgeDrop(wide, at(GRID_COLUMNS, 0, 4, 2), wide)).toBe('granted')
+
+    const full = at(0, 0, GRID_COLUMNS, 2)
+    expect(judgeDrop(full, at(0, 0, GRID_COLUMNS + 3, 2), full)).toBe('granted')
+  })
+
+  it('says nothing when there was no measurable request', () => {
+    expect(judgeDrop(from, null, from)).toBe('granted')
+  })
+})

--- a/frontend/src/lib/dashboard/editing.ts
+++ b/frontend/src/lib/dashboard/editing.ts
@@ -10,7 +10,7 @@
  */
 
 import { readGeometry, GRID_COLUMNS, type PanelGeometry } from './grid'
-import type { DashboardDocument, DashboardPanel } from './schema'
+import { panelTitle, type DashboardDocument, type DashboardPanel } from './schema'
 
 /** Where the grid says a panel now sits. */
 export interface LayoutChange {
@@ -62,47 +62,54 @@ export function withPagePanels(
   }
 }
 
-/** A rectangle in pixels — an element's box, or the grid's own. */
-export interface PixelRect {
-  left: number
-  top: number
-  width: number
-  height: number
-}
-
 /** One grid cell in pixels. */
 export interface CellSize {
   width: number
   height: number
 }
 
+/** How far a pointer travelled over the course of a gesture, in pixels. */
+export interface Travel {
+  dx: number
+  dy: number
+}
+
+/** Which of the two things a finished gesture was doing. */
+export type Gesture = 'move' | 'resize'
+
 /**
- * The cells a drag or resize in progress is asking for: where the operator has
- * put the element, converted through the grid's own cell size.
+ * The cells a finished drag or resize asked for: where the panel started, moved
+ * or grown by however far the pointer travelled.
  *
- * Deliberately **not** clamped into the row cap. The whole question this answers
- * is whether the operator asked for something the page has no room for, and a
- * clamp here would quietly turn every such request into a satisfied one.
- * Columns are a different matter — see `judgeDrop`.
+ * Read from the **pointer**, not from the panel. The library reports a panel in
+ * flight only while it is accepting the move — a refused one produces no event
+ * and never leaves its cells — so the panel's own position answers the wrong
+ * question. The pointer says what the operator asked for whether or not they got
+ * it, which is the only thing that distinguishes a refusal from a drag taken
+ * back.
  *
- * Null when the grid has not been measured: jsdom measures every box as 0×0,
- * and so does the first frame before layout. There is nothing to conclude from
- * that, and concluding anything would accuse the grid of refusing a drop the
- * operator never made.
+ * Deliberately **not** clamped into the row cap: a clamp here would quietly turn
+ * every out-of-room request into a satisfied one. Columns are a different
+ * matter — see `judgeDrop`.
+ *
+ * Null when the grid has not been measured: jsdom measures every box as 0×0, and
+ * so does the first frame before layout. Concluding anything from that would
+ * accuse the grid of refusing a drop the operator never made.
  */
 export function requestedCells(
-  item: PixelRect,
-  grid: PixelRect,
+  gesture: Gesture,
+  before: PanelGeometry,
+  travel: Travel,
   cell: CellSize,
 ): PanelGeometry | null {
   if (cell.width <= 0 || cell.height <= 0) return null
 
-  return {
-    x: Math.max(0, Math.round((item.left - grid.left) / cell.width)),
-    y: Math.max(0, Math.round((item.top - grid.top) / cell.height)),
-    w: Math.max(1, Math.round(item.width / cell.width)),
-    h: Math.max(1, Math.round(item.height / cell.height)),
-  }
+  const columns = Math.round(travel.dx / cell.width)
+  const rows = Math.round(travel.dy / cell.height)
+
+  return gesture === 'move'
+    ? { ...before, x: Math.max(0, before.x + columns), y: Math.max(0, before.y + rows) }
+    : { ...before, w: Math.max(1, before.w + columns), h: Math.max(1, before.h + rows) }
 }
 
 /** What the grid did with the placement a finished drag or resize asked for. */
@@ -142,6 +149,23 @@ export function judgeDrop(
   const asked = { ...requested, w, x: Math.min(requested.x, GRID_COLUMNS - w) }
 
   return samePlacement(asked, before) ? 'granted' : 'out-of-room'
+}
+
+/**
+ * The title to name in a refusal, or null when nothing stands refused.
+ *
+ * Deliberately just the title. Whether the *page* is full is a different
+ * question from whether the panel could go where it was dropped — and a much
+ * harder one, since a panel is never in its own way, so the obvious predicate
+ * answers "not full" for a page with room for exactly one thing in the space
+ * the panel already occupies. The message says what is certain instead.
+ */
+export function refusedPanelTitle(
+  panels: readonly DashboardPanel[],
+  panelId: string | null,
+): string | null {
+  const refused = panels.find((panel) => panel.id === panelId)
+  return refused ? panelTitle(refused) : null
 }
 
 function samePlacement(a: PanelGeometry, b: PanelGeometry): boolean {

--- a/frontend/src/lib/dashboard/editing.ts
+++ b/frontend/src/lib/dashboard/editing.ts
@@ -1,0 +1,149 @@
+/**
+ * The rules of an edit session: what a layout change does to a page, and what
+ * to make of a drag or resize the grid did not grant.
+ *
+ * Everything here is pure, so the two things that are otherwise only reachable
+ * with a real layout engine — normalizing what the grid library reports, and
+ * telling a refused drop from a satisfied one — are covered without a browser.
+ * The session itself (what is being edited, and when it is written) lives in
+ * `useEditSession`; nothing in this module knows about React or the server.
+ */
+
+import { readGeometry, GRID_COLUMNS, type PanelGeometry } from './grid'
+import type { DashboardDocument, DashboardPanel } from './schema'
+
+/** Where the grid says a panel now sits. */
+export interface LayoutChange {
+  id: string
+  /** As the library reports it: sparse, with its own defaults omitted. */
+  geometry: PanelGeometry
+}
+
+/**
+ * The page's panels with `changes` applied, or the **same array** when nothing
+ * actually moved.
+ *
+ * Identity is part of the contract: the grid reports a change for every node it
+ * touched, including ones it put back where they were, and a session that
+ * re-created its panel list each time would re-render every panel on the page
+ * mid-drag.
+ *
+ * Geometry is normalized on the way in rather than on the way out, so the
+ * session holds cells that are already inside the grid and the serializer has
+ * nothing left to guess about.
+ */
+export function applyLayoutChanges(
+  panels: readonly DashboardPanel[],
+  changes: readonly LayoutChange[],
+): DashboardPanel[] {
+  const moved = new Map(changes.map((change) => [change.id, readGeometry(change.geometry)]))
+  if (moved.size === 0) return panels as DashboardPanel[]
+
+  let changed = false
+  const next = panels.map((panel) => {
+    const geometry = moved.get(panel.id)
+    if (!geometry || samePlacement(panel.geometry, geometry)) return panel
+    changed = true
+    return { ...panel, geometry }
+  })
+
+  return changed ? next : (panels as DashboardPanel[])
+}
+
+/** The document with one page's panels replaced — what an explicit save writes. */
+export function withPagePanels(
+  document: DashboardDocument,
+  pageId: string,
+  panels: DashboardPanel[],
+): DashboardDocument {
+  return {
+    ...document,
+    pages: document.pages.map((page) => (page.id === pageId ? { ...page, panels } : page)),
+  }
+}
+
+/** A rectangle in pixels — an element's box, or the grid's own. */
+export interface PixelRect {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+/** One grid cell in pixels. */
+export interface CellSize {
+  width: number
+  height: number
+}
+
+/**
+ * The cells a drag or resize in progress is asking for: where the operator has
+ * put the element, converted through the grid's own cell size.
+ *
+ * Deliberately **not** clamped into the row cap. The whole question this answers
+ * is whether the operator asked for something the page has no room for, and a
+ * clamp here would quietly turn every such request into a satisfied one.
+ * Columns are a different matter — see `judgeDrop`.
+ *
+ * Null when the grid has not been measured: jsdom measures every box as 0×0,
+ * and so does the first frame before layout. There is nothing to conclude from
+ * that, and concluding anything would accuse the grid of refusing a drop the
+ * operator never made.
+ */
+export function requestedCells(
+  item: PixelRect,
+  grid: PixelRect,
+  cell: CellSize,
+): PanelGeometry | null {
+  if (cell.width <= 0 || cell.height <= 0) return null
+
+  return {
+    x: Math.max(0, Math.round((item.left - grid.left) / cell.width)),
+    y: Math.max(0, Math.round((item.top - grid.top) / cell.height)),
+    w: Math.max(1, Math.round(item.width / cell.width)),
+    h: Math.max(1, Math.round(item.height / cell.height)),
+  }
+}
+
+/** What the grid did with the placement a finished drag or resize asked for. */
+export type DropVerdict = 'granted' | 'out-of-room'
+
+/**
+ * Whether the operator got anywhere with the drag or resize they just finished.
+ *
+ * The grid enforces the row cap itself — it simulates the move and commits only
+ * if the result still fits — so a refused drop is a panel that **did not move at
+ * all** while being asked to. That is the whole signature, and it has to be that
+ * narrow: the engine reflows around a panel that lands on its neighbours,
+ * swapping and pushing them, so "you did not get the exact cells you dropped on"
+ * is the normal, successful case and must not be reported as a full page.
+ *
+ * A drag the operator took back looks identical from the outside — nothing
+ * moved — so the request is compared against where the panel started rather than
+ * against nothing.
+ *
+ * Running off the left or right edge is not a refusal either: the grid has a
+ * fixed number of columns, and being kept inside them is the frame, not the page
+ * being full. Running off the bottom is the opposite — that is exactly the row
+ * cap doing its job, and the operator is owed an explanation.
+ *
+ * A resize the cap cuts short is deliberately *not* refused: the panel visibly
+ * grows to the bottom of the page and stops, which explains itself.
+ */
+export function judgeDrop(
+  before: PanelGeometry,
+  requested: PanelGeometry | null,
+  granted: PanelGeometry,
+): DropVerdict {
+  if (!requested) return 'granted'
+  if (!samePlacement(before, granted)) return 'granted'
+
+  const w = Math.min(requested.w, GRID_COLUMNS)
+  const asked = { ...requested, w, x: Math.min(requested.x, GRID_COLUMNS - w) }
+
+  return samePlacement(asked, before) ? 'granted' : 'out-of-room'
+}
+
+function samePlacement(a: PanelGeometry, b: PanelGeometry): boolean {
+  return a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h
+}

--- a/frontend/src/test/gridSubstitute.ts
+++ b/frontend/src/test/gridSubstitute.ts
@@ -5,13 +5,17 @@
  * nothing else — see `gridstack.tsx` for what is and is not simulated there.
  */
 
-/** As much of a gridstack node as anything here cares about. */
+/**
+ * As much of a gridstack node as anything here cares about. Width and height
+ * are optional because the library omits values equal to its own defaults, so a
+ * spec can report the sparse node a 1×1 panel really produces.
+ */
 export interface GridNode {
   id: string
   x: number
   y: number
-  w: number
-  h: number
+  w?: number
+  h?: number
 }
 
 /** The props the substitute's grid was last rendered with. */

--- a/frontend/src/test/gridSubstitute.ts
+++ b/frontend/src/test/gridSubstitute.ts
@@ -1,0 +1,65 @@
+/**
+ * What the jsdom grid substitute saw, and what a spec can tell it back.
+ *
+ * Separate from the substitute's components so that file exports components and
+ * nothing else — see `gridstack.tsx` for what is and is not simulated there.
+ */
+
+/** As much of a gridstack node as anything here cares about. */
+export interface GridNode {
+  id: string
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/** The props the substitute's grid was last rendered with. */
+export interface MountedGrid {
+  options?: Record<string, unknown>
+  onChange?: (event: Event, nodes: GridNode[]) => void
+}
+
+let mounted: MountedGrid = {}
+const geometry = new Map<string, unknown>()
+
+/** @internal — the substitute's own bookkeeping. */
+export function recordGrid(grid: MountedGrid): void {
+  mounted = grid
+}
+
+/** @internal — the substitute's own bookkeeping. */
+export function recordItem(id: string, options: unknown): void {
+  geometry.set(id, options)
+}
+
+export const gridSubstitute = {
+  /** The options the grid is currently mounted with. */
+  options(): Record<string, unknown> {
+    return mounted.options ?? {}
+  },
+
+  /** Whether an edit session has wired itself up — nothing can move without it. */
+  acceptsLayoutChanges(): boolean {
+    return mounted.onChange !== undefined
+  },
+
+  /** The geometry each item was last rendered with, by panel id. */
+  geometry(): Map<string, unknown> {
+    return new Map(geometry)
+  },
+
+  /**
+   * Report that the engine moved panels, the way a finished drag or resize
+   * does. A no-op when nothing is listening, which is the state of every page
+   * that is not being edited.
+   */
+  moved(nodes: GridNode[]): void {
+    mounted.onChange?.(new Event('change'), nodes)
+  },
+
+  reset(): void {
+    mounted = {}
+    geometry.clear()
+  },
+}

--- a/frontend/src/test/gridstack.tsx
+++ b/frontend/src/test/gridstack.tsx
@@ -10,16 +10,24 @@
  * covers the real engine. Direct prior art: the multi-GPU dashboard spec
  * substitutes the chart component for exactly this reason.
  *
+ * What it does record is the *contract* with the library — the options it was
+ * mounted with and the geometry each item was given — and it lets a spec fire
+ * the one callback that carries geometry back (see `gridSubstitute`). That is
+ * how a spec drives a rearrangement without a layout engine; whether a real drag
+ * produces one is the browser project's question, not this file's.
+ *
  * The browser project must never load this file; it exists to exercise the
  * real library.
  */
 
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
+import { recordGrid, recordItem, type GridNode } from './gridSubstitute'
 
 interface GridStackProps {
-  options?: unknown
+  options?: Record<string, unknown>
   children?: ReactNode
   className?: string
+  onChange?: (event: Event, nodes: GridNode[]) => void
 }
 
 interface GridStackItemProps {
@@ -28,7 +36,9 @@ interface GridStackItemProps {
   children?: ReactNode
 }
 
-export function GridStack({ children, className }: GridStackProps) {
+export function GridStack({ children, className, options, onChange }: GridStackProps) {
+  useEffect(() => recordGrid({ options, onChange }))
+
   return (
     <div data-testid="grid-stack" className={className}>
       {children}
@@ -36,6 +46,8 @@ export function GridStack({ children, className }: GridStackProps) {
   )
 }
 
-export function GridStackItem({ id, children }: GridStackItemProps) {
+export function GridStackItem({ id, options, children }: GridStackItemProps) {
+  useEffect(() => recordItem(id, options))
+
   return <div data-testid={`grid-stack-item-${id}`}>{children}</div>
 }


### PR DESCRIPTION
Closes #83. Spec: #70. Decision record: #68.

Explicit **edit mode** on a grid page, so an operator can rearrange a page
deliberately and never by accident. A page is static until they ask to edit it —
which is what keeps chart tooltips, log filters and engine tabs working the rest
of the time, and what stops a stray drag from rewriting a configuration everyone
on the instance shares.

## What it does

- **Edit / Save / Discard**, with no autosave. The session is a working copy;
  the stored document is untouched until an explicit save, which writes the whole
  document because it is one instance-scoped configuration. A save the server
  refuses leaves the session open, since the work is still in the browser and
  that is when it is most needed.
- **Live motion freezes** while editing: tab rotation stops, counters land on
  their target instead of counting, and every panel keeps rendering the snapshot
  and log lines it had. The freeze is on the *reader*, not the writer —
  ingestion carries on filling the ring buffers, so there is no gap in the
  history once the dashboard starts moving again.
- **Out of room is visible.** The grid enforces the row cap itself, so a refused
  drop is a panel that simply does not move — invisible on its own, and a layout
  that silently snaps back reads as a broken drag rather than as a page with no
  room. It now says so.
- **No undo/redo.** Discarding the session is the substitute.
- Read-only instances can enter edit mode but cannot save, consistently with
  their standing banner.

## Two judgement calls worth reviewing

**What counts as a refusal.** The first rule — "you did not land on the cells you
dropped on" — fired on *successful* drags, because the engine swaps and pushes
neighbours constantly; the browser test caught it. The rule is now narrow:
*nothing moved while being asked to move*. A resize the cap merely cuts short is
deliberately not flagged — the panel visibly grows to the bottom and stops, which
explains itself. The message says only what is true of both refusal causes (the
row cap, and neighbours that cannot make way), because this side cannot tell
which one it was.

**Editing is not offered below the single-column breakpoint**, and a session open
when the window narrows is *suspended* rather than ended — static grid, no
saving, work intact until the window is wide again. #83 does not ask for this,
but without it a drag in the collapsed column authors cells in a grid one column
wide, and saving them overwrites the desktop arrangement they were derived from.

## Testing

- Pure rules (apply a change, judge a drop, name a refusal) — `editing.test.ts`.
- Application seam — `App.editMode.test.tsx`: entering and leaving edit mode,
  save/reload, discard, nothing written mid-drag, read-only, a save the server
  refuses, and a page holding still through a snapshot.
- Browser mode — `editMode.browser.test.tsx`, five cases jsdom structurally
  cannot reach: a refused move, a refused resize, a reflow that must *not* be
  reported, the narrow gate and the suspended session. Drags are driven with
  mouse events, not pointer events (the library binds mousedown on the item's
  content and then move and release on the document).
- Brought up against a local backend with a real state directory: save, reload,
  restore; the refusal message on a full page; the freeze against live snapshots.

`npm run lint && npm run build && npm test -- --run` green; `npm run test:browser`
green (545 unit, 14 browser). No Rust or deployment files touched.

## Known, not introduced here

Gridstack narrows a full-width (12-column) panel to 11 on any vertical resize —
its own pixel-to-cell rounding. Left alone; worth a look when #87 covers resize.

## Follow-ups this unblocks

#84 (palette and per-panel configuration), #85 (pages), #87 (the browser suite).

**Rebase-merge, not squash** — every commit is a Conventional Commit and should
land individually.