### PR TITLE
feat(frontend): panel palette and per-panel configuration

### DIFF
--- a/frontend/src/__tests__/App.panelEditing.test.tsx
+++ b/frontend/src/__tests__/App.panelEditing.test.tsx
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+import {
+  configurationResponse,
+  configurationWrites,
+  serveConfiguration,
+  type FetchMock,
+} from '../test/configurationServer'
+import { gridSubstitute } from '../test/gridSubstitute'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+import { PANEL_TYPE_IDS, defaultPanelTitle } from '../lib/dashboard/panels'
+import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+
+// Adding panels through the application seam (#84): real routing, real
+// configuration loading and saving over the fetch stub, real panels reading the
+// real store, and the shared jsdom grid substitute standing in for the layout
+// engine. What an operator does is asserted as they see it, and again after a
+// save and a reload — the round trip is the whole point of a configuration.
+substituteWebSocket()
+
+vi.mock('@/components/charts/TimeSeriesChart', () => ({
+  TimeSeriesChart: (props: { data?: Array<{ value: number }> }) => (
+    // Values live in an attribute, not text, so text assertions only ever match
+    // what the panels themselves render.
+    <div data-testid="chart" data-values={props.data?.map((p) => p.value).join(',')} />
+  ),
+}))
+
+function storedDocument(panels: unknown[]): string {
+  return JSON.stringify({
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [{ id: 'watch', name: 'Watch', panels }],
+  })
+}
+
+/** One panel across the top half, leaving the rest of the page free. */
+function onePanel(): unknown[] {
+  return [{ id: 'cpu', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 3 } }]
+}
+
+/** A page with no free cell at all. */
+function fullPage(): unknown[] {
+  return [{ id: 'cpu', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 12, h: 8 } }]
+}
+
+/** Opens the page at its own URL and settles the configuration it loads. */
+async function openPage(fetchMock: FetchMock) {
+  window.history.replaceState(null, '', '/pages/watch')
+  render(<App />)
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+  await act(() => configurationResponse(fetchMock))
+}
+
+/** Opens the page and enters edit mode, which is where the palette lives. */
+async function editPage(fetchMock: FetchMock) {
+  await openPage(fetchMock)
+  await userEvent.click(screen.getByRole('button', { name: 'Edit layout' }))
+}
+
+const palette = () => screen.getByRole('region', { name: 'Panel palette' })
+const saveLayout = () => screen.getByRole('button', { name: 'Save layout' })
+
+async function openPalette() {
+  await userEvent.click(screen.getByRole('button', { name: 'Add panel' }))
+}
+
+async function addPanelOfType(title: string) {
+  await openPalette()
+  await userEvent.click(within(palette()).getByRole('button', { name: title }))
+}
+
+/** Saves, then re-opens the page against exactly what was written. */
+async function saveAndReload(fetchMock: FetchMock): Promise<FetchMock> {
+  await userEvent.click(saveLayout())
+  await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+
+  const reloaded = serveConfiguration({ document: configurationWrites(fetchMock)[0] })
+  // The page being reloaded is the same page: unmount the first render, or
+  // every assertion after this one matches two of everything.
+  cleanup()
+  gridSubstitute.reset()
+  await openPage(reloaded)
+  return reloaded
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  gridSubstitute.reset()
+})
+
+describe('the panel palette', () => {
+  it('offers every panel type the dashboard can show', async () => {
+    // Including the log panel, which is a panel here rather than a fixed
+    // drawer, and the types this build renders as placeholders — a palette
+    // that hid them would make the vocabulary unreachable.
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await openPalette()
+
+    for (const type of PANEL_TYPE_IDS) {
+      expect(
+        within(palette()).getByRole('button', { name: defaultPanelTitle(type) }),
+        type,
+      ).toBeInTheDocument()
+    }
+    within(palette()).getByRole('button', { name: 'Logs' })
+  })
+
+  it('is not offered while the page is only being read', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await openPage(fetchMock)
+
+    expect(screen.queryByRole('button', { name: 'Add panel' })).not.toBeInTheDocument()
+  })
+
+  it('places the chosen panel in the first free slot', async () => {
+    // Reading order: the top row is half taken, so the new panel goes beside
+    // what is there rather than below it. No drag has to be aimed at anything.
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+
+    screen.getByRole('region', { name: 'GPU Power' })
+    expect(gridSubstitute.geometry().get('gpu-power')).toEqual({ x: 6, y: 0, w: 3, h: 3 })
+  })
+
+  it('closes once a panel is placed, so the page it landed on is visible', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+
+    expect(screen.queryByRole('region', { name: 'Panel palette' })).not.toBeInTheDocument()
+  })
+
+  it('adds a second panel of a type without colliding with the first', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+    await addPanelOfType('GPU Power')
+
+    expect(gridSubstitute.geometry().get('gpu-power')).toEqual({ x: 6, y: 0, w: 3, h: 3 })
+    expect(gridSubstitute.geometry().get('gpu-power-2')).toEqual({ x: 9, y: 0, w: 3, h: 3 })
+  })
+
+  it('says so, and adds nothing, when the page has no room', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(fullPage()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no room for .GPU Power./i)
+    expect(screen.queryByRole('region', { name: 'GPU Power' })).not.toBeInTheDocument()
+  })
+
+  it('keeps an added panel only once the layout is saved', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+
+    // Discarding is the undo: nothing was written, and the panel is gone.
+    await userEvent.click(screen.getByRole('button', { name: 'Discard' }))
+
+    expect(configurationWrites(fetchMock)).toEqual([])
+    expect(screen.queryByRole('region', { name: 'GPU Power' })).not.toBeInTheDocument()
+  })
+
+  it('writes the added panel, and a reload comes back to it', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+    await saveAndReload(fetchMock)
+
+    screen.getByRole('region', { name: 'GPU Power' })
+    expect(gridSubstitute.geometry().get('gpu-power')).toEqual({ x: 6, y: 0, w: 3, h: 3 })
+  })
+})

--- a/frontend/src/__tests__/App.panelEditing.test.tsx
+++ b/frontend/src/__tests__/App.panelEditing.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import App from '../App'
@@ -12,12 +12,14 @@ import { gridSubstitute } from '../test/gridSubstitute'
 import { MockWebSocket, substituteWebSocket } from '../test/websocket'
 import { PANEL_TYPE_IDS, defaultPanelTitle } from '../lib/dashboard/panels'
 import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+import type { GpuMetrics, MetricsSnapshot } from '../types/metrics'
 
-// Adding panels through the application seam (#84): real routing, real
-// configuration loading and saving over the fetch stub, real panels reading the
-// real store, and the shared jsdom grid substitute standing in for the layout
-// engine. What an operator does is asserted as they see it, and again after a
-// save and a reload — the round trip is the whole point of a configuration.
+// The palette and per-panel configuration through the application seam (#84):
+// real routing, real configuration loading and saving over the fetch stub, real
+// panels reading the real store, and the shared jsdom grid substitute standing
+// in for the layout engine. What an operator adds, removes, renames, repoints
+// and rewindows is asserted as they see it, and again after a save and a
+// reload — the round trip is the whole point of a configuration.
 substituteWebSocket()
 
 vi.mock('@/components/charts/TimeSeriesChart', () => ({
@@ -27,6 +29,8 @@ vi.mock('@/components/charts/TimeSeriesChart', () => ({
     <div data-testid="chart" data-values={props.data?.map((p) => p.value).join(',')} />
   ),
 }))
+
+const GIB = 1_073_741_824
 
 function storedDocument(panels: unknown[]): string {
   return JSON.stringify({
@@ -45,6 +49,55 @@ function fullPage(): unknown[] {
   return [{ id: 'cpu', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 12, h: 8 } }]
 }
 
+function gpu(index: number, utilization: number): GpuMetrics {
+  return {
+    index,
+    name: `NVIDIA GB10 #${index}`,
+    utilization_percent: utilization,
+    memory_total_bytes: 96 * GIB,
+    memory_used_bytes: 24 * GIB,
+    temperature_celsius: 55,
+    power_watts: 180,
+    power_limit_watts: 300,
+    clock_graphics_mhz: 1900,
+    clock_sm_mhz: 1900,
+    clock_memory_mhz: 8000,
+    fan_speed_percent: 30,
+  }
+}
+
+/** A two-GPU host, so a pin has something to be pinned to. */
+function snapshot(timestampMs: number, utilization = [10, 90]): MetricsSnapshot {
+  const gpus = utilization.map((value, index) => gpu(index, value))
+
+  return {
+    timestamp_ms: timestampMs,
+    gpu: gpus[0],
+    gpus,
+    cpu: { name: 'Grace CPU', aggregate_percent: 40, per_core: [{ id: 0, usage_percent: 7 }] },
+    memory: {
+      total_bytes: 128 * GIB,
+      display_total_bytes: 128 * GIB,
+      used_bytes: 64 * GIB,
+      available_bytes: 64 * GIB,
+      cached_bytes: 8 * GIB,
+      gpu_estimated_bytes: 24 * GIB,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: true,
+    },
+    disk: { name: 'nvme0n1', read_bytes_per_sec: 0, write_bytes_per_sec: 0 },
+    network: { name: 'enp1s0', rx_bytes_per_sec: 0, tx_bytes_per_sec: 0 },
+    engines: [],
+    gpu_events: [],
+  }
+}
+
+/** Delivers a snapshot over the newest socket — a reloaded page opens its own. */
+function receive(metrics: MetricsSnapshot) {
+  act(() => MockWebSocket.instances.at(-1)!.receive(JSON.stringify(metrics)))
+}
+
 /** Opens the page at its own URL and settles the configuration it loads. */
 async function openPage(fetchMock: FetchMock) {
   window.history.replaceState(null, '', '/pages/watch')
@@ -53,13 +106,22 @@ async function openPage(fetchMock: FetchMock) {
   await act(() => configurationResponse(fetchMock))
 }
 
-/** Opens the page and enters edit mode, which is where the palette lives. */
-async function editPage(fetchMock: FetchMock) {
+/**
+ * Opens the page, delivers `metrics` if the spec needs a host to bind to, and
+ * enters edit mode — which is where all of this lives.
+ *
+ * The snapshot arrives *before* edit mode by necessity: a page being edited
+ * holds the last snapshot it had, so a page that entered edit mode having seen
+ * none would hold nothing.
+ */
+async function editPage(fetchMock: FetchMock, metrics?: MetricsSnapshot) {
   await openPage(fetchMock)
+  if (metrics) receive(metrics)
   await userEvent.click(screen.getByRole('button', { name: 'Edit layout' }))
 }
 
 const palette = () => screen.getByRole('region', { name: 'Panel palette' })
+const settings = () => screen.getByRole('region', { name: 'Panel settings' })
 const saveLayout = () => screen.getByRole('button', { name: 'Save layout' })
 
 async function openPalette() {
@@ -69,6 +131,17 @@ async function openPalette() {
 async function addPanelOfType(title: string) {
   await openPalette()
   await userEvent.click(within(palette()).getByRole('button', { name: title }))
+}
+
+async function configure(title: string) {
+  await userEvent.click(screen.getByRole('button', { name: `Configure ${title}` }))
+}
+
+/** The panels of the one page in the single write the spec expects. */
+function savedPanels(fetchMock: FetchMock): Array<Record<string, unknown>> {
+  const writes = configurationWrites(fetchMock)
+  expect(writes).toHaveLength(1)
+  return JSON.parse(writes[0]).pages[0].panels
 }
 
 /** Saves, then re-opens the page against exactly what was written. */
@@ -88,6 +161,10 @@ async function saveAndReload(fetchMock: FetchMock): Promise<FetchMock> {
 beforeEach(() => {
   MockWebSocket.instances = []
   gridSubstitute.reset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 describe('the panel palette', () => {
@@ -173,5 +250,183 @@ describe('the panel palette', () => {
 
     screen.getByRole('region', { name: 'GPU Power' })
     expect(gridSubstitute.geometry().get('gpu-power')).toEqual({ x: 6, y: 0, w: 3, h: 3 })
+  })
+})
+
+describe('removing a panel', () => {
+  it('takes it off the page, and the save writes it out of the document', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await configure('CPU')
+    await userEvent.click(within(settings()).getByRole('button', { name: 'Remove panel' }))
+
+    expect(screen.queryByRole('region', { name: 'CPU' })).not.toBeInTheDocument()
+    // The settings had nothing left to configure and closed with the panel.
+    expect(screen.queryByRole('region', { name: 'Panel settings' })).not.toBeInTheDocument()
+
+    await saveAndReload(fetchMock)
+
+    expect(screen.queryByRole('region', { name: 'CPU' })).not.toBeInTheDocument()
+  })
+})
+
+describe('renaming a panel', () => {
+  it('puts the operator’s own words in the header, and keeps them', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await configure('CPU')
+    await userEvent.type(within(settings()).getByLabelText('Title'), 'CPU load, node 3')
+
+    screen.getByRole('region', { name: 'CPU load, node 3' })
+
+    await saveAndReload(fetchMock)
+
+    screen.getByRole('region', { name: 'CPU load, node 3' })
+  })
+
+  it('goes back to the panel type’s own title when the name is cleared', async () => {
+    const named = [{ ...(onePanel()[0] as object), title: 'CPU load, node 3' }]
+    const fetchMock = serveConfiguration({ document: storedDocument(named) })
+    await editPage(fetchMock)
+    await configure('CPU load, node 3')
+    await userEvent.clear(within(settings()).getByLabelText('Title'))
+
+    screen.getByRole('region', { name: 'CPU' })
+
+    await userEvent.click(saveLayout())
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    // Absent rather than empty: the document says "never renamed", so a
+    // reworded default reaches this panel later.
+    expect(savedPanels(fetchMock)[0]).not.toHaveProperty('title')
+  })
+})
+
+describe('pinning a panel to one target', () => {
+  const gpuPanel = () => screen.getByRole('region', { name: 'GPU Utilization' })
+
+  /** A GPU panel that follows the page, on a page of its own. */
+  function followingGpuPanel(): unknown[] {
+    return [{ id: 'util', type: 'gpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 3 } }]
+  }
+
+  it('shows the pinned GPU’s numbers under the pinned GPU’s name', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(followingGpuPanel()) })
+    await editPage(fetchMock, snapshot(1000, [10, 90]))
+
+    // Following the page, which starts on the primary GPU.
+    expect(gpuPanel()).toHaveTextContent('10')
+
+    await configure('GPU Utilization')
+    await userEvent.selectOptions(within(settings()).getByLabelText('Source'), 'gpu:1')
+
+    expect(gpuPanel()).toHaveTextContent('90')
+    expect(gpuPanel()).toHaveTextContent('GPU 1')
+  })
+
+  it('keeps the pin across a save and a reload', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(followingGpuPanel()) })
+    await editPage(fetchMock, snapshot(1000, [10, 90]))
+    await configure('GPU Utilization')
+    await userEvent.selectOptions(within(settings()).getByLabelText('Source'), 'gpu:1')
+
+    await saveAndReload(fetchMock)
+    receive(snapshot(2000, [10, 90]))
+
+    expect(gpuPanel()).toHaveTextContent('90')
+  })
+
+  it('puts a pinned panel back to following the page', async () => {
+    const pinned = [
+      { ...(followingGpuPanel()[0] as object), binding: { kind: 'gpu', index: 1 } },
+    ]
+    const fetchMock = serveConfiguration({ document: storedDocument(pinned) })
+    await editPage(fetchMock, snapshot(1000, [10, 90]))
+
+    expect(gpuPanel()).toHaveTextContent('90')
+
+    await configure('GPU Utilization')
+    await userEvent.selectOptions(within(settings()).getByLabelText('Source'), 'follow')
+
+    expect(gpuPanel()).toHaveTextContent('10')
+  })
+
+  it('is how a binding that could not be read is repaired', async () => {
+    // A hand-edited file, or a truncated write. The panel says it needs
+    // repointing rather than quietly showing the page's selection under a
+    // title that may name the target it lost.
+    const broken = [{ ...(followingGpuPanel()[0] as object), binding: { kind: 'nonsense' } }]
+    const fetchMock = serveConfiguration({ document: storedDocument(broken) })
+    await editPage(fetchMock, snapshot(1000, [10, 90]))
+
+    expect(gpuPanel()).not.toHaveTextContent('10')
+
+    await configure('GPU Utilization')
+    await userEvent.selectOptions(within(settings()).getByLabelText('Source'), 'gpu:0')
+
+    expect(gpuPanel()).toHaveTextContent('10')
+  })
+
+  it('offers nothing to pin on a panel that covers the whole host', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock, snapshot(1000))
+    await configure('CPU')
+
+    expect(within(settings()).queryByLabelText('Source')).not.toBeInTheDocument()
+  })
+})
+
+describe('a panel’s own time window', () => {
+  function gpuPanels(): unknown[] {
+    return [
+      { id: 'a', type: 'gpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 3 }, window: '5m' },
+      { id: 'b', type: 'gpu-utilization', geometry: { x: 6, y: 0, w: 6, h: 3 }, window: '15m' },
+    ]
+  }
+
+  it('is written for that panel alone', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+    await configure('GPU Power')
+    await userEvent.selectOptions(within(settings()).getByLabelText('Time window'), '15m')
+    await userEvent.click(saveLayout())
+
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    expect(savedPanels(fetchMock).map((panel) => panel.window)).toEqual(['5m', '15m'])
+  })
+
+  it('gives two panels on one page charts of different spans', async () => {
+    // Ten minutes of history: the five-minute panel has dropped the first
+    // reading, the fifteen-minute panel still has it. Same series, same page,
+    // different windows.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const fetchMock = serveConfiguration({ document: storedDocument(gpuPanels()) })
+    await openPage(fetchMock)
+
+    receive(snapshot(1000, [11, 90]))
+    act(() => {
+      MockWebSocket.instances.at(-1)!.receive(JSON.stringify(snapshot(601_000, [22, 90])))
+      vi.advanceTimersByTime(2000)
+    })
+
+    const spans = screen
+      .getAllByTestId('chart')
+      .map((chart) => chart.getAttribute('data-values'))
+
+    expect(spans).toEqual(['22', '11,22'])
+  })
+
+  it('is not offered on a panel whose rendering has no window to cover', async () => {
+    // A log tail shows whatever the engine last printed; a window here would
+    // be a control that changes nothing.
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('Logs')
+    await configure('Logs')
+
+    expect(within(settings()).queryByLabelText('Time window')).not.toBeInTheDocument()
+    // Its engine binding is still configurable, because logs bind like any
+    // other engine panel.
+    within(settings()).getByLabelText('Source')
   })
 })

--- a/frontend/src/__tests__/App.panelEditing.test.tsx
+++ b/frontend/src/__tests__/App.panelEditing.test.tsx
@@ -211,6 +211,25 @@ describe('the panel palette', () => {
     expect(screen.queryByRole('region', { name: 'Panel palette' })).not.toBeInTheDocument()
   })
 
+  it('closes on Escape, and on a click anywhere off it', async () => {
+    // It covers the page it is being added to, so it has to be dismissable
+    // without choosing anything — both ways a reader expects of a popover.
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+
+    await openPalette()
+    await userEvent.keyboard('{Escape}')
+
+    expect(screen.queryByRole('region', { name: 'Panel palette' })).not.toBeInTheDocument()
+
+    await openPalette()
+    await userEvent.click(screen.getByRole('region', { name: 'CPU' }))
+
+    expect(screen.queryByRole('region', { name: 'Panel palette' })).not.toBeInTheDocument()
+    // Dismissing chose nothing: the page is the page it was.
+    expect(screen.queryByRole('region', { name: 'GPU Power' })).not.toBeInTheDocument()
+  })
+
   it('adds a second panel of a type without colliding with the first', async () => {
     const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
     await editPage(fetchMock)

--- a/frontend/src/__tests__/timeWindows.test.ts
+++ b/frontend/src/__tests__/timeWindows.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { TIME_WINDOWS, TIME_WINDOW_SECONDS } from '../types/events'
+
+// The offered list and the table it is read against are two declarations of one
+// thing: a window added to the table and not the list is a window no panel can
+// be given, and one added to the list alone would read as zero seconds.
+describe('the time windows a panel can cover', () => {
+  it('offers exactly the windows the store can read', () => {
+    expect([...TIME_WINDOWS].sort()).toEqual(Object.keys(TIME_WINDOW_SECONDS).sort())
+  })
+
+  it('offers them shortest first', () => {
+    const spans = TIME_WINDOWS.map((window) => TIME_WINDOW_SECONDS[window])
+
+    expect(spans).toEqual([...spans].sort((a, b) => a - b))
+  })
+})

--- a/frontend/src/components/engines/SloSettingsControl.tsx
+++ b/frontend/src/components/engines/SloSettingsControl.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
+import { useDismissablePopover } from '@/hooks/useDismissablePopover'
 import { DEFAULT_SLO, type SloThresholds } from '@/lib/slo'
 
 interface SloSettingsControlProps {
@@ -48,9 +49,8 @@ export function SloSettingsControl({
   onChange,
   onReset,
 }: SloSettingsControlProps) {
-  const [open, setOpen] = useState(false)
+  const { open, setOpen, toggle, containerRef } = useDismissablePopover<HTMLDivElement>()
   const [draft, setDraft] = useState<FieldDraft>(() => toDraft(thresholds))
-  const containerRef = useRef<HTMLDivElement | null>(null)
 
   // Sync the local draft when external thresholds change (e.g. user switches
   // model and the hook reloads stored values). The draft is derived from the
@@ -61,28 +61,6 @@ export function SloSettingsControl({
     setPrevThresholds(thresholds)
     setDraft(toDraft(thresholds))
   }
-
-  // Click-outside + Escape close the popover.
-  useEffect(() => {
-    if (!open) return
-    function onPointerDown(event: MouseEvent | TouchEvent) {
-      if (!containerRef.current) return
-      if (!containerRef.current.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-    function onKey(event: KeyboardEvent) {
-      if (event.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', onPointerDown)
-    document.addEventListener('touchstart', onPointerDown)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown)
-      document.removeEventListener('touchstart', onPointerDown)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [open])
 
   const parsed = parseDraft(draft)
   const dirty =
@@ -111,7 +89,7 @@ export function SloSettingsControl({
         aria-haspopup="dialog"
         aria-expanded={open}
         disabled={disabled}
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggle}
         title="Edit SLO thresholds"
         className={`inline-flex items-center justify-center h-6 w-6 rounded-md border transition-colors focus:outline-none focus:ring-1 focus:ring-[#76B900]/60 ${
           disabled

--- a/frontend/src/components/grid/BarButton.tsx
+++ b/frontend/src/components/grid/BarButton.tsx
@@ -1,0 +1,37 @@
+/**
+ * The edit bar's button: small, quiet, and the same whether it begins a
+ * session, ends one, or opens the palette. Shared so the bar's controls cannot
+ * drift apart from each other one addition at a time.
+ */
+export function BarButton({
+  primary = false,
+  disabled = false,
+  expanded,
+  onClick,
+  children,
+}: {
+  primary?: boolean
+  disabled?: boolean
+  /** Set when the button opens something, so it says whether that is open. */
+  expanded?: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-expanded={expanded}
+      className={`text-[10px] uppercase tracking-wider px-2 py-1 rounded border transition-colors ${
+        disabled
+          ? 'border-white/[0.04] text-zinc-600 cursor-not-allowed opacity-60'
+          : primary
+            ? 'bg-[#76B900]/20 hover:bg-[#76B900]/30 border-[#76B900]/40 text-[#cfe98a]'
+            : 'border-white/[0.08] text-zinc-300 hover:bg-white/[0.06]'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/components/grid/EditModeBar.tsx
+++ b/frontend/src/components/grid/EditModeBar.tsx
@@ -63,9 +63,12 @@ export function EditModeBar({
       <div className="flex items-center gap-2">
         {editing ? (
           <>
-            {/* Adding places a panel in the first free slot, which is an
-                authored change to the desktop layout — so it is withheld
-                exactly where a drag is: in the collapsed single column. */}
+            {/* The rule for the collapsed column is about *cells*, not about
+                editing: adding chooses a slot, so it is withheld there exactly
+                as a drag is, and the operator is not placing panels into a
+                layout they cannot see. What a panel *is* — its title, window
+                and source — is not geometry, so its settings stay available at
+                any width. */}
             {!narrow && <PanelPalette onAdd={onAdd} />}
             <BarButton onClick={onDiscard} disabled={saving}>
               Discard
@@ -100,21 +103,16 @@ function Status({
   if (refused) {
     return (
       <p role="alert" className="text-xs text-amber-300 truncate">
-        {refused.kind === 'drop' ? (
-          <>
-            {/* It says only what is certain. The grid refuses a drop it cannot
-                fit under the row cap *and* one the panels around it cannot make
-                way for, and this side cannot tell which — so the wording covers
-                both and the advice works for either. */}
-            No room for “{refused.title}” there. The page is {GRID_MAX_ROWS} rows tall and the
-            panels around it cannot make way — try somewhere else, or make one of them smaller.
-          </>
-        ) : (
-          <>
-            No room for “{refused.title}” on this page. The page is {GRID_MAX_ROWS} rows tall and
-            has no free space that size — remove a panel, or make one smaller, and add it again.
-          </>
-        )}
+        {/* One sentence of fact, then the advice, which is the only half that
+            differs. What the drop message says is only what is certain: the
+            grid refuses a drop it cannot fit under the row cap *and* one the
+            panels around it cannot make way for, and this side cannot tell
+            which — so the wording covers both. */}
+        No room for “{refused.title}”{refused.kind === 'drop' ? ' there' : ' on this page'}. The
+        page is {GRID_MAX_ROWS} rows tall{' '}
+        {refused.kind === 'drop'
+          ? 'and the panels around it cannot make way — try somewhere else, or make one of them smaller.'
+          : 'and has no free space that size — remove a panel, or make one smaller, and add it again.'}
       </p>
     )
   }

--- a/frontend/src/components/grid/EditModeBar.tsx
+++ b/frontend/src/components/grid/EditModeBar.tsx
@@ -1,4 +1,19 @@
 import { GRID_MAX_ROWS } from '@/lib/dashboard/grid'
+import type { PanelType } from '@/lib/dashboard/panels'
+import { BarButton } from './BarButton'
+import { PanelPalette } from './PanelPalette'
+
+/**
+ * Something the page had no room for, named by the title the operator reads.
+ *
+ * A drop and an addition are told apart because the advice differs: a refused
+ * drag has somewhere else to go, while a panel that will not fit anywhere needs
+ * room made for it first.
+ */
+export interface Refusal {
+  kind: 'drop' | 'add'
+  title: string
+}
 
 interface EditModeBarProps {
   editing: boolean
@@ -11,10 +26,10 @@ interface EditModeBarProps {
    * that has nothing to do with the desktop arrangement being edited.
    */
   narrow: boolean
-  /** The panel whose last drop the grid would not take, by the title the
-   *  operator reads. */
-  refusedPanel: string | null
+  /** What the page would not take, or null when nothing stands refused. */
+  refused: Refusal | null
   onBegin: () => void
+  onAdd: (type: PanelType) => void
   onSave: () => void
   onDiscard: () => void
 }
@@ -35,18 +50,23 @@ export function EditModeBar({
   readOnly,
   saving,
   narrow,
-  refusedPanel,
+  refused,
   onBegin,
+  onAdd,
   onSave,
   onDiscard,
 }: EditModeBarProps) {
   return (
     <div className="shrink-0 flex items-center justify-between gap-3 pb-2 min-h-7">
-      <Status editing={editing} narrow={narrow} readOnly={readOnly} refusedPanel={refusedPanel} />
+      <Status editing={editing} narrow={narrow} readOnly={readOnly} refused={refused} />
 
       <div className="flex items-center gap-2">
         {editing ? (
           <>
+            {/* Adding places a panel in the first free slot, which is an
+                authored change to the desktop layout — so it is withheld
+                exactly where a drag is: in the collapsed single column. */}
+            {!narrow && <PanelPalette onAdd={onAdd} />}
             <BarButton onClick={onDiscard} disabled={saving}>
               Discard
             </BarButton>
@@ -70,22 +90,31 @@ function Status({
   editing,
   narrow,
   readOnly,
-  refusedPanel,
-}: Pick<EditModeBarProps, 'editing' | 'narrow' | 'readOnly' | 'refusedPanel'>) {
+  refused,
+}: Pick<EditModeBarProps, 'editing' | 'narrow' | 'readOnly' | 'refused'>) {
   // The refusal outranks everything else the bar could be saying: it is the
   // answer to what the operator just tried to do. It is an alert rather than a
-  // quiet status because the alternative — a panel that slides back with no
-  // explanation — reads as a broken drag rather than as a page with no room.
-  //
-  // It says only what is certain. The grid refuses a drop it cannot fit under
-  // the row cap *and* one the panels around it cannot make way for, and this
-  // side cannot tell which — so the wording covers both and the advice works
-  // for either.
-  if (refusedPanel) {
+  // quiet status because the alternative — a panel that slides back, or one
+  // that never appears, with no explanation — reads as a broken interaction
+  // rather than as a page with no room.
+  if (refused) {
     return (
       <p role="alert" className="text-xs text-amber-300 truncate">
-        No room for “{refusedPanel}” there. The page is {GRID_MAX_ROWS} rows tall and the panels
-        around it cannot make way — try somewhere else, or make one of them smaller.
+        {refused.kind === 'drop' ? (
+          <>
+            {/* It says only what is certain. The grid refuses a drop it cannot
+                fit under the row cap *and* one the panels around it cannot make
+                way for, and this side cannot tell which — so the wording covers
+                both and the advice works for either. */}
+            No room for “{refused.title}” there. The page is {GRID_MAX_ROWS} rows tall and the
+            panels around it cannot make way — try somewhere else, or make one of them smaller.
+          </>
+        ) : (
+          <>
+            No room for “{refused.title}” on this page. The page is {GRID_MAX_ROWS} rows tall and
+            has no free space that size — remove a panel, or make one smaller, and add it again.
+          </>
+        )}
       </p>
     )
   }
@@ -106,34 +135,5 @@ function Status({
         ? 'This dashboard is read-only, so a rearranged layout cannot be saved.'
         : 'Drag a panel to move it, or its bottom-right corner to resize it. Nothing is saved until you save.'}
     </p>
-  )
-}
-
-function BarButton({
-  primary = false,
-  disabled = false,
-  onClick,
-  children,
-}: {
-  primary?: boolean
-  disabled?: boolean
-  onClick: () => void
-  children: React.ReactNode
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={`text-[10px] uppercase tracking-wider px-2 py-1 rounded border transition-colors ${
-        disabled
-          ? 'border-white/[0.04] text-zinc-600 cursor-not-allowed opacity-60'
-          : primary
-            ? 'bg-[#76B900]/20 hover:bg-[#76B900]/30 border-[#76B900]/40 text-[#cfe98a]'
-            : 'border-white/[0.08] text-zinc-300 hover:bg-white/[0.06]'
-      }`}
-    >
-      {children}
-    </button>
   )
 }

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -55,6 +55,19 @@ export interface GridEditing {
 }
 
 /**
+ * The per-panel affordances an open session adds to each frame.
+ *
+ * Separate from `GridEditing` on purpose: that object is the grid library's
+ * contract and is held stable for the life of the session, while this one
+ * changes every time the operator opens another panel's settings.
+ */
+export interface PanelChrome {
+  /** The panel whose settings are open, or null while none are. */
+  configuringId: string | null
+  onConfigure: (panelId: string) => void
+}
+
+/**
  * One dashboard page as a grid of panels.
  *
  * Fit-to-viewport is the defining property: the row height is the measured
@@ -67,7 +80,15 @@ export interface GridEditing {
  * every panel interaction — chart tooltips, log filters, engine tabs — working
  * the rest of the time.
  */
-export function GridPage({ page, editing }: { page: DashboardPage; editing?: GridEditing }) {
+export function GridPage({
+  page,
+  editing,
+  chrome,
+}: {
+  page: DashboardPage
+  editing?: GridEditing
+  chrome?: PanelChrome
+}) {
   const [containerRef, { width, height }] = useElementSize<HTMLDivElement>()
   const narrow = isNarrow(width)
   const cellHeight = height > 0 ? Math.floor(height / GRID_MAX_ROWS) : FALLBACK_CELL_HEIGHT
@@ -184,7 +205,12 @@ export function GridPage({ page, editing }: { page: DashboardPage; editing?: Gri
         >
           {page.panels.map((panel) => (
             <GridStackItem key={panel.id} id={panel.id} options={panel.geometry}>
-              <GridPanel panel={panel} editing={Boolean(editing)} />
+              <GridPanel
+                panel={panel}
+                editing={Boolean(editing)}
+                configuring={chrome?.configuringId === panel.id}
+                onConfigure={chrome && (() => chrome.onConfigure(panel.id))}
+              />
             </GridStackItem>
           ))}
         </GridStack>

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -79,7 +79,9 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
   }, [])
 
   const onOutOfRoom = useCallback((panelId: string) => {
-    setSession((current) => (current ? { ...current, refused: { kind: 'drop', panelId } } : current))
+    setSession((current) =>
+      current ? { ...current, refused: { kind: 'drop', panelId } } : current,
+    )
   }, [])
 
   // One object for the life of the editor, so a drag does not re-bind the

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -1,13 +1,24 @@
 import { useCallback, useMemo, useState } from 'react'
 import { LiveMotionContext } from '@/hooks/useLiveMotion'
 import { useElementSize } from '@/hooks/useElementSize'
+import type { PanelBinding } from '@/lib/dashboard/bindings'
 import type { SaveOutcome } from '@/lib/dashboard/client'
-import { addPanel, applyLayoutChanges, refusedPanelTitle } from '@/lib/dashboard/editing'
+import {
+  addPanel,
+  applyLayoutChanges,
+  refusedPanelTitle,
+  removePanel,
+  renamePanel,
+  repointPanel,
+  setPanelWindow,
+} from '@/lib/dashboard/editing'
 import { defaultPanelTitle, type PanelType } from '@/lib/dashboard/panels'
 import type { DashboardPage, DashboardPanel } from '@/lib/dashboard/schema'
+import type { TimeWindow } from '@/types/events'
 import { EditModeBar, type Refusal } from './EditModeBar'
+import { PanelSettings } from './PanelSettings'
 import { isNarrow } from './breakpoint'
-import { GridPage, type GridEditing } from './GridPage'
+import { GridPage, type GridEditing, type PanelChrome } from './GridPage'
 
 /** What the page last had no room for: a drop the grid would not take, or a
  *  panel the palette could not place. */
@@ -15,11 +26,12 @@ type RefusedRequest =
   | { kind: 'drop'; panelId: string }
   | { kind: 'add'; type: PanelType }
 
-/** An edit session: the page as the operator is changing it, and whatever the
- *  page last refused them. */
+/** An edit session: the page as the operator is changing it, whatever the page
+ *  last refused them, and which panel's settings are open. */
 interface EditSession {
   panels: DashboardPanel[]
   refused: RefusedRequest | null
+  configuringId: string | null
 }
 
 interface GridPageEditorProps {
@@ -30,17 +42,19 @@ interface GridPageEditorProps {
 }
 
 /**
- * A page, plus the ability to change it: where the panels sit, and which panels
- * there are at all.
+ * A page, plus the ability to change it: where the panels sit, which panels
+ * there are at all, and what each one is.
  *
  * The session is a working copy that lives only here: the grid moves panels
- * inside it, the palette adds to it, and the stored configuration is untouched
- * until the operator saves. That is what makes discarding free, and it is the
- * only thing standing between an experimental layout and one every colleague on
- * this instance loads.
+ * inside it, the palette adds to it and the settings row edits it, and the
+ * stored configuration is untouched until the operator saves. That is what
+ * makes discarding free, and it is the only thing standing between an
+ * experimental layout and one every colleague on this instance loads.
  *
  * There is no undo. Discarding the session is the substitute — an undo stack
- * over a grid that reflows on collision is far deeper than what it would buy.
+ * over a grid that reflows on collision is far deeper than what it would buy —
+ * which is also why removing a panel is behind its settings rather than one
+ * click on the frame.
  */
 export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) {
   const [session, setSession] = useState<EditSession | null>(null)
@@ -86,6 +100,45 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
     })
   }, [])
 
+  /** One edit to the panel whose settings are open. */
+  const editConfigured = useCallback(
+    (edit: (panels: DashboardPanel[], panelId: string) => DashboardPanel[]) => {
+      setSession((current) =>
+        current?.configuringId
+          ? { ...current, panels: edit(current.panels, current.configuringId) }
+          : current,
+      )
+    },
+    [],
+  )
+
+  const remove = useCallback(() => {
+    // The settings close with the panel: there is nothing left to configure,
+    // and a refusal about it is no longer about anything.
+    setSession((current) =>
+      current?.configuringId
+        ? {
+            panels: removePanel(current.panels, current.configuringId),
+            configuringId: null,
+            refused: null,
+          }
+        : current,
+    )
+  }, [])
+
+  const chrome = useMemo(
+    (): PanelChrome => ({
+      configuringId: session?.configuringId ?? null,
+      onConfigure: (panelId) =>
+        setSession((current) =>
+          current
+            ? { ...current, configuringId: current.configuringId === panelId ? null : panelId }
+            : current,
+        ),
+    }),
+    [session?.configuringId],
+  )
+
   const shown = useMemo(
     () => (session ? { ...page, panels: session.panels } : page),
     [page, session],
@@ -111,6 +164,10 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
     return title ? { kind: 'drop', title } : null
   }, [shown, session?.refused])
 
+  const configured = session?.configuringId
+    ? shown.panels.find((panel) => panel.id === session.configuringId)
+    : undefined
+
   return (
     <div
       ref={containerRef}
@@ -126,7 +183,7 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
         saving={saving}
         narrow={narrow}
         refused={refused}
-        onBegin={() => setSession({ panels: page.panels, refused: null })}
+        onBegin={() => setSession({ panels: page.panels, refused: null, configuringId: null })}
         onAdd={add}
         onSave={() => void save()}
         onDiscard={() => setSession(null)}
@@ -134,10 +191,35 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
 
       {/* Everything below holds still while the page is being edited: no tab
           rotation, no counting, no chart or log redrawing under a panel in
-          flight. */}
+          flight — and no target appearing in the settings row's own lists
+          while the operator is choosing between them. */}
       <LiveMotionContext.Provider value={session === null}>
+        {configured && (
+          <PanelSettings
+            // Keyed by the panel, so opening another one's settings starts its
+            // title field from that panel rather than from the last.
+            key={configured.id}
+            panel={configured}
+            onRename={(title) => editConfigured((panels, id) => renamePanel(panels, id, title))}
+            onWindowChange={(window: TimeWindow) =>
+              editConfigured((panels, id) => setPanelWindow(panels, id, window))
+            }
+            onRepoint={(binding: PanelBinding) =>
+              editConfigured((panels, id) => repointPanel(panels, id, binding))
+            }
+            onRemove={remove}
+            onClose={() =>
+              setSession((current) => (current ? { ...current, configuringId: null } : current))
+            }
+          />
+        )}
+
         <div style={{ flex: 1, minHeight: 0 }}>
-          <GridPage page={shown} editing={session ? editingApi : undefined} />
+          <GridPage
+            page={shown}
+            editing={session ? editingApi : undefined}
+            chrome={session ? chrome : undefined}
+          />
         </div>
       </LiveMotionContext.Provider>
     </div>

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -2,18 +2,24 @@ import { useCallback, useMemo, useState } from 'react'
 import { LiveMotionContext } from '@/hooks/useLiveMotion'
 import { useElementSize } from '@/hooks/useElementSize'
 import type { SaveOutcome } from '@/lib/dashboard/client'
-import { applyLayoutChanges, refusedPanelTitle } from '@/lib/dashboard/editing'
+import { addPanel, applyLayoutChanges, refusedPanelTitle } from '@/lib/dashboard/editing'
+import { defaultPanelTitle, type PanelType } from '@/lib/dashboard/panels'
 import type { DashboardPage, DashboardPanel } from '@/lib/dashboard/schema'
-import { EditModeBar } from './EditModeBar'
+import { EditModeBar, type Refusal } from './EditModeBar'
 import { isNarrow } from './breakpoint'
 import { GridPage, type GridEditing } from './GridPage'
 
-/** An edit session: the page as the operator is rearranging it, and whatever
- *  the grid last refused them. */
+/** What the page last had no room for: a drop the grid would not take, or a
+ *  panel the palette could not place. */
+type RefusedRequest =
+  | { kind: 'drop'; panelId: string }
+  | { kind: 'add'; type: PanelType }
+
+/** An edit session: the page as the operator is changing it, and whatever the
+ *  page last refused them. */
 interface EditSession {
   panels: DashboardPanel[]
-  /** Id of the panel whose last drop had nowhere to go. */
-  refusedPanelId: string | null
+  refused: RefusedRequest | null
 }
 
 interface GridPageEditorProps {
@@ -24,12 +30,14 @@ interface GridPageEditorProps {
 }
 
 /**
- * A page, plus the ability to rearrange it.
+ * A page, plus the ability to change it: where the panels sit, and which panels
+ * there are at all.
  *
  * The session is a working copy that lives only here: the grid moves panels
- * inside it, and the stored configuration is untouched until the operator saves.
- * That is what makes discarding free, and it is the only thing standing between
- * an experimental drag and a layout every colleague on this instance loads.
+ * inside it, the palette adds to it, and the stored configuration is untouched
+ * until the operator saves. That is what makes discarding free, and it is the
+ * only thing standing between an experimental layout and one every colleague on
+ * this instance loads.
  *
  * There is no undo. Discarding the session is the substitute — an undo stack
  * over a grid that reflows on collision is far deeper than what it would buy.
@@ -53,13 +61,11 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
 
   const onGestureStart = useCallback(() => {
     // What the operator was told last was about the drag before this one.
-    setSession((current) =>
-      current?.refusedPanelId ? { ...current, refusedPanelId: null } : current,
-    )
+    setSession((current) => (current?.refused ? { ...current, refused: null } : current))
   }, [])
 
   const onOutOfRoom = useCallback((panelId: string) => {
-    setSession((current) => (current ? { ...current, refusedPanelId: panelId } : current))
+    setSession((current) => (current ? { ...current, refused: { kind: 'drop', panelId } } : current))
   }, [])
 
   // One object for the life of the editor, so a drag does not re-bind the
@@ -68,6 +74,17 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
     (): GridEditing => ({ onLayoutChange, onGestureStart, onOutOfRoom }),
     [onLayoutChange, onGestureStart, onOutOfRoom],
   )
+
+  const add = useCallback((type: PanelType) => {
+    setSession((current) => {
+      if (!current) return current
+      const outcome = addPanel(current.panels, type)
+
+      return outcome.status === 'added'
+        ? { ...current, panels: outcome.panels, refused: null }
+        : { ...current, refused: { kind: 'add', type } }
+    })
+  }, [])
 
   const shown = useMemo(
     () => (session ? { ...page, panels: session.panels } : page),
@@ -85,10 +102,14 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
     if (status === 'saved') setSession(null)
   }, [session, saving, onSave])
 
-  const refusedPanel = useMemo(
-    () => refusedPanelTitle(shown.panels, session?.refusedPanelId ?? null),
-    [shown, session?.refusedPanelId],
-  )
+  const refused = useMemo((): Refusal | null => {
+    const request = session?.refused
+    if (!request) return null
+    if (request.kind === 'add') return { kind: 'add', title: defaultPanelTitle(request.type) }
+
+    const title = refusedPanelTitle(shown.panels, request.panelId)
+    return title ? { kind: 'drop', title } : null
+  }, [shown, session?.refused])
 
   return (
     <div
@@ -104,8 +125,9 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
         readOnly={readOnly}
         saving={saving}
         narrow={narrow}
-        refusedPanel={refusedPanel}
-        onBegin={() => setSession({ panels: page.panels, refusedPanelId: null })}
+        refused={refused}
+        onBegin={() => setSession({ panels: page.panels, refused: null })}
+        onAdd={add}
         onSave={() => void save()}
         onDiscard={() => setSession(null)}
       />

--- a/frontend/src/components/grid/GridPanel.tsx
+++ b/frontend/src/components/grid/GridPanel.tsx
@@ -35,12 +35,8 @@ export function GridPanel({
     <section
       aria-label={title}
       className={`h-full min-h-0 flex flex-col rounded-md border bg-[#151519] px-2 py-1.5 overflow-hidden ${
-        editing
-          ? configuring
-            ? 'border-[#76B900] cursor-move select-none'
-            : 'border-[#76B900]/40 cursor-move select-none'
-          : 'border-white/[0.04]'
-      }`}
+        editing ? 'cursor-move select-none' : ''
+      } ${editing ? (configuring ? 'border-[#76B900]' : 'border-[#76B900]/40') : 'border-white/[0.04]'}`}
     >
       <div className="shrink-0 flex items-center gap-1">
         <h3 className="flex-1 min-w-0 text-[11px] font-semibold text-zinc-200 truncate">{title}</h3>

--- a/frontend/src/components/grid/GridPanel.tsx
+++ b/frontend/src/components/grid/GridPanel.tsx
@@ -1,3 +1,4 @@
+import { Settings2 } from 'lucide-react'
 import { isKnownPanelType } from '@/lib/dashboard/panels'
 import { panelTitle, type DashboardPanel } from '@/lib/dashboard/schema'
 import { renderPanelContent } from './panelRegistry'
@@ -12,27 +13,50 @@ import { renderPanelContent } from './panelRegistry'
  * In edit mode the frame says it is draggable, and its contents stop taking the
  * pointer — the drag would start either way, since the grid listens on the frame
  * and the event bubbles, but a chart that pops a tooltip under a panel in flight
- * is noise the operator did not ask for.
+ * is noise the operator did not ask for. The header keeps its pointer, because
+ * that is where the panel's own settings are opened from; the grid library
+ * declines to start a drag on a button, so the two do not fight.
  */
 export function GridPanel({
   panel,
   editing = false,
+  configuring = false,
+  onConfigure,
 }: {
   panel: DashboardPanel
   editing?: boolean
+  /** This panel's settings are the ones open, so its frame says so. */
+  configuring?: boolean
+  onConfigure?: () => void
 }) {
+  const title = panelTitle(panel)
+
   return (
     <section
-      aria-label={panelTitle(panel)}
+      aria-label={title}
       className={`h-full min-h-0 flex flex-col rounded-md border bg-[#151519] px-2 py-1.5 overflow-hidden ${
         editing
-          ? 'border-[#76B900]/40 cursor-move select-none'
+          ? configuring
+            ? 'border-[#76B900] cursor-move select-none'
+            : 'border-[#76B900]/40 cursor-move select-none'
           : 'border-white/[0.04]'
       }`}
     >
-      <h3 className="shrink-0 text-[11px] font-semibold text-zinc-200 truncate">
-        {panelTitle(panel)}
-      </h3>
+      <div className="shrink-0 flex items-center gap-1">
+        <h3 className="flex-1 min-w-0 text-[11px] font-semibold text-zinc-200 truncate">{title}</h3>
+        {editing && onConfigure && (
+          <button
+            type="button"
+            aria-label={`Configure ${title}`}
+            onClick={onConfigure}
+            className={`shrink-0 rounded p-0.5 transition-colors ${
+              configuring ? 'text-[#76B900]' : 'text-zinc-500 hover:text-zinc-200'
+            }`}
+          >
+            <Settings2 aria-hidden="true" className="w-3 h-3" />
+          </button>
+        )}
+      </div>
       <div className={`flex-1 min-h-0 min-w-0 ${editing ? 'pointer-events-none' : ''}`}>
         {renderPanelContent(panel) ?? <PanelPlaceholder type={panel.type} />}
       </div>
@@ -44,7 +68,7 @@ export function GridPanel({
  * The two ways a panel can have no content, told apart because the operator's
  * next move differs: an unknown type means this build was rolled back past the
  * one that created the panel, while a known type without a component is simply
- * not built yet (#80–#82) and needs no action at all.
+ * not built yet and needs no action at all.
  */
 function PanelPlaceholder({ type }: { type: string }) {
   return (

--- a/frontend/src/components/grid/PanelPalette.tsx
+++ b/frontend/src/components/grid/PanelPalette.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react'
+import { PANEL_TYPE_IDS, defaultPanelTitle, type PanelType } from '@/lib/dashboard/panels'
+import { BarButton } from './BarButton'
+
+/**
+ * Every panel type the dashboard can show, as a list to add from.
+ *
+ * This is where the full vocabulary becomes reachable rather than only
+ * preset-placed — including the types this build renders as a placeholder,
+ * which are still real panels an operator may want a slot kept for.
+ *
+ * **Click-to-add, not drag-from-palette.** The chosen panel is placed in the
+ * first free slot and dragged into position from there, so nothing has to be
+ * aimed at empty space; dragging out of a list is more moving parts and
+ * notably worse on touch. The list closes on the way out for the same reason:
+ * the operator's next move is on the panel that just landed.
+ */
+export function PanelPalette({ onAdd }: { onAdd: (type: PanelType) => void }) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // Click-outside and Escape close it, the way the dashboard's other popover
+  // does — a list covering the page is in the way of the drag that follows.
+  useEffect(() => {
+    if (!open) return
+
+    function onPointerDown(event: MouseEvent | TouchEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('touchstart', onPointerDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('touchstart', onPointerDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <BarButton expanded={open} onClick={() => setOpen((current) => !current)}>
+        Add panel
+      </BarButton>
+
+      {open && (
+        <section
+          aria-label="Panel palette"
+          className="absolute right-0 top-full z-20 mt-1 w-56 max-h-[60vh] overflow-y-auto rounded-md border border-white/[0.08] bg-[#0d0d10] p-1 shadow-xl"
+        >
+          {/* Declaration order is palette order, so related panels sit
+              together where an operator goes looking for them. */}
+          {PANEL_TYPE_IDS.map((type) => (
+            <button
+              key={type}
+              type="button"
+              onClick={() => {
+                setOpen(false)
+                onAdd(type)
+              }}
+              className="w-full text-left px-2 py-1.5 rounded text-xs text-zinc-300 hover:bg-white/[0.06] hover:text-zinc-100 transition-colors"
+            >
+              {defaultPanelTitle(type)}
+            </button>
+          ))}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/grid/PanelPalette.tsx
+++ b/frontend/src/components/grid/PanelPalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useDismissablePopover } from '@/hooks/useDismissablePopover'
 import { PANEL_TYPE_IDS, defaultPanelTitle, type PanelType } from '@/lib/dashboard/panels'
 import { BarButton } from './BarButton'
 
@@ -13,39 +13,15 @@ import { BarButton } from './BarButton'
  * first free slot and dragged into position from there, so nothing has to be
  * aimed at empty space; dragging out of a list is more moving parts and
  * notably worse on touch. The list closes on the way out for the same reason:
- * the operator's next move is on the panel that just landed.
+ * the operator's next move is on the panel that just landed, and a list over
+ * the page is in the way of it.
  */
 export function PanelPalette({ onAdd }: { onAdd: (type: PanelType) => void }) {
-  const [open, setOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-
-  // Click-outside and Escape close it, the way the dashboard's other popover
-  // does — a list covering the page is in the way of the drag that follows.
-  useEffect(() => {
-    if (!open) return
-
-    function onPointerDown(event: MouseEvent | TouchEvent) {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-    function onKey(event: KeyboardEvent) {
-      if (event.key === 'Escape') setOpen(false)
-    }
-
-    document.addEventListener('mousedown', onPointerDown)
-    document.addEventListener('touchstart', onPointerDown)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown)
-      document.removeEventListener('touchstart', onPointerDown)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [open])
+  const { open, setOpen, toggle, containerRef } = useDismissablePopover<HTMLDivElement>()
 
   return (
     <div ref={containerRef} className="relative">
-      <BarButton expanded={open} onClick={() => setOpen((current) => !current)}>
+      <BarButton expanded={open} onClick={toggle}>
         Add panel
       </BarButton>
 

--- a/frontend/src/components/grid/PanelSettings.tsx
+++ b/frontend/src/components/grid/PanelSettings.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react'
 import { useLatestSnapshot } from '@/hooks/useMetricsStore'
-import { bindingChoices, bindingFromChoice } from '@/lib/dashboard/bindingChoices'
+import {
+  bindingChoices,
+  bindingFromChoice,
+  type BindingChoice,
+} from '@/lib/dashboard/bindingChoices'
 import type { PanelBinding } from '@/lib/dashboard/bindings'
 import { defaultPanelTitle, panelBindingKind, panelUsesWindow } from '@/lib/dashboard/panels'
 import type { DashboardPanel } from '@/lib/dashboard/schema'
@@ -130,7 +134,7 @@ function Select({
   onChange,
 }: {
   value: string
-  options: readonly { value: string; label: string; absent?: boolean }[]
+  options: readonly BindingChoice[]
   onChange: (value: string) => void
 }) {
   return (

--- a/frontend/src/components/grid/PanelSettings.tsx
+++ b/frontend/src/components/grid/PanelSettings.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import { useLatestSnapshot } from '@/hooks/useMetricsStore'
+import { bindingChoices, bindingFromChoice } from '@/lib/dashboard/bindingChoices'
+import type { PanelBinding } from '@/lib/dashboard/bindings'
+import { defaultPanelTitle, panelBindingKind, panelUsesWindow } from '@/lib/dashboard/panels'
+import type { DashboardPanel } from '@/lib/dashboard/schema'
+import { snapshotGpus } from '@/lib/identity'
+import { TIME_WINDOWS, type TimeWindow } from '@/types/events'
+import { BarButton } from './BarButton'
+
+interface PanelSettingsProps {
+  panel: DashboardPanel
+  onRename: (title: string) => void
+  onWindowChange: (window: TimeWindow) => void
+  onRepoint: (binding: PanelBinding) => void
+  onRemove: () => void
+  onClose: () => void
+}
+
+/**
+ * What one panel is, as opposed to where it sits: its title, the span its chart
+ * covers, and what it is pointed at.
+ *
+ * It is a row above the grid rather than a form inside the panel, because a
+ * panel can legitimately be one cell tall and a form that size is unusable. The
+ * panel being configured says so in its own frame, which is what ties the two
+ * together.
+ *
+ * Removal lives here rather than as a button on the frame. There is no undo —
+ * discarding the session is the substitute — so deleting a panel is worth the
+ * second click that opening its settings costs.
+ *
+ * Only the controls that mean something for this panel are shown: a host-wide
+ * panel has nothing to pin, and a log tail has no window to cover. A control
+ * that changes nothing is worse than no control at all.
+ */
+export function PanelSettings({
+  panel,
+  onRename,
+  onWindowChange,
+  onRepoint,
+  onRemove,
+  onClose,
+}: PanelSettingsProps) {
+  // What the operator is typing, spaces and all. The stored title is trimmed —
+  // a blank one means "never renamed" — so a field reading back from it would
+  // swallow every space at the moment it was typed. Mounted per panel (the
+  // caller keys it), so switching panels starts the field from that panel's
+  // own title.
+  const [draft, setDraft] = useState(panel.title ?? '')
+
+  // The held snapshot, frozen with the rest of the page: the targets on offer
+  // hold still while the operator is choosing between them.
+  const snapshot = useLatestSnapshot()
+  const source = bindingChoices(
+    panelBindingKind(panel.type),
+    panel.binding,
+    snapshot ? snapshotGpus(snapshot) : [],
+    snapshot?.engines ?? [],
+  )
+
+  return (
+    <section
+      aria-label="Panel settings"
+      className="shrink-0 flex flex-wrap items-center gap-3 mb-2 px-2 py-1.5 rounded-md border border-[#76B900]/30 bg-white/[0.02]"
+    >
+      <Field label="Title">
+        <input
+          type="text"
+          value={draft}
+          // The type's own default, shown as the placeholder: clearing the
+          // field is how a panel goes back to it, so it has to be visible.
+          placeholder={defaultPanelTitle(panel.type)}
+          onChange={(event) => {
+            setDraft(event.target.value)
+            onRename(event.target.value)
+          }}
+          className="w-44 bg-white/[0.03] border border-white/[0.06] rounded-md px-2 py-1 text-[11px] text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-[#76B900]/60"
+        />
+      </Field>
+
+      {panelUsesWindow(panel.type) && (
+        <Field label="Time window">
+          <Select
+            value={panel.window}
+            onChange={(value) => onWindowChange(value as TimeWindow)}
+            options={TIME_WINDOWS.map((window) => ({ value: window, label: window }))}
+          />
+        </Field>
+      )}
+
+      {source.choices.length > 0 && (
+        <Field label="Source">
+          <Select
+            value={source.value}
+            onChange={(value) => onRepoint(bindingFromChoice(value))}
+            options={source.choices}
+          />
+        </Field>
+      )}
+
+      <div className="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-[10px] uppercase tracking-wider px-2 py-1 rounded border border-red-500/30 text-red-300 hover:bg-red-500/10 transition-colors"
+        >
+          Remove panel
+        </button>
+        <BarButton onClick={onClose}>Done</BarButton>
+      </div>
+    </section>
+  )
+}
+
+/** A labelled control. The label wraps its input, so it names it without an id
+ *  that would have to be unique across however many panels a page holds. */
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex items-center gap-2 text-[11px] text-zinc-500">
+      <span className="leading-none">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function Select({
+  value,
+  options,
+  onChange,
+}: {
+  value: string
+  options: readonly { value: string; label: string; absent?: boolean }[]
+  onChange: (value: string) => void
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="bg-white/[0.03] border border-white/[0.06] rounded-md px-2 py-1 text-[11px] text-zinc-200 focus:outline-none focus:ring-1 focus:ring-[#76B900]/60 cursor-pointer"
+    >
+      {options.map((option) => (
+        <option
+          key={option.value}
+          value={option.value}
+          // Kept selectable: a target that is not on this host is still what
+          // the panel is pinned to, and hiding it is how a panel silently ends
+          // up showing something else.
+          className={option.absent ? 'bg-[#0d0d10] text-amber-300' : 'bg-[#0d0d10] text-zinc-200'}
+        >
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/frontend/src/hooks/useDismissablePopover.ts
+++ b/frontend/src/hooks/useDismissablePopover.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+
+/** Everything a popover needs to open, close, and be dismissed. */
+export interface DismissablePopover<T extends HTMLElement> {
+  open: boolean
+  setOpen: (open: boolean) => void
+  toggle: () => void
+  /** Put this on the element that holds the trigger *and* the popover — a
+   *  pointer inside it is not "outside". */
+  containerRef: RefObject<T | null>
+}
+
+/**
+ * A popover that closes when the pointer goes down outside it, or on Escape.
+ *
+ * Both are what a reader expects of anything that covers the page, and getting
+ * either wrong strands the operator behind a panel they cannot dismiss — so the
+ * dashboard has one implementation rather than one per popover.
+ *
+ * Nothing is listened for while it is closed: a page of closed popovers costs
+ * no document-level handlers at all.
+ */
+export function useDismissablePopover<T extends HTMLElement>(): DismissablePopover<T> {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<T | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    function onPointerDown(event: MouseEvent | TouchEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('touchstart', onPointerDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('touchstart', onPointerDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return {
+    open,
+    setOpen,
+    toggle: () => setOpen((current) => !current),
+    containerRef,
+  }
+}

--- a/frontend/src/lib/dashboard/bindingChoices.test.ts
+++ b/frontend/src/lib/dashboard/bindingChoices.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import type { EngineIdentity } from '@/lib/identity'
+import { FOLLOW, UNREADABLE, type PanelBinding } from './bindings'
+import { bindingChoices, bindingFromChoice } from './bindingChoices'
+
+const GPUS = [
+  { index: 0, name: 'NVIDIA GB10' },
+  { index: 1, name: 'NVIDIA GB10' },
+]
+
+// Two engines of the one type the backend detects, which is also the case a
+// pin exists for: same provider, different port.
+const ENGINES: EngineIdentity[] = [
+  { engine_type: 'Vllm', endpoint: 'http://localhost:8000' },
+  { engine_type: 'Vllm', endpoint: 'http://localhost:8001' },
+]
+
+const values = (binding: PanelBinding, kind: 'gpu' | 'engine' | 'none' = 'gpu') =>
+  bindingChoices(kind, binding, GPUS, ENGINES).choices.map((choice) => choice.value)
+
+describe('what a GPU panel can be pointed at', () => {
+  it('offers the page selection and every GPU on the host', () => {
+    expect(values(FOLLOW)).toEqual(['follow', 'gpu:0', 'gpu:1'])
+  })
+
+  it('marks the one the panel is bound to as selected', () => {
+    const control = bindingChoices('gpu', { kind: 'gpu', index: 1 }, GPUS, ENGINES)
+
+    expect(control.value).toBe('gpu:1')
+    expect(control.choices.map((choice) => choice.absent)).not.toContain(true)
+  })
+
+  it('names the GPU, so the operator picks a card rather than a number', () => {
+    const [, first] = bindingChoices('gpu', FOLLOW, GPUS, ENGINES).choices
+
+    expect(first.label).toContain('GPU 0')
+    expect(first.label).toContain('NVIDIA GB10')
+  })
+})
+
+describe('what an engine panel can be pointed at', () => {
+  it('offers the page selection and every engine on the host', () => {
+    expect(values(FOLLOW, 'engine')).toEqual([
+      'follow',
+      'engine:http://localhost:8000',
+      'engine:http://localhost:8001',
+    ])
+  })
+
+  it('names each engine the way the rest of the dashboard does', () => {
+    const [, first] = bindingChoices('engine', FOLLOW, GPUS, ENGINES).choices
+
+    expect(first.label).toContain('vLLM')
+    expect(first.label).toContain('8000')
+  })
+})
+
+describe('a panel bound to something that is not here', () => {
+  it('keeps offering the GPU it is pinned to, marked as absent', () => {
+    // Dropping the option would leave the select showing some other GPU while
+    // the panel is still pinned to this one — the prohibited failure, made
+    // permanent by the next edit.
+    const control = bindingChoices('gpu', { kind: 'gpu', index: 3 }, GPUS, ENGINES)
+
+    expect(control.value).toBe('gpu:3')
+    expect(control.choices.at(-1)).toMatchObject({ value: 'gpu:3', absent: true })
+    expect(control.choices.at(-1)?.label).toContain('GPU 3')
+  })
+
+  it('keeps offering the engine it is pinned to, marked as absent', () => {
+    const gone = 'http://localhost:9999'
+    const control = bindingChoices('engine', { kind: 'engine', endpoint: gone }, GPUS, ENGINES)
+
+    expect(control.value).toBe(`engine:${gone}`)
+    expect(control.choices.at(-1)).toMatchObject({ absent: true })
+    expect(control.choices.at(-1)?.label).toContain(gone)
+  })
+})
+
+describe('a binding the document could not offer', () => {
+  it('shows a panel whose binding could not be read as needing a target', () => {
+    const control = bindingChoices('gpu', UNREADABLE, GPUS, ENGINES)
+
+    expect(control.value).toBe('unreadable')
+    expect(control.choices[0]).toMatchObject({ value: 'unreadable', absent: true })
+    // Everything else is still on offer: repointing is how the panel is
+    // repaired.
+    expect(control.choices.map((choice) => choice.value)).toContain('gpu:0')
+  })
+
+  it('treats a binding of the wrong kind the same way', () => {
+    // An engine binding on a GPU panel is a corrupt document. Resolving it to
+    // some GPU anyway is what must never happen, here as much as at render.
+    expect(
+      bindingChoices('gpu', { kind: 'engine', endpoint: 'http://localhost:8000' }, GPUS, ENGINES)
+        .value,
+    ).toBe('unreadable')
+  })
+})
+
+describe('a panel that binds to nothing', () => {
+  it('is offered no choices at all', () => {
+    // Host-wide panels cover the whole machine; there is nothing to pin.
+    expect(bindingChoices('none', FOLLOW, GPUS, ENGINES).choices).toEqual([])
+  })
+})
+
+describe('a host with nothing to bind to', () => {
+  it('still offers the page selection, so the control is never empty', () => {
+    expect(bindingChoices('engine', FOLLOW, [], []).choices.map((c) => c.value)).toEqual(['follow'])
+  })
+})
+
+describe('reading a choice back', () => {
+  it('round-trips every choice the control offers', () => {
+    for (const binding of [
+      FOLLOW,
+      { kind: 'gpu', index: 1 } as const,
+      { kind: 'engine', endpoint: 'http://localhost:8001' } as const,
+    ]) {
+      const kind = binding.kind === 'engine' ? 'engine' : 'gpu'
+      expect(bindingFromChoice(bindingChoices(kind, binding, GPUS, ENGINES).value)).toEqual(binding)
+    }
+  })
+
+  it('reads an endpoint that has colons of its own', () => {
+    expect(bindingFromChoice('engine:http://localhost:8000')).toEqual({
+      kind: 'engine',
+      endpoint: 'http://localhost:8000',
+    })
+  })
+
+  it('refuses to guess at anything else', () => {
+    // Including the unreadable option itself, which is shown to say what the
+    // panel is, not to be chosen.
+    expect(bindingFromChoice('unreadable')).toEqual(UNREADABLE)
+    expect(bindingFromChoice('gpu:')).toEqual(UNREADABLE)
+    expect(bindingFromChoice('nonsense')).toEqual(UNREADABLE)
+  })
+})

--- a/frontend/src/lib/dashboard/bindingChoices.ts
+++ b/frontend/src/lib/dashboard/bindingChoices.ts
@@ -1,0 +1,134 @@
+/**
+ * What a panel can be pointed at, as a list an operator picks from.
+ *
+ * The mirror image of `bindings`: that module reads a binding and resolves it,
+ * this one offers the ones a panel could have. Both obey the same prohibition —
+ * **no silent substitution**. A panel pinned to a GPU or an engine that is not
+ * on this host keeps its own option, marked absent and selected, because a
+ * control that quietly showed a different target would repoint the panel the
+ * moment anything else about it was edited.
+ *
+ * Pure, so the awkward cases — a pin to something absent, a binding that could
+ * not be read, a binding of the wrong kind for the panel — are covered without
+ * rendering anything.
+ */
+
+import { engineDescription } from '@/lib/format'
+import { findEngineByEndpoint, findGpuByIndex, gpuIndexOf, type EngineIdentity, type GpuIdentity } from '@/lib/identity'
+import type { GpuMetrics } from '@/types/metrics'
+import { FOLLOW, UNREADABLE, type PanelBinding } from './bindings'
+import type { PanelBindingKind } from './panels'
+
+/** The value of the option a panel that follows its page carries. */
+const FOLLOW_CHOICE = 'follow'
+
+/**
+ * The value shown for a binding that names nothing this panel can use. Offered
+ * so the control has something to select — never a target to choose.
+ */
+const UNREADABLE_CHOICE = 'unreadable'
+
+/** One thing a panel could be pointed at. */
+export interface BindingChoice {
+  /** Round-trips through `bindingFromChoice`; safe as an option value. */
+  value: string
+  label: string
+  /** The target is not on this host — a pin left dangling, or a broken binding. */
+  absent?: boolean
+}
+
+/** Everything the control needs: what to offer, and what is selected now. */
+export interface BindingControl {
+  value: string
+  choices: BindingChoice[]
+}
+
+/** A GPU as the control names it. */
+type GpuChoiceSource = GpuIdentity & Pick<GpuMetrics, 'name'>
+
+/**
+ * The targets a panel of this binding kind can be pointed at, with the one it
+ * currently holds selected.
+ *
+ * A panel that binds to nothing gets no choices — there is nothing on a
+ * host-wide panel to pin, and offering a control that does nothing is worse
+ * than offering none.
+ */
+export function bindingChoices(
+  kind: PanelBindingKind,
+  binding: PanelBinding,
+  gpus: readonly GpuChoiceSource[],
+  engines: readonly EngineIdentity[],
+): BindingControl {
+  if (kind === 'none') return { value: FOLLOW_CHOICE, choices: [] }
+
+  const pinned = kind === binding.kind ? binding : null
+  const readable = pinned !== null || binding.kind === 'follow'
+
+  const choices: BindingChoice[] = [
+    // The unreadable option leads, because it is what the panel is right now
+    // and the operator's next move is to replace it.
+    ...(readable ? [] : [{ value: UNREADABLE_CHOICE, label: 'Not readable — choose a target', absent: true }]),
+    { value: FOLLOW_CHOICE, label: kind === 'gpu' ? 'Follow the page’s GPU' : 'Follow the page’s engine' },
+    ...(kind === 'gpu' ? gpus.map(gpuChoice) : engines.map(engineChoice)),
+  ]
+
+  const value = pinned ? choiceOf(pinned) : readable ? FOLLOW_CHOICE : UNREADABLE_CHOICE
+  const missing = pinned && !onThisHost(pinned, gpus, engines) ? absentChoice(pinned) : null
+
+  return { value, choices: missing ? [...choices, missing] : choices }
+}
+
+/**
+ * The binding a chosen option means.
+ *
+ * Anything that is not one of the offered targets — the unreadable option
+ * included — reads as unreadable rather than as a guess. The values come from
+ * this module's own choices, so there is no legitimate third case.
+ */
+export function bindingFromChoice(value: string): PanelBinding {
+  if (value === FOLLOW_CHOICE) return FOLLOW
+
+  const separator = value.indexOf(':')
+  const kind = value.slice(0, separator)
+  const target = value.slice(separator + 1)
+  if (target.length === 0) return UNREADABLE
+
+  if (kind === 'gpu') {
+    const index = Number(target)
+    return Number.isInteger(index) && index >= 0 ? { kind: 'gpu', index } : UNREADABLE
+  }
+
+  return kind === 'engine' ? { kind: 'engine', endpoint: target } : UNREADABLE
+}
+
+function gpuChoice(gpu: GpuChoiceSource): BindingChoice {
+  const index = gpuIndexOf(gpu)
+  return { value: `gpu:${index}`, label: `GPU ${index} — ${gpu.name}` }
+}
+
+function engineChoice(engine: EngineIdentity): BindingChoice {
+  return { value: `engine:${engine.endpoint}`, label: engineDescription(engine) }
+}
+
+/** The option kept for a target the host does not have, so the pin stays visible. */
+function absentChoice(binding: PanelBinding): BindingChoice {
+  const name = binding.kind === 'gpu' ? `GPU ${binding.index}` : binding.kind === 'engine' ? binding.endpoint : ''
+  return { value: choiceOf(binding), label: `${name} (not on this host)`, absent: true }
+}
+
+function onThisHost(
+  binding: PanelBinding,
+  gpus: readonly GpuChoiceSource[],
+  engines: readonly EngineIdentity[],
+): boolean {
+  if (binding.kind === 'gpu') return findGpuByIndex(gpus, binding.index) !== undefined
+  if (binding.kind === 'engine') return findEngineByEndpoint(engines, binding.endpoint) !== undefined
+  return true
+}
+
+function choiceOf(binding: PanelBinding): string {
+  if (binding.kind === 'gpu') return `gpu:${binding.index}`
+  if (binding.kind === 'engine') return `engine:${binding.endpoint}`
+  return binding.kind === 'follow' ? FOLLOW_CHOICE : UNREADABLE_CHOICE
+}

--- a/frontend/src/lib/dashboard/bindingChoices.ts
+++ b/frontend/src/lib/dashboard/bindingChoices.ts
@@ -14,7 +14,13 @@
  */
 
 import { engineDescription } from '@/lib/format'
-import { findEngineByEndpoint, findGpuByIndex, gpuIndexOf, type EngineIdentity, type GpuIdentity } from '@/lib/identity'
+import {
+  findEngineByEndpoint,
+  findGpuByIndex,
+  gpuIndexOf,
+  type EngineIdentity,
+  type GpuIdentity,
+} from '@/lib/identity'
 import type { GpuMetrics } from '@/types/metrics'
 import { FOLLOW, UNREADABLE, type PanelBinding } from './bindings'
 import type { PanelBindingKind } from './panels'
@@ -47,6 +53,13 @@ export interface BindingControl {
 type GpuChoiceSource = GpuIdentity & Pick<GpuMetrics, 'name'>
 
 /**
+ * A binding that names a concrete target. Following and unreadable are the
+ * other two states, and neither has a target to look up, label or keep — so
+ * everything below takes this rather than re-asking which kind it has.
+ */
+type PinnedBinding = Extract<PanelBinding, { kind: 'gpu' } | { kind: 'engine' }>
+
+/**
  * The targets a panel of this binding kind can be pointed at, with the one it
  * currently holds selected.
  *
@@ -62,14 +75,14 @@ export function bindingChoices(
 ): BindingControl {
   if (kind === 'none') return { value: FOLLOW_CHOICE, choices: [] }
 
-  const pinned = kind === binding.kind ? binding : null
+  const pinned = pinnedTarget(kind, binding)
   const readable = pinned !== null || binding.kind === 'follow'
 
   const choices: BindingChoice[] = [
     // The unreadable option leads, because it is what the panel is right now
     // and the operator's next move is to replace it.
-    ...(readable ? [] : [{ value: UNREADABLE_CHOICE, label: 'Not readable — choose a target', absent: true }]),
-    { value: FOLLOW_CHOICE, label: kind === 'gpu' ? 'Follow the page’s GPU' : 'Follow the page’s engine' },
+    ...(readable ? [] : [unreadableChoice()]),
+    { value: FOLLOW_CHOICE, label: followLabel(kind) },
     ...(kind === 'gpu' ? gpus.map(gpuChoice) : engines.map(engineChoice)),
   ]
 
@@ -102,33 +115,57 @@ export function bindingFromChoice(value: string): PanelBinding {
   return kind === 'engine' ? { kind: 'engine', endpoint: target } : UNREADABLE
 }
 
+/**
+ * The panel's binding when it names a target this control could offer, null
+ * otherwise — following, unreadable, or naming the wrong kind of target for
+ * this panel, which is a corrupt document and reads the same way.
+ */
+function pinnedTarget(kind: 'gpu' | 'engine', binding: PanelBinding): PinnedBinding | null {
+  if (kind === 'gpu' && binding.kind === 'gpu') return binding
+  if (kind === 'engine' && binding.kind === 'engine') return binding
+  return null
+}
+
 function gpuChoice(gpu: GpuChoiceSource): BindingChoice {
-  const index = gpuIndexOf(gpu)
-  return { value: `gpu:${index}`, label: `GPU ${index} — ${gpu.name}` }
+  const pin = { kind: 'gpu', index: gpuIndexOf(gpu) } as const
+  return { value: choiceOf(pin), label: `${pinLabel(pin)} — ${gpu.name}` }
 }
 
 function engineChoice(engine: EngineIdentity): BindingChoice {
-  return { value: `engine:${engine.endpoint}`, label: engineDescription(engine) }
+  const pin = { kind: 'engine', endpoint: engine.endpoint } as const
+  return { value: choiceOf(pin), label: engineDescription(engine) }
+}
+
+function unreadableChoice(): BindingChoice {
+  return { value: UNREADABLE_CHOICE, label: 'Not readable — choose a target', absent: true }
 }
 
 /** The option kept for a target the host does not have, so the pin stays visible. */
-function absentChoice(binding: PanelBinding): BindingChoice {
-  const name = binding.kind === 'gpu' ? `GPU ${binding.index}` : binding.kind === 'engine' ? binding.endpoint : ''
-  return { value: choiceOf(binding), label: `${name} (not on this host)`, absent: true }
+function absentChoice(pin: PinnedBinding): BindingChoice {
+  return { value: choiceOf(pin), label: `${pinLabel(pin)} (not on this host)`, absent: true }
 }
 
 function onThisHost(
-  binding: PanelBinding,
+  pin: PinnedBinding,
   gpus: readonly GpuChoiceSource[],
   engines: readonly EngineIdentity[],
 ): boolean {
-  if (binding.kind === 'gpu') return findGpuByIndex(gpus, binding.index) !== undefined
-  if (binding.kind === 'engine') return findEngineByEndpoint(engines, binding.endpoint) !== undefined
-  return true
+  return pin.kind === 'gpu'
+    ? findGpuByIndex(gpus, pin.index) !== undefined
+    : findEngineByEndpoint(engines, pin.endpoint) !== undefined
 }
 
-function choiceOf(binding: PanelBinding): string {
-  if (binding.kind === 'gpu') return `gpu:${binding.index}`
-  if (binding.kind === 'engine') return `engine:${binding.endpoint}`
-  return binding.kind === 'follow' ? FOLLOW_CHOICE : UNREADABLE_CHOICE
+/** The one place a target becomes an option value, and the only grammar
+ *  `bindingFromChoice` has to read back. */
+function choiceOf(pin: PinnedBinding): string {
+  return pin.kind === 'gpu' ? `gpu:${pin.index}` : `engine:${pin.endpoint}`
+}
+
+/** How a target is named to the operator, on its own. */
+function pinLabel(pin: PinnedBinding): string {
+  return pin.kind === 'gpu' ? `GPU ${pin.index}` : pin.endpoint
+}
+
+function followLabel(kind: 'gpu' | 'engine'): string {
+  return kind === 'gpu' ? 'Follow the page’s GPU' : 'Follow the page’s engine'
 }

--- a/frontend/src/lib/dashboard/editing.test.ts
+++ b/frontend/src/lib/dashboard/editing.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { FOLLOW } from './bindings'
+import { FOLLOW, UNREADABLE } from './bindings'
 import {
+  addPanel,
   applyLayoutChanges,
   judgeDrop,
   refusedPanelTitle,
+  removePanel,
+  renamePanel,
+  repointPanel,
   requestedCells,
+  setPanelWindow,
   withPagePanels,
 } from './editing'
+import { defaultPanelSize } from './panels'
 import { GRID_COLUMNS, GRID_MAX_ROWS, type PanelGeometry } from './grid'
 import { DEFAULT_TIME_WINDOW, type DashboardDocument, type DashboardPanel } from './schema'
 
@@ -188,5 +194,131 @@ describe('naming the panel a refusal is about', () => {
 
     expect(refusedPanelTitle(panels, null)).toBeNull()
     expect(refusedPanelTitle(panels, 'a-panel-since-removed')).toBeNull()
+  })
+})
+
+describe('adding a panel from the palette', () => {
+  it('places it in the first free slot, so nothing has to be aimed at', () => {
+    // The left half of the top rows is taken; reading order puts the new panel
+    // immediately to its right rather than below everything.
+    const outcome = addPanel([panel('a', at(0, 0, 6, 3))], 'gpu-power')
+
+    expect(outcome).toMatchObject({ status: 'added' })
+    if (outcome.status !== 'added') return
+    expect(outcome.panels).toHaveLength(2)
+    expect(outcome.panels[1].geometry).toEqual({ x: 6, y: 0, ...defaultPanelSize('gpu-power') })
+  })
+
+  it('adds it at the size its type asks for', () => {
+    const outcome = addPanel([], 'logs')
+
+    expect(outcome.status === 'added' && outcome.panels[0].geometry).toEqual({
+      x: 0,
+      y: 0,
+      ...defaultPanelSize('logs'),
+    })
+  })
+
+  it('leaves it following the page, so it renders on any host', () => {
+    // A panel pinned at birth would name a target the operator never chose,
+    // and would be wrong on the next machine the layout is opened on.
+    const outcome = addPanel([], 'gpu-power')
+
+    expect(outcome.status === 'added' && outcome.panels[0]).toMatchObject({
+      type: 'gpu-power',
+      binding: FOLLOW,
+      window: DEFAULT_TIME_WINDOW,
+    })
+    // No title: the type's default is used, so renaming a default later
+    // reaches panels an operator added but never renamed.
+    expect(outcome.status === 'added' && 'title' in outcome.panels[0]).toBe(false)
+  })
+
+  it('gives the panel an id no other panel on the page holds', () => {
+    const first = addPanel([], 'gpu-power')
+    const second = first.status === 'added' ? addPanel(first.panels, 'gpu-power') : first
+
+    expect(second.status === 'added' && second.panels.map((p) => p.id)).toEqual([
+      'gpu-power',
+      'gpu-power-2',
+    ])
+  })
+
+  it('refuses when the page has no room, and changes nothing', () => {
+    // The refusal is per panel size rather than per page: what is full is the
+    // space this panel would need, which is the only thing the operator can act
+    // on.
+    const full = [panel('a', at(0, 0, GRID_COLUMNS, GRID_MAX_ROWS))]
+
+    expect(addPanel(full, 'gpu-power')).toEqual({ status: 'out-of-room' })
+  })
+})
+
+describe('removing a panel', () => {
+  it('drops the one named and leaves the rest where they are', () => {
+    const panels = [panel('a', at(0, 0, 6, 4)), panel('b', at(6, 0, 6, 4))]
+
+    expect(removePanel(panels, 'a')).toEqual([panels[1]])
+  })
+
+  it('hands back the very same list when the page has no such panel', () => {
+    const panels = [panel('a', at(0, 0, 6, 4))]
+
+    expect(removePanel(panels, 'ghost')).toBe(panels)
+  })
+})
+
+describe('renaming a panel', () => {
+  it('puts the operator’s own words in the title', () => {
+    const [renamed] = renamePanel([panel('a', at(0, 0, 6, 4))], 'a', 'Node 3 RAM')
+
+    expect(renamed.title).toBe('Node 3 RAM')
+  })
+
+  it('drops the title entirely when it is cleared', () => {
+    // Absent, not empty: the panel goes back to reading as its type's default
+    // rather than rendering a blank header, and the document says so.
+    const titled = [{ ...panel('a', at(0, 0, 6, 4)), title: 'Node 3 RAM' }]
+
+    expect('title' in renamePanel(titled, 'a', '   ')[0]).toBe(false)
+  })
+
+  it('changes nothing else about the panel', () => {
+    const original = panel('a', at(0, 0, 6, 4))
+
+    expect(renamePanel([original], 'a', 'Node 3 RAM')[0]).toEqual({
+      ...original,
+      title: 'Node 3 RAM',
+    })
+  })
+})
+
+describe('a panel’s own time window', () => {
+  it('is set on that panel alone, so two can differ on one page', () => {
+    const panels = [panel('a', at(0, 0, 6, 4)), panel('b', at(6, 0, 6, 4))]
+
+    const next = setPanelWindow(panels, 'b', '15m')
+
+    expect(next.map((p) => p.window)).toEqual([DEFAULT_TIME_WINDOW, '15m'])
+  })
+})
+
+describe('pointing a panel at a target', () => {
+  it('pins it to the target the operator chose', () => {
+    const [pinned] = repointPanel([panel('a', at(0, 0, 6, 4))], 'a', { kind: 'gpu', index: 2 })
+
+    expect(pinned.binding).toEqual({ kind: 'gpu', index: 2 })
+  })
+
+  it('puts it back to following the page', () => {
+    const pinned = [{ ...panel('a', at(0, 0, 6, 4)), binding: { kind: 'gpu', index: 2 } as const }]
+
+    expect(repointPanel(pinned, 'a', FOLLOW)[0].binding).toEqual(FOLLOW)
+  })
+
+  it('is how a binding that could not be read is repaired', () => {
+    const broken = [{ ...panel('a', at(0, 0, 6, 4)), binding: UNREADABLE }]
+
+    expect(repointPanel(broken, 'a', FOLLOW)[0].binding).toEqual(FOLLOW)
   })
 })

--- a/frontend/src/lib/dashboard/editing.ts
+++ b/frontend/src/lib/dashboard/editing.ts
@@ -218,7 +218,10 @@ export function addPanel(panels: readonly DashboardPanel[], type: PanelType): Ad
     panelId,
     // No title: the type's own default is used, so a default reworded in a
     // later release reaches every panel nobody renamed.
-    panels: [...panels, { id: panelId, type, geometry, binding: FOLLOW, window: DEFAULT_TIME_WINDOW }],
+    panels: [
+      ...panels,
+      { id: panelId, type, geometry, binding: FOLLOW, window: DEFAULT_TIME_WINDOW },
+    ],
   }
 }
 

--- a/frontend/src/lib/dashboard/editing.ts
+++ b/frontend/src/lib/dashboard/editing.ts
@@ -1,16 +1,30 @@
 /**
- * The rules of an edit session: what a layout change does to a page, and what
- * to make of a drag or resize the grid did not grant.
+ * The rules of an edit session: what a layout change does to a page, what an
+ * operator's own edits do to it, and what to make of a drag, resize or addition
+ * the page had no room for.
  *
  * Everything here is pure, so the two things that are otherwise only reachable
  * with a real layout engine — normalizing what the grid library reports, and
  * telling a refused drop from a satisfied one — are covered without a browser.
  * The session itself (what is being edited, and when it is written) lives in
- * `useEditSession`; nothing in this module knows about React or the server.
+ * `GridPageEditor`; nothing in this module knows about React or the server.
+ *
+ * Every edit is a **replacement**: a panel list in, a new panel list out, with
+ * the untouched panels kept by identity. The session holds the result, and
+ * nothing reaches the server until the operator saves.
  */
 
-import { readGeometry, GRID_COLUMNS, type PanelGeometry } from './grid'
-import { panelTitle, type DashboardDocument, type DashboardPanel } from './schema'
+import type { PanelBinding } from './bindings'
+import { FOLLOW } from './bindings'
+import { firstFreeSlot, readGeometry, GRID_COLUMNS, type PanelGeometry } from './grid'
+import { defaultPanelSize, type PanelType } from './panels'
+import {
+  panelTitle,
+  DEFAULT_TIME_WINDOW,
+  type DashboardDocument,
+  type DashboardPanel,
+} from './schema'
+import type { TimeWindow } from '@/types/events'
 
 /** Where the grid says a panel now sits. */
 export interface LayoutChange {
@@ -166,6 +180,134 @@ export function refusedPanelTitle(
 ): string | null {
   const refused = panels.find((panel) => panel.id === panelId)
   return refused ? panelTitle(refused) : null
+}
+
+/** What became of a click on the palette. */
+export type AddPanelOutcome =
+  | { status: 'added'; panels: DashboardPanel[]; panelId: string }
+  /** Nothing on the page could make way for a panel of this size. */
+  | { status: 'out-of-room' }
+
+/**
+ * The page with one more panel of `type`, placed in the first free slot.
+ *
+ * Click-to-add rather than drag-from-palette: the operator picks a type and the
+ * panel appears where their eye already is, then they drag it into position.
+ * Aiming a drag at empty space is the thing this avoids, and it is much the
+ * worse of the two on touch.
+ *
+ * The new panel **follows the page** and takes the default window. Pinning it
+ * at birth would name a target the operator never chose — and one that may not
+ * exist on the next host the layout is opened on.
+ *
+ * Out of room is a first-class outcome rather than a silent no-op: the page is
+ * a fixed number of rows, so "there is nowhere to put this" is a state the
+ * operator is owed an explanation for.
+ */
+export function addPanel(panels: readonly DashboardPanel[], type: PanelType): AddPanelOutcome {
+  const geometry = firstFreeSlot(
+    panels.map((panel) => panel.geometry),
+    defaultPanelSize(type),
+  )
+  if (!geometry) return { status: 'out-of-room' }
+
+  const panelId = unusedPanelId(panels, type)
+
+  return {
+    status: 'added',
+    panelId,
+    // No title: the type's own default is used, so a default reworded in a
+    // later release reaches every panel nobody renamed.
+    panels: [...panels, { id: panelId, type, geometry, binding: FOLLOW, window: DEFAULT_TIME_WINDOW }],
+  }
+}
+
+/**
+ * The page without the panel named. There is no undo — discarding the session
+ * is the substitute — so removal is offered from the panel's own settings
+ * rather than as a one-click affordance on the frame.
+ */
+export function removePanel(
+  panels: readonly DashboardPanel[],
+  panelId: string,
+): DashboardPanel[] {
+  const next = panels.filter((panel) => panel.id !== panelId)
+  return next.length === panels.length ? (panels as DashboardPanel[]) : next
+}
+
+/**
+ * The page with one panel titled in the operator's own vocabulary.
+ *
+ * A title that is blank or only whitespace is **dropped** rather than stored:
+ * the panel goes back to reading as its type's default, which is the only way
+ * back from a rename once the original wording is gone.
+ */
+export function renamePanel(
+  panels: readonly DashboardPanel[],
+  panelId: string,
+  title: string,
+): DashboardPanel[] {
+  const trimmed = title.trim()
+
+  return mapPanel(panels, panelId, (panel) => {
+    if (trimmed.length > 0) return { ...panel, title: trimmed }
+    const cleared = { ...panel }
+    delete cleared.title
+    return cleared
+  })
+}
+
+/**
+ * The page with one panel's chart covering a different span. Per panel, so a
+ * short spike and a longer trend can sit side by side on the same page.
+ */
+export function setPanelWindow(
+  panels: readonly DashboardPanel[],
+  panelId: string,
+  window: TimeWindow,
+): DashboardPanel[] {
+  return mapPanel(panels, panelId, (panel) => ({ ...panel, window }))
+}
+
+/**
+ * The page with one panel pointed somewhere else — pinned to a concrete GPU or
+ * engine, or put back to following the page's selection.
+ *
+ * This is also the only repair for a binding that could not be read: the panel
+ * says it needs repointing, and repointing it is what the operator does.
+ */
+export function repointPanel(
+  panels: readonly DashboardPanel[],
+  panelId: string,
+  binding: PanelBinding,
+): DashboardPanel[] {
+  return mapPanel(panels, panelId, (panel) => ({ ...panel, binding }))
+}
+
+/**
+ * An id nothing else on the page holds, derived from the type so a saved
+ * document reads as what it is. Ids are unique per page, and the grid keys its
+ * items by them, so a collision would put two panels in one slot.
+ */
+function unusedPanelId(panels: readonly DashboardPanel[], type: string): string {
+  const taken = new Set(panels.map((panel) => panel.id))
+  if (!taken.has(type)) return type
+
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${type}-${suffix}`
+    if (!taken.has(candidate)) return candidate
+  }
+}
+
+/** One panel replaced, the others kept by identity. The same list back when the
+ *  page has no panel by that id — a panel removed under an open settings row. */
+function mapPanel(
+  panels: readonly DashboardPanel[],
+  panelId: string,
+  edit: (panel: DashboardPanel) => DashboardPanel,
+): DashboardPanel[] {
+  if (!panels.some((panel) => panel.id === panelId)) return panels as DashboardPanel[]
+  return panels.map((panel) => (panel.id === panelId ? edit(panel) : panel))
 }
 
 function samePlacement(a: PanelGeometry, b: PanelGeometry): boolean {

--- a/frontend/src/lib/dashboard/panels.test.ts
+++ b/frontend/src/lib/dashboard/panels.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest'
+import { GRID_COLUMNS, GRID_MAX_ROWS } from './grid'
 import {
   PANEL_TYPES,
   PANEL_TYPE_IDS,
+  defaultPanelSize,
   defaultPanelTitle,
   isKnownPanelType,
   panelBindingKind,
+  panelUsesWindow,
 } from './panels'
 
 describe('the panel type vocabulary', () => {
@@ -87,6 +90,47 @@ describe('panelBindingKind', () => {
     // Nothing can be bound for a panel this build cannot render at all; it
     // shows an unsupported-panel placeholder instead.
     expect(panelBindingKind('gpu-voltage')).toBe('none')
+  })
+})
+
+describe('defaultPanelSize', () => {
+  it('gives every panel type a size that fits an empty page', () => {
+    // A size no page could ever hold would make its palette entry permanently
+    // refusable, which reads as a broken palette rather than as a full page.
+    for (const id of PANEL_TYPE_IDS) {
+      const { w, h } = defaultPanelSize(id)
+      expect(w, id).toBeGreaterThanOrEqual(1)
+      expect(h, id).toBeGreaterThanOrEqual(1)
+      expect(w, id).toBeLessThanOrEqual(GRID_COLUMNS)
+      expect(h, id).toBeLessThanOrEqual(GRID_MAX_ROWS)
+    }
+  })
+
+  it('gives a log panel the extra width a line of output needs', () => {
+    expect(defaultPanelSize('logs').w).toBeGreaterThan(defaultPanelSize('gpu-power').w)
+  })
+
+  it('falls back to the standard size for an unimplemented panel', () => {
+    // A rolled-back build cannot add one of these from the palette, but the
+    // size is still asked for wherever a panel is placed by type.
+    expect(defaultPanelSize('gpu-voltage')).toEqual(defaultPanelSize('gpu-power'))
+  })
+})
+
+describe('panelUsesWindow', () => {
+  it('reports a charting panel as covering a time window', () => {
+    expect(panelUsesWindow('gpu-power')).toBe(true)
+    expect(panelUsesWindow('engine-latency')).toBe(true)
+  })
+
+  it('reports the log panel as not covering one', () => {
+    // Logs are a live tail of whatever the engine last printed, so offering a
+    // window to choose would be a control that changes nothing.
+    expect(panelUsesWindow('logs')).toBe(false)
+  })
+
+  it('reports an unimplemented panel as not covering one', () => {
+    expect(panelUsesWindow('gpu-voltage')).toBe(false)
   })
 })
 

--- a/frontend/src/lib/dashboard/panels.ts
+++ b/frontend/src/lib/dashboard/panels.ts
@@ -13,6 +13,8 @@
  * Adding one is additive and needs none.
  */
 
+import type { PanelSize } from './grid'
+
 /** What a panel needs pointed at it before it can show anything. */
 export type PanelBindingKind =
   /** One GPU, identified by its integer index. */
@@ -28,7 +30,25 @@ export interface PanelTypeSpec {
   binds: PanelBindingKind
   /** Title shown when the operator has not renamed the panel. */
   title: string
+  /**
+   * Size the palette places the panel at, when the standard one is wrong for
+   * it. Only a starting point — the operator drags and resizes from there — so
+   * a type only declares this when the standard size would land it unreadable.
+   */
+  size?: PanelSize
+  /**
+   * Whether the panel's rendering covers the time window it carries. Absent
+   * means it does, which is true of every panel that charts a series; a type
+   * declares `false` when its window would be a control that changes nothing.
+   */
+  windowed?: boolean
 }
+
+/**
+ * What a panel is added at: a quarter of the grid's width and a bit under half
+ * its height, so four sit in a row and the page still tiles.
+ */
+export const DEFAULT_PANEL_SIZE: PanelSize = { w: 3, h: 3 }
 
 /**
  * The vocabulary. Declaration order is palette order, so related panels sit
@@ -65,8 +85,9 @@ export const PANEL_TYPES = {
   'engine-spec-decode': { binds: 'engine', title: 'Speculative Decoding' },
   'inference-timeline': { binds: 'engine', title: 'Inference Requests' },
   // The log socket addresses an engine by endpoint, so logs bind like any
-  // other engine panel instead of being a fixed drawer.
-  logs: { binds: 'engine', title: 'Logs' },
+  // other engine panel instead of being a fixed drawer. A line of container
+  // output is long, and a tail has no window to cover.
+  logs: { binds: 'engine', title: 'Logs', size: { w: 6, h: 4 }, windowed: false },
 } as const satisfies Record<string, PanelTypeSpec>
 
 /** A panel type this build implements. */
@@ -102,4 +123,34 @@ export function panelBindingKind(type: string): PanelBindingKind {
  */
 export function defaultPanelTitle(type: string): string {
   return isKnownPanelType(type) ? PANEL_TYPES[type].title : type
+}
+
+/**
+ * The cells a newly placed panel takes. Click-to-add puts the panel in the
+ * first free slot of this size and the operator moves it from there, so this
+ * only has to be a sane starting point rather than the right answer.
+ */
+export function defaultPanelSize(type: string): PanelSize {
+  return (isKnownPanelType(type) ? panelSpec(type).size : undefined) ?? DEFAULT_PANEL_SIZE
+}
+
+/**
+ * Whether the panel's own time window reaches its rendering — the question the
+ * settings ask before offering the operator a window to choose.
+ *
+ * An unimplemented type answers false: it renders a placeholder, so nothing it
+ * carries reaches a chart. Its stored window is left untouched all the same,
+ * because the build that understands the type will want it.
+ */
+export function panelUsesWindow(type: string): boolean {
+  return isKnownPanelType(type) && panelSpec(type).windowed !== false
+}
+
+/**
+ * One type's declaration, read as the interface rather than as its own literal
+ * type — which is what makes the optional fields readable on the types that
+ * leave them out.
+ */
+function panelSpec(type: PanelType): PanelTypeSpec {
+  return PANEL_TYPES[type]
 }

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -27,6 +27,10 @@ export const TIME_WINDOW_SECONDS: Record<TimeWindow, number> = {
   '15m': 900,
 }
 
-/** Every window a panel can cover, shortest first — the order they are offered
- *  in. Derived from the table above so the two cannot drift apart. */
-export const TIME_WINDOWS = Object.keys(TIME_WINDOW_SECONDS) as TimeWindow[]
+/**
+ * Every window a panel can cover, shortest first — the order they are offered
+ * in. Written out rather than derived from the table above, because the order
+ * is part of what this is and object key order is not something to lean on; a
+ * spec holds the two in step.
+ */
+export const TIME_WINDOWS: readonly TimeWindow[] = ['5m', '10m', '15m']

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -26,3 +26,7 @@ export const TIME_WINDOW_SECONDS: Record<TimeWindow, number> = {
   '10m': 600,
   '15m': 900,
 }
+
+/** Every window a panel can cover, shortest first — the order they are offered
+ *  in. Derived from the table above so the two cannot drift apart. */
+export const TIME_WINDOWS = Object.keys(TIME_WINDOW_SECONDS) as TimeWindow[]


### PR DESCRIPTION
Closes #84.

An operator can now change *what* a page contains, not only where things sit.

## What this adds

- **A palette** listing every registered panel type, including the log panel and the types this build still renders as placeholders. **Click-to-add** places the chosen panel in the first free slot, in reading order, and it is dragged into position from there — drag-from-palette was rejected in #70 as more moving parts and notably worse on touch.
- **Per-panel settings**, opened from a gear on the panel's frame while editing: title, the time window the chart covers, the source it is bound to, and removal. The settings are a row above the grid rather than a form inside the panel, because a panel can legitimately be one cell tall.
- **Pinning**: a panel goes from `follow` to a concrete GPU or engine and back. A pin to a target this host does not have keeps its own option, marked, rather than being quietly replaced by one that is here — the same prohibition on silent substitution that binding resolution follows.
- **No room is a state, not a silent no-op.** A panel that fits nowhere is refused in the same place, and in the same terms, as a drop the grid will not take; only the advice differs.

Removal sits behind the settings rather than one click on the frame: there is no undo, and discarding the whole session is the only way back.

## Acceptance criteria

- [x] The palette lists every registered panel type, including the log panel
- [x] Clicking a type places it in the first free slot; with no free slot the refusal is visible and comprehensible
- [x] A panel can be removed and its title renamed; both survive save and reload
- [x] Two panels on one page can carry different time windows, and each chart's span reflects its own
- [x] A panel can be pinned from `follow` to a concrete target and back, and that survives save and reload
- [x] A pinned panel never shows a source other than the one its label names
- [x] `npm run lint && npm run build && npm test -- --run` green

## Commits

1. `feat(frontend): panel-list edits an operator makes by hand` — the pure edits (add/remove/rename/window/binding), plus the two things placement and configuration need to ask of a panel type: the size it is added at, and whether its window reaches its rendering at all.
2. `feat(frontend): the targets a panel can be pinned to` — the mirror image of binding resolution, as a list to pick from.
3. `feat(frontend): a palette that places a panel in the first free slot`
4. `feat(frontend): per-panel settings for title, window, source and removal`
5. `refactor(frontend): review follow-ups for the palette and panel settings` — one shared dismissable-popover hook (the SLO control had the same effect copied), a pinned-binding type that removes the repeated `kind` cascades, and coverage for the palette's two ways of being dismissed.

## Testing

Test-first at the pure seams (`editing`, `bindingChoices`, `panels`), then at the application seam: `App.panelEditing.test.tsx` drives real routing, real configuration load/save over the fetch stub and real panels reading the real store, asserting each behaviour as the operator sees it and again after a save and a reload.

- `npm run lint` clean, `npm run build` clean
- 615 unit tests green, 14 browser tests green
- No new browser-mode specs: nothing here depends on layout — placement and refusal are computed by the pure grid module. The browser suite is #87.

Also verified by hand on the Spark (dev instance on :3001 with its own state directory, `--simulate-gpus 1` for a second GPU): the gear opens settings without starting a drag, the palette overlays and dismisses correctly, add/rename/pin/window all survive save and reload.

## Scope

Nothing here touches pages and resets (#85), the default preset or the cutover (#86), or the browser suite (#87). No Rust, and no change to the metrics contract.