### PR TITLE
feat(frontend): multiple pages with header tabs, URLs and resets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ Thumbs.db
 # Claude Code workspace
 .claude/
 .gstack/
+# Playwright CLI output (may contain credentials)
+.playwright-cli/

--- a/README.md
+++ b/README.md
@@ -323,8 +323,13 @@ Each page has its own URL, built from a stable id plus a readable slug:
 
 ```
 /pages/<id>            e.g. /pages/overview
-/pages/<id>/<slug>     e.g. /pages/p-7f3a/training-view
+/pages/<id>/<slug>     e.g. /pages/overview/wall-display
 ```
+
+The id is fixed when the page is created and never changes again; the slug is
+whatever the page is called now, and is omitted when it would only repeat the
+id. The second example above is the page created as *Overview* and since
+renamed to *Wall Display*.
 
 **Only the id is matched** — the slug is decoration. Renaming a page rewrites
 the slug and leaves the id alone, so a kiosk browser or a bookmark pointed at

--- a/README.md
+++ b/README.md
@@ -311,6 +311,33 @@ curl -X DELETE localhost:3000/api/dashboard                # reset
 
 Unmatched paths under `/api` return `404` rather than the app shell.
 
+### Dashboard pages and kiosk URLs
+
+A configuration holds any number of named **pages** — separate arrangements of
+panels, kept side by side rather than one being chosen permanently. They are
+created, renamed and deleted from the **Pages** menu in the header, and switched
+between from the tabs beside it; tabs that do not fit the header move into an
+overflow menu rather than pushing it out of shape.
+
+Each page has its own URL, built from a stable id plus a readable slug:
+
+```
+/pages/<id>            e.g. /pages/overview
+/pages/<id>/<slug>     e.g. /pages/p-7f3a/training-view
+```
+
+**Only the id is matched** — the slug is decoration. Renaming a page rewrites
+the slug and leaves the id alone, so a kiosk browser or a bookmark pointed at
+the old URL still lands on the same page. Pointing a wall display at one page's
+URL is what makes it come back to that page after a reboot with no interaction.
+
+Resetting is two-tiered: deleting a single page from the Pages menu takes that
+page only, while **Reset everything** asks for confirmation and then removes the
+stored document outright — which is the same `DELETE /api/dashboard` above, and
+leaves the dashboard rendering its default preset. The dashboard always keeps at
+least one page, so the last one cannot be deleted; resetting is the way to start
+over.
+
 ### Log viewer (`--enable-log-viewer`, Linux only, opt-in)
 
 `--enable-log-viewer` (or the `SPARK_DASHBOARD_ENABLE_LOG_VIEWER=1` env var)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { ConfigurationNotices } from './components/ConfigurationNotices'
 import { Dashboard } from './components/views/Dashboard'
 import { GridPageEditor } from './components/grid/GridPageEditor'
 import { LogViewer } from './components/LogViewer'
+import { PageBar } from './components/pages/PageBar'
 import { withPagePanels } from './lib/dashboard/editing'
 import type { SaveOutcome } from './lib/dashboard/client'
 import type { DashboardPanel } from './lib/dashboard/schema'
@@ -99,7 +100,12 @@ function AppContent() {
 function GridPageContent({ pageId }: { pageId: string }) {
   const { metrics, connectionStatus, isStale } = useMetrics()
   useMetricsIngest(metrics)
-  const { document, notices: configurationNotices, readOnly, save } = useDashboardConfiguration()
+  const { document, notices: configurationNotices, readOnly, save, reset } =
+    useDashboardConfiguration()
+  // The edit session lives in the editor below, but the header has to know about
+  // it: switching pages unmounts the session, so the page list holds still for
+  // as long as there is unsaved work in it.
+  const [editing, setEditing] = useState(false)
 
   // Null document means the load has not resolved; rendering nothing beats
   // flashing the preset past an operator whose real page is milliseconds away.
@@ -118,14 +124,35 @@ function GridPageContent({ pageId }: { pageId: string }) {
 
   return (
     <div className="h-dvh flex flex-col bg-[#08080a] overflow-hidden">
-      <AppHeader status={connectionStatus} isStale={isStale} />
+      <AppHeader
+        status={connectionStatus}
+        isStale={isStale}
+        pages={
+          document && (
+            <PageBar
+              document={document}
+              activePageId={pageId}
+              readOnly={readOnly}
+              editing={editing}
+              save={save}
+              reset={reset}
+            />
+          )
+        }
+      />
 
       <ConfigurationNotices notices={configurationNotices} />
 
       <main className="flex-1 min-h-0 p-3 lg:p-4 2xl:p-5 min-[1920px]:p-6">
         {document &&
           (page ? (
-            <GridPageEditor key={page.id} page={page} readOnly={readOnly} onSave={savePanels} />
+            <GridPageEditor
+              key={page.id}
+              page={page}
+              readOnly={readOnly}
+              onSave={savePanels}
+              onEditingChange={setEditing}
+            />
           ) : (
             <div className="h-full flex items-center justify-center">
               <div className="text-center">

--- a/frontend/src/__tests__/App.pages.test.tsx
+++ b/frontend/src/__tests__/App.pages.test.tsx
@@ -1,0 +1,384 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+import {
+  configurationResets,
+  configurationResponse,
+  configurationWrites,
+  serveConfiguration,
+  type FetchMock,
+} from '../test/configurationServer'
+import { gridSubstitute } from '../test/gridSubstitute'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+import { DASHBOARD_SCHEMA_VERSION, type DashboardPage } from '../lib/dashboard/schema'
+
+// Multiple pages through the application seam (#85): real routing and history,
+// real configuration loading, saving and resetting over the fetch stub, and the
+// shared jsdom grid substitute standing in for the layout engine. Every
+// assertion is what an operator sees — a tab, an address bar, a page that came
+// back after a reload — rather than how the document is shaped on the way there.
+//
+// jsdom measures every box as 0×0, so the tab strip here always has room for
+// every tab. What happens when it does not is `pageTabs.browser.test.tsx`.
+substituteWebSocket()
+
+/** One panel, so a page is told apart by what is on it rather than by its name alone. */
+function pageOf(id: string, name: string, panelType: string): Record<string, unknown> {
+  return {
+    id,
+    name,
+    panels: [{ id: 'only', type: panelType, geometry: { x: 0, y: 0, w: 6, h: 3 } }],
+  }
+}
+
+function storedDocument(...pages: Array<Record<string, unknown>>): string {
+  return JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION, pages })
+}
+
+/** The two-page configuration most of these specs start from. */
+function twoPages(): string {
+  return storedDocument(
+    pageOf('watch', 'Watch', 'cpu-utilization'),
+    pageOf('wall', 'Wall Display', 'memory'),
+  )
+}
+
+async function openPage(fetchMock: FetchMock, pathname = '/pages/watch') {
+  window.history.replaceState(null, '', pathname)
+  render(<App />)
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+  await act(() => configurationResponse(fetchMock))
+}
+
+const tabs = () => screen.getByRole('navigation', { name: 'Pages' })
+const tabNames = () =>
+  within(tabs())
+    .getAllByRole('link')
+    .map((tab) => tab.textContent)
+
+const menu = () => screen.getByRole('region', { name: 'Page settings' })
+
+async function openMenu() {
+  await userEvent.click(screen.getByRole('button', { name: 'Pages' }))
+}
+
+/** The pages of the single write the spec expects, as the server stored them. */
+function savedPages(fetchMock: FetchMock): DashboardPage[] {
+  const writes = configurationWrites(fetchMock)
+  expect(writes).toHaveLength(1)
+  return JSON.parse(writes[0]).pages
+}
+
+/** Re-opens the application against exactly what the server is now holding. */
+async function reload(fetchMock: FetchMock, pathname: string): Promise<FetchMock> {
+  cleanup()
+  gridSubstitute.reset()
+  // The same stub keeps serving: it holds what was written, which is the only
+  // way a reload can be said to have restored anything.
+  await openPage(fetchMock, pathname)
+  return fetchMock
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  gridSubstitute.reset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.history.replaceState(null, '', '/')
+})
+
+describe('the page tabs', () => {
+  it('names every page in the configuration', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }))
+
+    expect(tabNames()).toEqual(['Watch', 'Wall Display'])
+  })
+
+  it('marks the page the URL names as the one being viewed', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }), '/pages/wall')
+
+    expect(within(tabs()).getByRole('link', { current: 'page' })).toHaveTextContent('Wall Display')
+  })
+
+  it('switches page in one click, without reloading the document', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }))
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+
+    await userEvent.click(within(tabs()).getByRole('link', { name: 'Wall Display' }))
+
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'CPU' })).not.toBeInTheDocument()
+  })
+
+  it('puts the page it switched to in the address bar, so a reload stays there', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await userEvent.click(within(tabs()).getByRole('link', { name: 'Wall Display' }))
+    expect(window.location.pathname).toBe('/pages/wall/wall-display')
+
+    await reload(fetchMock, window.location.pathname)
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+  })
+
+  it('leaves the tab a real link, so a kiosk URL can be copied out of it', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }))
+
+    expect(within(tabs()).getByRole('link', { name: 'Wall Display' })).toHaveAttribute(
+      'href',
+      '/pages/wall/wall-display',
+    )
+  })
+
+  it('comes back to the previous page on the browser’s back button', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }))
+    await userEvent.click(within(tabs()).getByRole('link', { name: 'Wall Display' }))
+
+    act(() => window.history.back())
+    await waitFor(() => expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument())
+  })
+
+  it('shows no tabs on the root dashboard, which the grid has not taken over yet', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }), '/')
+
+    expect(screen.queryByRole('navigation', { name: 'Pages' })).not.toBeInTheDocument()
+  })
+})
+
+describe('creating a page', () => {
+  it('stores the new page and lands the operator on it, empty and ready to fill', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(screen.getByRole('button', { name: 'New page' }))
+
+    await waitFor(() => expect(window.location.pathname).toBe('/pages/page-3'))
+    expect(savedPages(fetchMock).map((page) => page.name)).toEqual([
+      'Watch',
+      'Wall Display',
+      'Page 3',
+    ])
+    expect(screen.queryAllByRole('region')).toEqual([])
+  })
+
+  it('survives a reload, which is the only reason to store it at all', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(screen.getByRole('button', { name: 'New page' }))
+    await waitFor(() => expect(window.location.pathname).toBe('/pages/page-3'))
+
+    await reload(fetchMock, '/pages/page-3')
+    expect(tabNames()).toEqual(['Watch', 'Wall Display', 'Page 3'])
+  })
+
+  it('stays where it is when the server refuses the write', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages(), putStatus: 500 })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(screen.getByRole('button', { name: 'New page' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Saving the dashboard configuration failed.')).toBeInTheDocument(),
+    )
+    // Not on a page the server has never heard of.
+    expect(window.location.pathname).toBe('/pages/watch')
+    expect(tabNames()).toEqual(['Watch', 'Wall Display'])
+  })
+})
+
+describe('renaming a page', () => {
+  it('renames the tab and keeps the panels where they were', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.clear(within(menu()).getByLabelText('Page name'))
+    await userEvent.type(within(menu()).getByLabelText('Page name'), 'Training View')
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Rename' }))
+
+    await waitFor(() => expect(tabNames()).toEqual(['Training View', 'Wall Display']))
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+    expect(savedPages(fetchMock)[0]).toMatchObject({ id: 'watch', name: 'Training View' })
+  })
+
+  it('keeps the page’s URL working, which is what a kiosk display is pointed at', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    // The kiosk was configured with the slug the page had before the rename.
+    await openPage(fetchMock, '/pages/watch/watch')
+
+    await openMenu()
+    await userEvent.clear(within(menu()).getByLabelText('Page name'))
+    await userEvent.type(within(menu()).getByLabelText('Page name'), 'Training View')
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Rename' }))
+    await waitFor(() => expect(tabNames()).toEqual(['Training View', 'Wall Display']))
+
+    // The address bar reads as the page does now…
+    expect(window.location.pathname).toBe('/pages/watch/training-view')
+    // …and the kiosk's stale URL still lands on the same page.
+    await reload(fetchMock, '/pages/watch/watch')
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+    expect(within(tabs()).getByRole('link', { current: 'page' })).toHaveTextContent('Training View')
+  })
+
+  it('does not offer to rename a page to nothing', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }))
+
+    await openMenu()
+    await userEvent.clear(within(menu()).getByLabelText('Page name'))
+
+    expect(within(menu()).getByRole('button', { name: 'Rename' })).toBeDisabled()
+  })
+})
+
+describe('deleting a page', () => {
+  it('removes the page and lands on its neighbour', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock, '/pages/wall')
+
+    await openMenu()
+    await userEvent.click(screen.getByRole('button', { name: 'Delete “Wall Display”' }))
+
+    await waitFor(() => expect(window.location.pathname).toBe('/pages/watch'))
+    expect(tabNames()).toEqual(['Watch'])
+    expect(savedPages(fetchMock).map((page) => page.id)).toEqual(['watch'])
+  })
+
+  it('never takes the last page, which would leave nothing to show', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument(pageOf('watch', 'Watch', 'cpu-utilization')),
+    })
+    await openPage(fetchMock)
+    await openMenu()
+
+    expect(screen.getByRole('button', { name: 'Delete “Watch”' })).toBeDisabled()
+    expect(screen.getByText('The dashboard always has at least one page.')).toBeInTheDocument()
+    expect(configurationWrites(fetchMock)).toEqual([])
+  })
+})
+
+describe('resetting everything', () => {
+  it('asks before it takes every page', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Reset everything' }))
+
+    expect(within(menu()).getByRole('group', { name: 'Confirm reset' })).toHaveTextContent(
+      /cannot be undone/i,
+    )
+    expect(configurationResets(fetchMock)).toBe(0)
+  })
+
+  it('removes the stored document and comes back on the default preset', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Reset everything' }))
+    await userEvent.click(
+      within(screen.getByRole('group', { name: 'Confirm reset' })).getByRole('button', {
+        name: 'Reset everything',
+      }),
+    )
+
+    await waitFor(() => expect(window.location.pathname).toBe('/pages/overview'))
+    expect(configurationResets(fetchMock)).toBe(1)
+    expect(tabNames()).toEqual(['Overview'])
+    // The preset, not an empty dashboard: a reset is a working dashboard back.
+    expect(screen.getByRole('region', { name: 'GPU Utilization' })).toBeInTheDocument()
+
+    // And it is a reset, not a write: the server is holding nothing again.
+    await reload(fetchMock, '/pages/overview')
+    expect(tabNames()).toEqual(['Overview'])
+  })
+
+  it('takes nothing when the operator backs out', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Reset everything' }))
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Cancel' }))
+
+    expect(configurationResets(fetchMock)).toBe(0)
+    expect(tabNames()).toEqual(['Watch', 'Wall Display'])
+  })
+
+  it('says so when the removal failed, and leaves the pages alone', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages(), deleteStatus: 500 })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Reset everything' }))
+    await userEvent.click(
+      within(screen.getByRole('group', { name: 'Confirm reset' })).getByRole('button', {
+        name: 'Reset everything',
+      }),
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText('Resetting the dashboard configuration failed.')).toBeInTheDocument(),
+    )
+    expect(tabNames()).toEqual(['Watch', 'Wall Display'])
+  })
+})
+
+describe('a dashboard that cannot be written', () => {
+  it('withholds every page edit and says why', async () => {
+    await openPage(serveConfiguration({ document: twoPages(), readOnly: true }))
+    await openMenu()
+
+    expect(
+      within(menu()).getByText('This dashboard is read-only, so its pages cannot be changed.'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New page' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Delete “Watch”' })).toBeDisabled()
+    expect(within(menu()).getByRole('button', { name: 'Reset everything' })).toBeDisabled()
+  })
+
+  it('still switches pages, because reading them was never a write', async () => {
+    await openPage(serveConfiguration({ document: twoPages(), readOnly: true }))
+
+    await userEvent.click(within(tabs()).getByRole('link', { name: 'Wall Display' }))
+
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+  })
+})
+
+describe('a layout being edited', () => {
+  it('holds the page list still, so unsaved work cannot be navigated away from', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }))
+    await userEvent.click(screen.getByRole('button', { name: 'Edit layout' }))
+
+    await userEvent.click(within(tabs()).getByRole('link', { name: 'Wall Display' }))
+
+    expect(screen.getByRole('region', { name: 'CPU' })).toBeInTheDocument()
+    expect(window.location.pathname).toBe('/pages/watch')
+
+    await openMenu()
+    expect(
+      within(menu()).getByText(
+        'Save or discard your layout changes to add, rename or delete pages.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New page' })).toBeDisabled()
+  })
+
+  it('gives the page list back the moment the edit is discarded', async () => {
+    await openPage(serveConfiguration({ document: twoPages() }))
+    await userEvent.click(screen.getByRole('button', { name: 'Edit layout' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Discard' }))
+
+    await userEvent.click(within(tabs()).getByRole('link', { name: 'Wall Display' }))
+
+    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/App.pages.test.tsx
+++ b/frontend/src/__tests__/App.pages.test.tsx
@@ -162,7 +162,30 @@ describe('creating a page', () => {
       'Wall Display',
       'Page 3',
     ])
-    expect(screen.queryAllByRole('region')).toEqual([])
+    // No panels: a new page is empty, so the operator adds what they came for
+    // rather than deleting a preset they did not ask for.
+    expect(within(screen.getByRole('main')).queryAllByRole('region')).toEqual([])
+  })
+
+  it('stays open on the new page’s name, so creating and naming it is one job', async () => {
+    const fetchMock = serveConfiguration({ document: twoPages() })
+    await openPage(fetchMock)
+
+    await openMenu()
+    await userEvent.click(screen.getByRole('button', { name: 'New page' }))
+    await waitFor(() => expect(window.location.pathname).toBe('/pages/page-3'))
+
+    // The menu did not close, and the field now names the page just made.
+    const name = within(menu()).getByLabelText('Page name')
+    expect(name).toHaveValue('Page 3')
+
+    await userEvent.clear(name)
+    await userEvent.type(name, 'Training View')
+    await userEvent.click(within(menu()).getByRole('button', { name: 'Rename' }))
+
+    await waitFor(() => expect(tabNames()).toEqual(['Watch', 'Wall Display', 'Training View']))
+    // The id was fixed at creation, so naming it afterwards left the URL alone.
+    expect(window.location.pathname).toBe('/pages/page-3/training-view')
   })
 
   it('survives a reload, which is the only reason to store it at all', async () => {

--- a/frontend/src/__tests__/browser/pageTabs.browser.test.tsx
+++ b/frontend/src/__tests__/browser/pageTabs.browser.test.tsx
@@ -36,12 +36,18 @@ function Harness({ width, list, activePageId }: {
   )
 }
 
-/** The tabs on the strip — the menu's own links are inside its list, not here. */
+/**
+ * The tabs on the strip — the menu's own links are inside its list, not here.
+ *
+ * `queryAllByRole`, so an empty strip is an empty list rather than a throw: on a
+ * narrow enough header no tab fits at all, and that is a state to assert, not an
+ * error.
+ */
 function stripTabs(): string[] {
   const menu = screen.queryByRole('list', { name: 'More pages' })
 
   return within(screen.getByRole('navigation', { name: 'Pages' }))
-    .getAllByRole('link')
+    .queryAllByRole('link')
     .filter((tab) => !menu?.contains(tab))
     .map((tab) => tab.textContent ?? '')
 }
@@ -115,6 +121,28 @@ describe('the page tabs in a real layout engine', () => {
     // and before that every tab is on it for want of a reason not to be.
     await waitFor(() => expect(overflowButton()).not.toBeNull())
     expect(stripTabs()).toContain('Arrangement number 8 for the wall display')
+  })
+
+  it('names the page on the menu button when the header fits no tab at all', async () => {
+    // A phone: the masthead and the connection badge leave the strip almost
+    // nothing. A tab sliced by the clip edge would claim to say where the
+    // operator is and fail, so the button says it instead.
+    render(<Harness width={90} list={pages(4)} activePageId="page-2" />)
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Arrangement number 2 for the wall display' }),
+      ).not.toBeNull(),
+    )
+    expect(stripTabs()).toEqual([])
+
+    // And every page, the current one included, is still in the menu.
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Arrangement number 2 for the wall display' }),
+    )
+    expect(
+      within(await screen.findByRole('list', { name: 'More pages' })).getAllByRole('link'),
+    ).toHaveLength(4)
   })
 
   it('gives the tabs back when the header is widened again', async () => {

--- a/frontend/src/__tests__/browser/pageTabs.browser.test.tsx
+++ b/frontend/src/__tests__/browser/pageTabs.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { PageTabs } from '@/components/pages/PageTabs'
 import type { DashboardPage } from '@/lib/dashboard/schema'
 
@@ -56,7 +57,11 @@ const overflowButton = () => screen.queryByRole('button', { name: /more$/ })
  * runs after layout, before paint) and the render it causes.
  */
 async function measured(): Promise<void> {
-  await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+  // Inside `act`, because the render the observer causes is a state update the
+  // test asked for — outside it React rightly complains that nobody was waiting.
+  await act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+  })
 }
 
 describe('the page tabs in a real layout engine', () => {
@@ -80,7 +85,7 @@ describe('the page tabs in a real layout engine', () => {
     expect(visible.length).toBeLessThan(8)
 
     // Nothing is lost: the strip and the menu together are still every page.
-    overflowButton()!.click()
+    await userEvent.click(overflowButton()!)
     const hidden = within(await screen.findByRole('list', { name: 'More pages' }))
       .getAllByRole('link')
       .map((tab) => tab.textContent ?? '')

--- a/frontend/src/__tests__/browser/pageTabs.browser.test.tsx
+++ b/frontend/src/__tests__/browser/pageTabs.browser.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { PageTabs } from '@/components/pages/PageTabs'
+import type { DashboardPage } from '@/lib/dashboard/schema'
+
+// The tab strip in a real layout engine: the #85 acceptance criterion that
+// depends on measurement. Which tabs fit is decided from measured widths on a
+// ResizeObserver path, and jsdom measures every box as 0×0 — so in the unit
+// project every tab always fits and the overflow menu never appears at all.
+// Without this spec, a strip that hid every tab, or none, would pass there.
+//
+// Tailwind classes do not apply here (the browser project runs no Tailwind
+// build), so a tab is as wide as its text and nothing else. That is fine and
+// deliberate: the assertions are about which tabs are reachable, never about
+// pixel counts.
+
+function pages(count: number): DashboardPage[] {
+  return Array.from({ length: count }, (_, index) => ({
+    // Long names, so a handful of them exceed any reasonable strip.
+    id: `page-${index + 1}`,
+    name: `Arrangement number ${index + 1} for the wall display`,
+    panels: [],
+  }))
+}
+
+function Harness({ width, list, activePageId }: {
+  width: number
+  list: DashboardPage[]
+  activePageId: string
+}) {
+  return (
+    <div style={{ width, display: 'flex' }}>
+      <PageTabs pages={list} activePageId={activePageId} locked={false} onSelect={() => {}} />
+    </div>
+  )
+}
+
+/** The tabs on the strip — the menu's own links are inside its list, not here. */
+function stripTabs(): string[] {
+  const menu = screen.queryByRole('list', { name: 'More pages' })
+
+  return within(screen.getByRole('navigation', { name: 'Pages' }))
+    .getAllByRole('link')
+    .filter((tab) => !menu?.contains(tab))
+    .map((tab) => tab.textContent ?? '')
+}
+
+const overflowButton = () => screen.queryByRole('button', { name: /more$/ })
+
+/**
+ * Waits for the strip to have been measured and re-rendered on it.
+ *
+ * Before the first ResizeObserver callback every width is unknown, which reads
+ * as "everything fits" — so an assertion made too early passes on the
+ * unmeasured state and proves nothing. Two frames covers the observer (which
+ * runs after layout, before paint) and the render it causes.
+ */
+async function measured(): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+}
+
+describe('the page tabs in a real layout engine', () => {
+  it('shows every page when the header has room, with no menu to open', async () => {
+    const list = pages(3)
+    render(<Harness width={2000} list={list} activePageId="page-1" />)
+    await measured()
+
+    expect(stripTabs()).toHaveLength(3)
+    expect(overflowButton()).toBeNull()
+  })
+
+  it('moves the tabs that do not fit into a menu, and keeps them one click away', async () => {
+    const list = pages(8)
+    render(<Harness width={600} list={list} activePageId="page-1" />)
+
+    await waitFor(() => expect(overflowButton()).not.toBeNull())
+
+    const visible = stripTabs()
+    expect(visible.length).toBeGreaterThan(0)
+    expect(visible.length).toBeLessThan(8)
+
+    // Nothing is lost: the strip and the menu together are still every page.
+    overflowButton()!.click()
+    const hidden = within(await screen.findByRole('list', { name: 'More pages' }))
+      .getAllByRole('link')
+      .map((tab) => tab.textContent ?? '')
+    expect([...visible, ...hidden].sort()).toEqual(list.map((page) => page.name).sort())
+  })
+
+  it('never lets the strip run past the header it sits in', async () => {
+    render(<Harness width={600} list={pages(8)} activePageId="page-1" />)
+    await waitFor(() => expect(overflowButton()).not.toBeNull())
+
+    const nav = screen.getByRole('navigation', { name: 'Pages' }).getBoundingClientRect()
+    const rightmost = Math.max(
+      ...within(screen.getByRole('navigation', { name: 'Pages' }))
+        .getAllByRole('link')
+        .map((tab) => tab.getBoundingClientRect().right),
+      overflowButton()!.getBoundingClientRect().right,
+    )
+
+    expect(rightmost).toBeLessThanOrEqual(nav.right + 1)
+  })
+
+  it('keeps the page being viewed on the strip when it sits past the fold', async () => {
+    // The last of eight, which no prefix of the list would ever reach.
+    render(<Harness width={600} list={pages(8)} activePageId="page-8" />)
+
+    // The overflow button first: it is what proves the strip has been measured,
+    // and before that every tab is on it for want of a reason not to be.
+    await waitFor(() => expect(overflowButton()).not.toBeNull())
+    expect(stripTabs()).toContain('Arrangement number 8 for the wall display')
+  })
+
+  it('gives the tabs back when the header is widened again', async () => {
+    const list = pages(8)
+    const { rerender } = render(<Harness width={600} list={list} activePageId="page-1" />)
+    await waitFor(() => expect(overflowButton()).not.toBeNull())
+
+    rerender(<Harness width={4000} list={list} activePageId="page-1" />)
+
+    await waitFor(() => expect(stripTabs()).toHaveLength(8))
+    expect(overflowButton()).toBeNull()
+  })
+})

--- a/frontend/src/__tests__/useDashboardConfiguration.test.tsx
+++ b/frontend/src/__tests__/useDashboardConfiguration.test.tsx
@@ -288,4 +288,62 @@ describe('useDashboardConfiguration', () => {
 
     expect(result.current.document).toEqual(defaultDashboardDocument())
   })
+
+  it('renders the preset again the moment a reset is accepted', async () => {
+    serveConfiguration({ document: stored })
+    const { result } = await loaded()
+
+    await act(async () => {
+      expect(await result.current.reset()).toBe('reset')
+    })
+
+    expect(result.current.document).toEqual(defaultDashboardDocument())
+    expect(result.current.notices).toEqual([])
+  })
+
+  it('makes no request when asked to reset a read-only instance', async () => {
+    // The same reasoning as a save: the banner already says nothing can be
+    // written, and the request would only fail the same way.
+    const fetchMock = serveConfiguration({ document: stored, readOnly: true })
+    const { result } = await loaded()
+    const readsSoFar = fetchMock.mock.calls.length
+
+    await act(async () => {
+      expect(await result.current.reset()).toBe('read-only')
+    })
+
+    expect(fetchMock.mock.calls).toHaveLength(readsSoFar)
+  })
+
+  it('says so when the reset failed, and keeps showing the stored document', async () => {
+    // A different sentence from a failed save, because a different thing did
+    // not happen: nothing was removed, rather than nothing written.
+    serveConfiguration({ document: stored, deleteStatus: 500 })
+    const { result } = await loaded()
+    const before = result.current.document
+
+    await act(async () => {
+      expect(await result.current.reset()).toBe('failed')
+    })
+
+    expect(result.current.notices).toEqual([{ kind: 'reset-failed' }])
+    expect(result.current.document).toEqual(before)
+  })
+
+  it('is the way back from a document this build cannot read', async () => {
+    // The banner describes a stored document that a reset removed, so the
+    // complaint goes with it — which is what makes a rollback recoverable
+    // without hand-editing a file on the server.
+    serveConfiguration({
+      document: JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION + 5, pages: [] }),
+    })
+    const { result } = await loaded()
+    expect(result.current.notices).not.toEqual([])
+
+    await act(async () => {
+      await result.current.reset()
+    })
+
+    expect(result.current.notices).toEqual([])
+  })
 })

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,22 +1,43 @@
+import type { ReactNode } from 'react'
 import { ConnectionBadge } from './ConnectionBadge'
 import type { ConnectionStatus } from '@/hooks/useMetrics'
 
 /**
- * The product masthead: title and connection badge. Shared by the root
- * dashboard and the grid pages so both routes read as the same product; the
- * page tabs (#85) will slot in here between the two.
+ * The product masthead: title, page navigation, and connection badge. Shared by
+ * the root dashboard and the grid pages so both routes read as the same product.
+ *
+ * The page tabs sit *between* the title and the badge rather than replacing
+ * either: the header's existing identity is what tells an operator at a glance
+ * which tool they are looking at, and the rework preserves it. `pages` is a slot
+ * because only the grid routes have pages to show — the root URL keeps serving
+ * the pre-grid dashboard untouched until the #86 cutover.
  */
-export function AppHeader({ status, isStale }: { status: ConnectionStatus; isStale: boolean }) {
+export function AppHeader({
+  status,
+  isStale,
+  pages,
+}: {
+  status: ConnectionStatus
+  isStale: boolean
+  pages?: ReactNode
+}) {
   return (
-    <header className="shrink-0 border-b border-white/[0.04] px-4 py-1.5 flex justify-between items-center">
+    <header className="shrink-0 border-b border-white/[0.04] px-4 py-1.5 flex items-center gap-3">
       <h1
-        className="text-xl font-semibold text-zinc-100 tracking-tight"
+        className="shrink-0 text-xl font-semibold text-zinc-100 tracking-tight"
         style={{ fontFamily: 'Inter, sans-serif' }}
       >
         <span className="text-[#76B900]">Spark</span>{' '}
         <span className="text-zinc-500 font-normal">Dashboard</span>
       </h1>
-      <ConnectionBadge status={status} isStale={isStale} />
+
+      {pages}
+
+      {/* `ml-auto` rather than `justify-between`, so the badge stays hard right
+          whether or not there are pages between it and the title. */}
+      <div className="ml-auto shrink-0">
+        <ConnectionBadge status={status} isStale={isStale} />
+      </div>
     </header>
   )
 }

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -28,7 +28,11 @@ export function AppHeader({
         style={{ fontFamily: 'Inter, sans-serif' }}
       >
         <span className="text-[#76B900]">Spark</span>{' '}
-        <span className="text-zinc-500 font-normal">Dashboard</span>
+        {/* The green mark is the identity and always shows; the second word is
+            the first thing to go when the header is narrow, because a masthead
+            that leaves no room for the page tabs has crowded out the navigation
+            it exists to sit beside. */}
+        <span className="hidden sm:inline text-zinc-500 font-normal">Dashboard</span>
       </h1>
 
       {pages}

--- a/frontend/src/components/ConfigurationNotices.tsx
+++ b/frontend/src/components/ConfigurationNotices.tsx
@@ -100,5 +100,11 @@ function describe(notice: ConfigurationNotice): NoticeText {
         detail: 'The server refused it for its size. Remove some panels or pages and save again.',
         tone: 'error',
       }
+    case 'reset-failed':
+      return {
+        title: 'Resetting the dashboard configuration failed.',
+        detail: 'The stored configuration is still there, and nothing was removed. Try again.',
+        tone: 'error',
+      }
   }
 }

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { LiveMotionContext } from '@/hooks/useLiveMotion'
 import { useElementSize } from '@/hooks/useElementSize'
 import type { PanelBinding } from '@/lib/dashboard/bindings'
@@ -39,6 +39,12 @@ interface GridPageEditorProps {
   /** Nothing can be written on this instance; the standing banner says why. */
   readOnly: boolean
   onSave: (panels: DashboardPanel[]) => Promise<SaveOutcome['status']>
+  /**
+   * Whether a session is open, for the page list in the header. The session is a
+   * working copy that dies with this component, so switching pages while one is
+   * open would throw it away — the header withholds that until it is settled.
+   */
+  onEditingChange?: (editing: boolean) => void
 }
 
 /**
@@ -56,7 +62,12 @@ interface GridPageEditorProps {
  * which is also why removing a panel is behind its settings rather than one
  * click on the frame.
  */
-export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) {
+export function GridPageEditor({
+  page,
+  readOnly,
+  onSave,
+  onEditingChange,
+}: GridPageEditorProps) {
   const [session, setSession] = useState<EditSession | null>(null)
   const [saving, setSaving] = useState(false)
   const [containerRef, { width }] = useElementSize<HTMLDivElement>()
@@ -66,6 +77,17 @@ export function GridPageEditor({ page, readOnly, onSave }: GridPageEditorProps) 
   // static and saving is withheld, so the work is still there when the window
   // is wide again.
   const narrow = isNarrow(width)
+
+  const editing = session !== null
+  // Told rather than derived: the header is a sibling of this component, and
+  // the session it needs to know about is deliberately private to it.
+  useEffect(() => {
+    onEditingChange?.(editing)
+    // A page reached with the back button unmounts the editor and takes the
+    // session with it. Without this the header would stay locked against a
+    // session that no longer exists, with no button left on screen to end it.
+    return () => onEditingChange?.(false)
+  }, [editing, onEditingChange])
 
   const onLayoutChange = useCallback<GridEditing['onLayoutChange']>((changes) => {
     setSession((current) =>

--- a/frontend/src/components/pages/PageBar.tsx
+++ b/frontend/src/components/pages/PageBar.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { navigateTo, replacePath } from '@/hooks/useRoute'
+import type { ResetOutcome, SaveOutcome } from '@/lib/dashboard/client'
+import { addPage, canRemovePage, removePage, renamePage } from '@/lib/dashboard/pages'
+import { defaultDashboardDocument } from '@/lib/dashboard/preset'
+import { pagePath } from '@/lib/dashboard/routes'
+import type { DashboardDocument } from '@/lib/dashboard/schema'
+import { PagesMenu } from './PagesMenu'
+import { PageTabs } from './PageTabs'
+
+interface PageBarProps {
+  document: DashboardDocument
+  /** The page the URL names. Not necessarily one the document still has. */
+  activePageId: string
+  /** Nothing can be written on this instance; the standing banner says why. */
+  readOnly: boolean
+  /** A layout edit session is open on the page being viewed. */
+  editing: boolean
+  save: (document: DashboardDocument) => Promise<SaveOutcome['status']>
+  reset: () => Promise<ResetOutcome['status']>
+}
+
+/**
+ * The page list in the header, and everything an operator does to it.
+ *
+ * This is where the rule that a page edit is **written immediately** is carried
+ * out — see `lib/dashboard/pages` for why — and where each one decides where the
+ * operator ends up afterwards. Navigation and persistence are deliberately in
+ * the same place: a page that is created and not navigated to is invisible, and
+ * one that is navigated to before the write lands would 404 on a reload.
+ *
+ * **Nothing moves until the write is accepted.** A failed save leaves the
+ * operator on the page they were on, looking at the banner the save path already
+ * raises, rather than at a page that does not exist on the server.
+ *
+ * The whole bar goes quiet while a layout is being edited. The edit session
+ * lives in the page below and dies with it, so leaving mid-edit would silently
+ * discard work the operator has been told is unsaved — and the way out is the
+ * Save and Discard buttons that are already on screen.
+ */
+export function PageBar({ document, activePageId, readOnly, editing, save, reset }: PageBarProps) {
+  // A second page write while the first is in flight would race it, and the
+  // loser would be written from a document that never had the winner's page.
+  const [busy, setBusy] = useState(false)
+  const page = document.pages.find((candidate) => candidate.id === activePageId)
+
+  async function run(work: () => Promise<void>): Promise<void> {
+    if (busy) return
+    setBusy(true)
+    try {
+      await work()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  /** Goes to a page of `next`, which is the document the server just took. */
+  function go(next: DashboardDocument, pageId: string, replace = false): void {
+    const target = next.pages.find((candidate) => candidate.id === pageId)
+    if (!target) return
+    ;(replace ? replacePath : navigateTo)(pagePath(target))
+  }
+
+  const create = () =>
+    run(async () => {
+      const { document: next, pageId } = addPage(document)
+      if ((await save(next)) === 'saved') go(next, pageId)
+    })
+
+  const rename = (name: string) =>
+    run(async () => {
+      const next = renamePage(document, activePageId, name)
+      if (next === document) return
+      // Replace rather than push: the page has not changed, only the slug that
+      // describes it, so back should leave the page rather than undo a rename.
+      if ((await save(next)) === 'saved') go(next, activePageId, true)
+    })
+
+  const remove = () =>
+    run(async () => {
+      const outcome = removePage(document, activePageId)
+      if (outcome.status !== 'removed') return
+      if ((await save(outcome.document)) === 'saved') go(outcome.document, outcome.nextPageId)
+    })
+
+  const resetEverything = () =>
+    run(async () => {
+      if ((await reset()) !== 'reset') return
+      // The stored document is gone, so what renders now is the preset — and
+      // whatever page the operator was on is very likely not one of its pages.
+      const first = defaultDashboardDocument().pages[0]
+      if (first) navigateTo(pagePath(first))
+    })
+
+  return (
+    <>
+      <PageTabs
+        pages={document.pages}
+        activePageId={activePageId}
+        locked={editing || busy}
+        onSelect={(selected) => navigateTo(pagePath(selected))}
+      />
+
+      {/* No menu without a page to act on: the URL names one the document does
+          not have, and the tabs beside it are the way back to one that exists. */}
+      {page && (
+        <PagesMenu
+          page={page}
+          canDelete={canRemovePage(document)}
+          readOnly={readOnly}
+          locked={editing}
+          busy={busy}
+          onCreate={create}
+          onRename={rename}
+          onDelete={remove}
+          onResetEverything={resetEverything}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/pages/PageTabs.tsx
+++ b/frontend/src/components/pages/PageTabs.tsx
@@ -1,0 +1,237 @@
+import { useLayoutEffect, useState } from 'react'
+import { useDismissablePopover } from '@/hooks/useDismissablePopover'
+import { useElementSize } from '@/hooks/useElementSize'
+import { pagePath } from '@/lib/dashboard/routes'
+import type { DashboardPage } from '@/lib/dashboard/schema'
+import { fitTabs, TAB_GAP } from './tabFit'
+
+interface PageTabsProps {
+  pages: readonly DashboardPage[]
+  /** The page being viewed. Not necessarily one of `pages` — a URL can name a
+   *  page that has since been deleted. */
+  activePageId: string
+  /**
+   * A layout is being edited, so leaving the page would throw the session away.
+   * The tabs stay visible and say where the operator is; they just do not go
+   * anywhere until the edit is saved or discarded.
+   */
+  locked: boolean
+  onSelect: (page: DashboardPage) => void
+}
+
+/**
+ * The pages of this dashboard, as tabs in the masthead.
+ *
+ * Tabs rather than a sidebar: a sidebar costs horizontal space permanently, in a
+ * layout whose entire premise is fitting the viewport, and on a wall display a
+ * visible row of page names beats a dropdown nobody is standing close enough to
+ * open. Tabs that do not fit move into a menu, so a dashboard with a dozen pages
+ * degrades to a shorter strip rather than an unusable header.
+ *
+ * Every tab is a real link to the page's own URL, so middle-click, open-in-new-
+ * tab and bookmarking all work; the click handler takes over only to avoid
+ * reloading the application and dropping every metrics socket with it.
+ */
+export function PageTabs({ pages, activePageId, locked, onSelect }: PageTabsProps) {
+  const [stripRef, strip] = useElementSize<HTMLDivElement>()
+  // The natural width of every tab, measured off a hidden copy of the whole
+  // strip. Measuring the *visible* tabs instead would be circular — hiding a tab
+  // is what removes its width, so the widths would depend on the answer they are
+  // the input to, and the strip would oscillate.
+  const [measureRef, measured] = useElementSize<HTMLDivElement>()
+  const [widths, setWidths] = useState<readonly number[]>([])
+
+  useLayoutEffect(() => {
+    const row = measureRef.current
+    if (!row) return
+
+    const next = Array.from(row.children).map((child) => (child as HTMLElement).offsetWidth)
+    setWidths((current) => (sameWidths(current, next) ? current : next))
+    // The measured row's own width stands in for everything that can change a
+    // tab's width without changing the page list — a font finishing loading,
+    // most of all.
+  }, [pages, measured.width, measureRef])
+
+  const activeIndex = pages.findIndex((page) => page.id === activePageId)
+  const { visible, overflow } = fitTabs(
+    // Before the first measurement every width is missing, which reads as
+    // unmeasured and shows every tab — the same thing jsdom sees.
+    pages.map((_, index) => widths[index] ?? 0),
+    activeIndex,
+    strip.width,
+  )
+
+  if (pages.length === 0) return null
+
+  return (
+    // Everything that decides a width is inline rather than Tailwind, for the
+    // reason `GridPage` measures itself inline: the widths here are the input to
+    // which tabs are shown, so they have to hold in the browser test project,
+    // which runs no Tailwind build. The gap is the constant the fit is computed
+    // from, so the strip and the arithmetic cannot drift apart. Colour, type and
+    // radius stay in classes — nothing there changes a measurement.
+    <nav aria-label="Pages" style={{ flex: 1, minWidth: 0 }}>
+      <div ref={stripRef} style={ROW}>
+        {/* Bare spans, not list items: a span measures its own content wherever
+            it lands, while a block-level wrapper would measure the container
+            it sits in and report every tab as full width. */}
+        <div ref={measureRef} aria-hidden style={MEASURING_ROW}>
+          {pages.map((page) => (
+            <span key={page.id} className={tabClass(false)}>
+              {page.name}
+            </span>
+          ))}
+        </div>
+
+        <ul style={{ display: 'flex', alignItems: 'center', gap: TAB_GAP }}>
+          {visible.map((index) => (
+            <li key={pages[index].id}>
+              <PageLink
+                page={pages[index]}
+                active={index === activeIndex}
+                locked={locked}
+                onSelect={onSelect}
+              />
+            </li>
+          ))}
+        </ul>
+
+        {overflow.length > 0 && (
+          <OverflowMenu
+            pages={overflow.map((index) => pages[index])}
+            activePageId={activePageId}
+            locked={locked}
+            onSelect={onSelect}
+          />
+        )}
+      </div>
+    </nav>
+  )
+}
+
+const ROW: React.CSSProperties = {
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  gap: TAB_GAP,
+  // A tab is never half on screen: what does not fit is in the menu, not
+  // clipped at the edge.
+  overflow: 'hidden',
+}
+
+/**
+ * The hidden copy every width is read off. Out of flow and at its natural width,
+ * so it neither pushes the real strip around nor gets squeezed by it — a
+ * measuring row that the container had already narrowed would measure the answer
+ * rather than the question.
+ */
+const MEASURING_ROW: React.CSSProperties = {
+  position: 'absolute',
+  left: 0,
+  top: 0,
+  display: 'flex',
+  gap: TAB_GAP,
+  width: 'max-content',
+  visibility: 'hidden',
+  pointerEvents: 'none',
+}
+
+/** The pages that did not fit, behind one button, still one click away. */
+function OverflowMenu({
+  pages,
+  activePageId,
+  locked,
+  onSelect,
+}: {
+  pages: readonly DashboardPage[]
+  activePageId: string
+  locked: boolean
+  onSelect: (page: DashboardPage) => void
+}) {
+  const { open, setOpen, toggle, containerRef } = useDismissablePopover<HTMLDivElement>()
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative', flexShrink: 0 }}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="text-[11px] px-2 py-1 rounded-md border border-white/[0.08] text-zinc-400 hover:text-zinc-200 hover:bg-white/[0.06] transition-colors whitespace-nowrap"
+      >
+        {pages.length} more
+      </button>
+
+      {open && (
+        <ul
+          aria-label="More pages"
+          className="absolute left-0 top-full z-20 mt-1 w-52 max-h-[60vh] overflow-y-auto rounded-md border border-white/[0.08] bg-[#0d0d10] p-1 shadow-xl"
+        >
+          {pages.map((page) => (
+            <li key={page.id}>
+              <PageLink
+                page={page}
+                active={page.id === activePageId}
+                locked={locked}
+                block
+                onSelect={(selected) => {
+                  setOpen(false)
+                  onSelect(selected)
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function PageLink({
+  page,
+  active,
+  locked,
+  block = false,
+  onSelect,
+}: {
+  page: DashboardPage
+  active: boolean
+  locked: boolean
+  block?: boolean
+  onSelect: (page: DashboardPage) => void
+}) {
+  return (
+    <a
+      href={pagePath(page)}
+      // The current page is announced as such rather than only coloured, so the
+      // strip says where the operator is without relying on the accent green.
+      aria-current={active ? 'page' : undefined}
+      aria-disabled={locked || undefined}
+      title={locked ? 'Save or discard your layout changes to switch pages.' : undefined}
+      onClick={(event) => {
+        // Never a full page load: the metrics socket, the history buffers and
+        // the log connections all live above the router and must survive a page
+        // switch. Modified clicks are left to the browser, which is the whole
+        // reason these are links.
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+        event.preventDefault()
+        if (!locked) onSelect(page)
+      }}
+      className={`${tabClass(active)} ${block ? 'block' : ''} ${locked ? 'cursor-not-allowed opacity-50' : ''}`}
+    >
+      {page.name}
+    </a>
+  )
+}
+
+/** One class list, so the hidden measuring row measures the tabs that ship. */
+function tabClass(active: boolean): string {
+  return `whitespace-nowrap rounded-md px-2.5 py-1 text-[11px] transition-colors ${
+    active
+      ? 'bg-[#76B900]/15 text-[#cfe98a] border border-[#76B900]/30'
+      : 'border border-transparent text-zinc-400 hover:text-zinc-200 hover:bg-white/[0.06]'
+  }`
+}
+
+function sameWidths(a: readonly number[], b: readonly number[]): boolean {
+  return a.length === b.length && a.every((width, index) => width === b[index])
+}

--- a/frontend/src/components/pages/PageTabs.tsx
+++ b/frontend/src/components/pages/PageTabs.tsx
@@ -72,34 +72,50 @@ export function PageTabs({ pages, activePageId, locked, onSelect }: PageTabsProp
     // radius stay in classes — nothing there changes a measurement.
     <nav aria-label="Pages" style={{ flex: 1, minWidth: 0 }}>
       <div ref={stripRef} style={ROW}>
-        {/* Bare spans, not list items: a span measures its own content wherever
-            it lands, while a block-level wrapper would measure the container
-            it sits in and report every tab as full width. */}
-        <div ref={measureRef} aria-hidden style={MEASURING_ROW}>
-          {pages.map((page) => (
-            <span key={page.id} className={tabClass(false)}>
-              {page.name}
-            </span>
-          ))}
-        </div>
+        {/* Only the tabs are clipped. The menu button sits outside this box,
+            because its popover hangs below the row — inside, the very thing
+            that keeps a tab from overhanging the header would swallow the
+            dropdown whole, on exactly the narrow screens that need it most. */}
+        <div style={TABS}>
+          {/* Bare spans, not list items: a span measures its own content
+              wherever it lands, while a block-level wrapper would measure the
+              container it sits in and report every tab as full width. */}
+          <div ref={measureRef} aria-hidden style={MEASURING_ROW}>
+            {pages.map((page) => (
+              <span key={page.id} className={tabClass(false)}>
+                {page.name}
+              </span>
+            ))}
+          </div>
 
-        <ul style={{ display: 'flex', alignItems: 'center', gap: TAB_GAP }}>
-          {visible.map((index) => (
-            <li key={pages[index].id}>
-              <PageLink
-                page={pages[index]}
-                active={index === activeIndex}
-                locked={locked}
-                onSelect={onSelect}
-              />
-            </li>
-          ))}
-        </ul>
+          {visible.length > 0 && (
+            <ul style={{ display: 'flex', alignItems: 'center', gap: TAB_GAP }}>
+              {visible.map((index) => (
+                <li key={pages[index].id}>
+                  <PageLink
+                    page={pages[index]}
+                    active={index === activeIndex}
+                    locked={locked}
+                    onSelect={onSelect}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
 
         {overflow.length > 0 && (
           <OverflowMenu
             pages={overflow.map((index) => pages[index])}
             activePageId={activePageId}
+            // With no tab on the strip, this button is the only thing left that
+            // can say which page is showing — so it says it, instead of counting
+            // pages nobody can see.
+            label={
+              activeIndex >= 0 && overflow.includes(activeIndex)
+                ? pages[activeIndex].name
+                : `${overflow.length} more`
+            }
             locked={locked}
             onSelect={onSelect}
           />
@@ -109,14 +125,27 @@ export function PageTabs({ pages, activePageId, locked, onSelect }: PageTabsProp
   )
 }
 
+/** The whole strip: the clipped tab area, then the menu button beside it. */
 const ROW: React.CSSProperties = {
-  position: 'relative',
   display: 'flex',
   alignItems: 'center',
   gap: TAB_GAP,
-  // A tab is never half on screen: what does not fit is in the menu, not
-  // clipped at the edge. The padding keeps that clip off the tabs themselves,
-  // so an active tab's border is inside the box rather than on its boundary.
+  minWidth: 0,
+}
+
+/**
+ * The tabs, and the only thing that clips: a tab is never half on screen, so
+ * what does not fit is in the menu rather than sliced at the edge.
+ *
+ * It shrinks but does not grow, so the menu button sits beside the last tab
+ * instead of being pushed to the far end of the header. The vertical padding
+ * keeps the clip off the tabs themselves — an active tab's border is inside the
+ * box rather than on its boundary.
+ */
+const TABS: React.CSSProperties = {
+  position: 'relative',
+  flex: '0 1 auto',
+  minWidth: 0,
   paddingBlock: 2,
   overflow: 'hidden',
 }
@@ -142,25 +171,30 @@ const MEASURING_ROW: React.CSSProperties = {
 function OverflowMenu({
   pages,
   activePageId,
+  label,
   locked,
   onSelect,
 }: {
   pages: readonly DashboardPage[]
   activePageId: string
+  /** What the button reads: a count, or the current page when no tab fits. */
+  label: string
   locked: boolean
   onSelect: (page: DashboardPage) => void
 }) {
   const { open, setOpen, toggle, containerRef } = useDismissablePopover<HTMLDivElement>()
 
   return (
-    <div ref={containerRef} style={{ position: 'relative', flexShrink: 0 }}>
+    // `maxWidth` rather than a shrinking button: a page name can be long, and
+    // one that overran the strip would be clipped by it exactly as a tab would.
+    <div ref={containerRef} style={{ position: 'relative', flexShrink: 0, maxWidth: '100%' }}>
       <button
         type="button"
         onClick={toggle}
         aria-expanded={open}
-        className="text-[11px] px-2 py-1 rounded-md border border-white/[0.08] text-zinc-400 hover:text-zinc-200 hover:bg-white/[0.06] transition-colors whitespace-nowrap"
+        className="max-w-full truncate text-[11px] px-2 py-1 rounded-md border border-white/[0.08] text-zinc-400 hover:text-zinc-200 hover:bg-white/[0.06] transition-colors whitespace-nowrap"
       >
-        {pages.length} more
+        {label}
       </button>
 
       {open && (

--- a/frontend/src/components/pages/PageTabs.tsx
+++ b/frontend/src/components/pages/PageTabs.tsx
@@ -115,7 +115,9 @@ const ROW: React.CSSProperties = {
   alignItems: 'center',
   gap: TAB_GAP,
   // A tab is never half on screen: what does not fit is in the menu, not
-  // clipped at the edge.
+  // clipped at the edge. The padding keeps that clip off the tabs themselves,
+  // so an active tab's border is inside the box rather than on its boundary.
+  paddingBlock: 2,
   overflow: 'hidden',
 }
 
@@ -172,7 +174,6 @@ function OverflowMenu({
                 page={page}
                 active={page.id === activePageId}
                 locked={locked}
-                block
                 onSelect={(selected) => {
                   setOpen(false)
                   onSelect(selected)
@@ -190,13 +191,11 @@ function PageLink({
   page,
   active,
   locked,
-  block = false,
   onSelect,
 }: {
   page: DashboardPage
   active: boolean
   locked: boolean
-  block?: boolean
   onSelect: (page: DashboardPage) => void
 }) {
   return (
@@ -216,16 +215,22 @@ function PageLink({
         event.preventDefault()
         if (!locked) onSelect(page)
       }}
-      className={`${tabClass(active)} ${block ? 'block' : ''} ${locked ? 'cursor-not-allowed opacity-50' : ''}`}
+      className={`${tabClass(active)} ${locked ? 'cursor-not-allowed opacity-50' : ''}`}
     >
       {page.name}
     </a>
   )
 }
 
-/** One class list, so the hidden measuring row measures the tabs that ship. */
+/**
+ * One class list, so the hidden measuring row measures the tabs that ship.
+ *
+ * `block` is load-bearing, not styling. An inline anchor's vertical padding and
+ * border hang outside its line box, so the strip — which clips what does not fit
+ * — would cut the bottom off the tab the operator is on.
+ */
 function tabClass(active: boolean): string {
-  return `whitespace-nowrap rounded-md px-2.5 py-1 text-[11px] transition-colors ${
+  return `block whitespace-nowrap rounded-md px-2.5 py-1 text-[11px] transition-colors ${
     active
       ? 'bg-[#76B900]/15 text-[#cfe98a] border border-[#76B900]/30'
       : 'border border-transparent text-zinc-400 hover:text-zinc-200 hover:bg-white/[0.06]'

--- a/frontend/src/components/pages/PagesMenu.tsx
+++ b/frontend/src/components/pages/PagesMenu.tsx
@@ -36,6 +36,11 @@ interface PagesMenuProps {
  * that page; resetting takes everything and cannot be undone, so it asks first —
  * in place, because a confirmation the operator has to hunt for in a modal is
  * one they learn to dismiss without reading.
+ *
+ * Naming a page and renaming one are deliberately the same control. A page is
+ * created named after its position and renamed from the field above, which is
+ * why creating one leaves this menu open: the next thing an operator does with
+ * a new page is call it something.
  */
 export function PagesMenu({
   page,
@@ -49,6 +54,13 @@ export function PagesMenu({
   onResetEverything,
 }: PagesMenuProps) {
   const { open, setOpen, toggle, containerRef } = useDismissablePopover<HTMLDivElement>()
+
+  /** Every action here changes the page the menu is describing, so it gets the
+   *  menu out of the way of whatever it did. */
+  const andClose = (action: () => void) => () => {
+    setOpen(false)
+    action()
+  }
 
   const disabled = readOnly || locked || busy
   const reason = readOnly
@@ -86,7 +98,11 @@ export function PagesMenu({
 
           <div className="h-px bg-white/[0.06]" />
 
-          <MenuButton disabled={disabled} onClick={() => close(setOpen, onCreate)}>
+          {/* The one action that does *not* close the menu. Creating a page and
+              naming it is one job, and the field that names it is right above:
+              the menu re-keys to the page that was just made, so the operator
+              types over “Page 3” instead of hunting for this menu again. */}
+          <MenuButton disabled={disabled} onClick={onCreate}>
             New page
           </MenuButton>
 
@@ -94,27 +110,18 @@ export function PagesMenu({
             disabled={disabled || !canDelete}
             hint={canDelete ? undefined : 'The dashboard always has at least one page.'}
             tone="danger"
-            onClick={() => close(setOpen, onDelete)}
+            onClick={andClose(onDelete)}
           >
             Delete “{page.name}”
           </MenuButton>
 
           <div className="h-px bg-white/[0.06]" />
 
-          <ResetEverything
-            disabled={disabled}
-            onConfirm={() => close(setOpen, onResetEverything)}
-          />
+          <ResetEverything disabled={disabled} onConfirm={andClose(onResetEverything)} />
         </section>
       )}
     </div>
   )
-}
-
-/** Runs the action and gets the menu out of the way of whatever it did. */
-function close(setOpen: (open: boolean) => void, action: () => void): void {
-  setOpen(false)
-  action()
 }
 
 /**

--- a/frontend/src/components/pages/PagesMenu.tsx
+++ b/frontend/src/components/pages/PagesMenu.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react'
+import { useDismissablePopover } from '@/hooks/useDismissablePopover'
+import type { DashboardPage } from '@/lib/dashboard/schema'
+
+interface PagesMenuProps {
+  /** The page being viewed — the one this menu renames and deletes. */
+  page: DashboardPage
+  /** False for the only page there is: deleting it would leave nothing to show. */
+  canDelete: boolean
+  /** Nothing can be written on this instance; the standing banner says why. */
+  readOnly: boolean
+  /** A layout edit is open, so the page list must hold still until it is settled. */
+  locked: boolean
+  /** A page write is in flight; a second one would race it. */
+  busy: boolean
+  onCreate: () => void
+  onRename: (name: string) => void
+  onDelete: () => void
+  onResetEverything: () => void
+}
+
+/**
+ * Where a page is made, named, thrown away — and where the whole configuration
+ * is reset.
+ *
+ * A menu rather than controls on the tabs themselves: renaming and deleting are
+ * occasional, and a tab strip covered in affordances is a strip you cannot
+ * click to switch pages, which is the thing it is for.
+ *
+ * These edits are **written when they are made**, unlike a layout change. A drag
+ * is one of hundreds of intermediate positions and needs a session to hold it;
+ * "create a page" is already the deliberate, named request that a save button
+ * would only ask the operator to repeat.
+ *
+ * Reset is two-tiered, and only one tier is destructive. Deleting a page takes
+ * that page; resetting takes everything and cannot be undone, so it asks first —
+ * in place, because a confirmation the operator has to hunt for in a modal is
+ * one they learn to dismiss without reading.
+ */
+export function PagesMenu({
+  page,
+  canDelete,
+  readOnly,
+  locked,
+  busy,
+  onCreate,
+  onRename,
+  onDelete,
+  onResetEverything,
+}: PagesMenuProps) {
+  const { open, setOpen, toggle, containerRef } = useDismissablePopover<HTMLDivElement>()
+
+  const disabled = readOnly || locked || busy
+  const reason = readOnly
+    ? 'This dashboard is read-only, so its pages cannot be changed.'
+    : locked
+      ? 'Save or discard your layout changes to add, rename or delete pages.'
+      : null
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="text-[10px] uppercase tracking-wider px-2 py-1 rounded border border-white/[0.08] text-zinc-400 hover:text-zinc-200 hover:bg-white/[0.06] transition-colors"
+      >
+        Pages
+      </button>
+
+      {open && (
+        <section
+          aria-label="Page settings"
+          className="absolute right-0 top-full z-20 mt-1 w-64 rounded-md border border-white/[0.08] bg-[#0d0d10] p-2 shadow-xl flex flex-col gap-2"
+        >
+          {reason && <p className="text-[11px] text-amber-300/90 leading-snug">{reason}</p>}
+
+          <RenameField
+            // Keyed by the page, so switching pages starts the field from the
+            // page now being viewed rather than from the last one.
+            key={page.id}
+            page={page}
+            disabled={disabled}
+            onRename={onRename}
+          />
+
+          <div className="h-px bg-white/[0.06]" />
+
+          <MenuButton disabled={disabled} onClick={() => close(setOpen, onCreate)}>
+            New page
+          </MenuButton>
+
+          <MenuButton
+            disabled={disabled || !canDelete}
+            hint={canDelete ? undefined : 'The dashboard always has at least one page.'}
+            tone="danger"
+            onClick={() => close(setOpen, onDelete)}
+          >
+            Delete “{page.name}”
+          </MenuButton>
+
+          <div className="h-px bg-white/[0.06]" />
+
+          <ResetEverything
+            disabled={disabled}
+            onConfirm={() => close(setOpen, onResetEverything)}
+          />
+        </section>
+      )}
+    </div>
+  )
+}
+
+/** Runs the action and gets the menu out of the way of whatever it did. */
+function close(setOpen: (open: boolean) => void, action: () => void): void {
+  setOpen(false)
+  action()
+}
+
+/**
+ * The page's name, edited in place.
+ *
+ * A form, so Enter submits — renaming is a one-field job and reaching for a
+ * button with the cursor already in the field is friction for nothing. Unlike a
+ * panel title, it is not applied on every keystroke: this writes to the server,
+ * and a per-character write of a document everyone on the instance shares is not
+ * a rename, it is a denial of service.
+ */
+function RenameField({
+  page,
+  disabled,
+  onRename,
+}: {
+  page: DashboardPage
+  disabled: boolean
+  onRename: (name: string) => void
+}) {
+  const [draft, setDraft] = useState(page.name)
+  const unchanged = draft.trim().length === 0 || draft.trim() === page.name
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (!disabled && !unchanged) onRename(draft)
+      }}
+      className="flex flex-col gap-1"
+    >
+      <label className="flex flex-col gap-1 text-[11px] text-zinc-500">
+        <span>Page name</span>
+        <input
+          type="text"
+          value={draft}
+          disabled={disabled}
+          onChange={(event) => setDraft(event.target.value)}
+          className="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-2 py-1 text-[11px] text-zinc-200 disabled:opacity-50 focus:outline-none focus:ring-1 focus:ring-[#76B900]/60"
+        />
+      </label>
+      <MenuButton disabled={disabled || unchanged} submit>
+        Rename
+      </MenuButton>
+    </form>
+  )
+}
+
+/**
+ * The reset that takes everything: the stored document is removed, and the
+ * default preset — which *is* the absence of the document — comes back.
+ *
+ * Two clicks, with the second one spelling out what goes. A page delete asks for
+ * no confirmation because it takes one page the operator can see; this takes
+ * every arrangement on the instance, including colleagues' work.
+ */
+function ResetEverything({ disabled, onConfirm }: { disabled: boolean; onConfirm: () => void }) {
+  const [asking, setAsking] = useState(false)
+
+  if (!asking) {
+    return (
+      <MenuButton disabled={disabled} tone="danger" onClick={() => setAsking(true)}>
+        Reset everything
+      </MenuButton>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5" role="group" aria-label="Confirm reset">
+      <p className="text-[11px] text-zinc-400 leading-snug">
+        Delete every page on this dashboard and go back to the default? This cannot be undone.
+      </p>
+      <div className="flex gap-1.5">
+        <MenuButton disabled={disabled} tone="danger" onClick={onConfirm}>
+          Reset everything
+        </MenuButton>
+        <MenuButton onClick={() => setAsking(false)}>Cancel</MenuButton>
+      </div>
+    </div>
+  )
+}
+
+function MenuButton({
+  children,
+  disabled = false,
+  submit = false,
+  tone = 'normal',
+  hint,
+  onClick,
+}: {
+  children: React.ReactNode
+  disabled?: boolean
+  submit?: boolean
+  tone?: 'normal' | 'danger'
+  /** Why the button is unavailable, said in the row rather than in a tooltip. */
+  hint?: string
+  onClick?: () => void
+}) {
+  return (
+    <div className="flex-1">
+      <button
+        type={submit ? 'submit' : 'button'}
+        onClick={onClick}
+        disabled={disabled}
+        className={`w-full text-left px-2 py-1.5 rounded text-[11px] border transition-colors ${
+          disabled
+            ? 'border-white/[0.04] text-zinc-600 cursor-not-allowed'
+            : tone === 'danger'
+              ? 'border-red-500/30 text-red-300 hover:bg-red-500/10'
+              : 'border-white/[0.08] text-zinc-300 hover:bg-white/[0.06] hover:text-zinc-100'
+        }`}
+      >
+        {children}
+      </button>
+      {hint && disabled && <p className="mt-1 px-2 text-[10px] text-zinc-600">{hint}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/pages/tabFit.test.ts
+++ b/frontend/src/components/pages/tabFit.test.ts
@@ -46,8 +46,21 @@ describe('fitTabs', () => {
     expect(layout).toEqual({ visible: [0, 3], overflow: [1, 2] })
   })
 
-  it('shows the page being viewed even when it is the only thing that fits', () => {
-    expect(fitTabs([100, 400, 100], 1, 200)).toEqual({ visible: [1], overflow: [0, 2] })
+  it('shows the page being viewed when it is the only thing that fits', () => {
+    const available = OVERFLOW_BUTTON_WIDTH + TAB_GAP + 100
+
+    expect(fitTabs([300, 100, 300], 1, available)).toEqual({ visible: [1], overflow: [0, 2] })
+  })
+
+  it('gives the space to the tabs that do fit when the page being viewed cannot', () => {
+    // Rather than forcing a 400px tab through a 120px opening. Saying where the
+    // operator is falls to the menu button, which takes the page's name.
+    expect(fitTabs([100, 400, 100], 1, 200)).toEqual({ visible: [0], overflow: [1, 2] })
+  })
+
+  it('empties the strip when there is no room for anything at all', () => {
+    // A phone, where the masthead and the badge leave the strip almost nothing.
+    expect(fitTabs([100, 100], 0, 20)).toEqual({ visible: [], overflow: [0, 1] })
   })
 
   it('fills from the front when the URL names no page in the list', () => {

--- a/frontend/src/components/pages/tabFit.test.ts
+++ b/frontend/src/components/pages/tabFit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { fitTabs, OVERFLOW_BUTTON_WIDTH, TAB_GAP } from './tabFit'
+
+/** The width a strip of `count` equal tabs needs, gaps included. */
+function strip(width: number, count: number): number {
+  return width * count + TAB_GAP * (count - 1)
+}
+
+describe('fitTabs', () => {
+  it('shows every tab when the strip has not been measured, rather than hiding them all', () => {
+    expect(fitTabs([100, 100, 100], 0, 0)).toEqual({ visible: [0, 1, 2], overflow: [] })
+  })
+
+  it('shows every tab when they all fit, with no menu to open', () => {
+    expect(fitTabs([100, 100, 100], 0, strip(100, 3))).toEqual({
+      visible: [0, 1, 2],
+      overflow: [],
+    })
+  })
+
+  it('counts the gaps between tabs, not just the tabs', () => {
+    // One pixel short of the gaps is one pixel short.
+    expect(fitTabs([100, 100, 100], 0, strip(100, 3) - 1).overflow).not.toEqual([])
+  })
+
+  it('moves the tabs that do not fit into the menu, keeping document order', () => {
+    // Room for two tabs beside the menu button, and no more.
+    const available = OVERFLOW_BUTTON_WIDTH + TAB_GAP + strip(100, 2)
+
+    expect(fitTabs([100, 100, 100, 100], 0, available)).toEqual({
+      visible: [0, 1],
+      overflow: [2, 3],
+    })
+  })
+
+  it('reserves room for the menu button, so it never lands on top of a tab', () => {
+    // Four tabs fit exactly — until the button they overflow into is paid for.
+    expect(fitTabs([100, 100, 100, 100, 100], 0, strip(100, 4)).visible).toEqual([0, 1, 2])
+  })
+
+  it('keeps the page being viewed on the strip when it sits past the fold', () => {
+    const available = OVERFLOW_BUTTON_WIDTH + TAB_GAP + strip(100, 2)
+    const layout = fitTabs([100, 100, 100, 100], 3, available)
+
+    // The active tab displaces a leading one rather than reordering the strip.
+    expect(layout).toEqual({ visible: [0, 3], overflow: [1, 2] })
+  })
+
+  it('shows the page being viewed even when it is the only thing that fits', () => {
+    expect(fitTabs([100, 400, 100], 1, 200)).toEqual({ visible: [1], overflow: [0, 2] })
+  })
+
+  it('fills from the front when the URL names no page in the list', () => {
+    const available = OVERFLOW_BUTTON_WIDTH + TAB_GAP + strip(100, 2)
+
+    expect(fitTabs([100, 100, 100, 100], -1, available)).toEqual({
+      visible: [0, 1],
+      overflow: [2, 3],
+    })
+  })
+
+  it('stops at the first tab that does not fit, so a narrow tab never jumps a wide one', () => {
+    const available = OVERFLOW_BUTTON_WIDTH + TAB_GAP + strip(100, 2)
+
+    // The 300px tab does not fit; the 40px one behind it stays behind it.
+    expect(fitTabs([100, 300, 40], 0, available)).toEqual({ visible: [0], overflow: [1, 2] })
+  })
+
+  it('has nothing to show for a document with no pages', () => {
+    expect(fitTabs([], -1, 500)).toEqual({ visible: [], overflow: [] })
+  })
+})

--- a/frontend/src/components/pages/tabFit.ts
+++ b/frontend/src/components/pages/tabFit.ts
@@ -1,0 +1,92 @@
+/**
+ * How many page tabs the header shows, and which ones go in the overflow menu.
+ *
+ * The header is a fixed strip that also carries the product title and the
+ * connection badge, so a dashboard with a dozen pages cannot simply grow more
+ * tabs — past some number they would push the badge off the end, or wrap the
+ * masthead onto a second line and cost the grid below the very viewport height
+ * the whole layout is built to fit. Tabs that do not fit move into a menu
+ * instead, which is what keeps the header usable at any page count.
+ *
+ * The decision is a pure function of measured widths so it can be reasoned about
+ * and tested without a browser; the measuring itself is `PageTabs`'s job.
+ *
+ * **Zero available width means unmeasured, not "no room".** jsdom measures every
+ * box as 0×0, and so does the first frame before layout — concluding "nothing
+ * fits" from that would hide every tab behind a menu on a header that has not
+ * been laid out yet, which is precisely the wrong default. Unmeasured shows
+ * everything, exactly as an unmeasured grid refuses to conclude anything about a
+ * drop.
+ */
+
+/** Horizontal gap between tabs, in px. Must match the strip's `gap-*` class. */
+export const TAB_GAP = 4
+
+/**
+ * Width reserved for the overflow button, in px. A constant rather than a
+ * measurement: the button only exists when something overflows, so measuring it
+ * would make its width depend on the answer it is an input to. Generous enough
+ * to cover its widest label, and being a little conservative only ever moves one
+ * more tab into a menu that is already open for business.
+ */
+export const OVERFLOW_BUTTON_WIDTH = 76
+
+/** Which tabs are on the strip and which are behind the menu, as indices. */
+export interface TabLayout {
+  /** In document order, so the tabs never reshuffle under the pointer. */
+  visible: number[]
+  overflow: number[]
+}
+
+/**
+ * The tabs that fit in `available` px, given each tab's natural width.
+ *
+ * **The page being viewed is always one of them.** When it sits past the point
+ * where the strip runs out, it takes the place of the leading tabs that would
+ * otherwise have filled the space — the operator is never left looking at a
+ * header that does not say where they are. Everything else fills in from the
+ * front, in document order.
+ */
+export function fitTabs(
+  widths: readonly number[],
+  activeIndex: number,
+  available: number,
+): TabLayout {
+  const all = widths.map((_, index) => index)
+  if (available <= 0 || rowWidth(widths, all) <= available) return { visible: all, overflow: [] }
+
+  // Something is overflowing, so the menu button is on screen and costs width.
+  const budget = available - OVERFLOW_BUTTON_WIDTH - TAB_GAP
+  const active = activeIndex >= 0 && activeIndex < widths.length ? activeIndex : null
+
+  const chosen = new Set<number>()
+  let used = 0
+
+  /** Spends the width one more tab costs, gap included once there is a tab to sit beside. */
+  const place = (index: number) => {
+    used += widths[index] + (chosen.size > 0 ? TAB_GAP : 0)
+    chosen.add(index)
+  }
+
+  // The active tab is not negotiable, so its width comes off the top — even when
+  // it is the only thing that fits, and even when it does not.
+  if (active !== null) place(active)
+
+  for (const index of all) {
+    if (chosen.has(index)) continue
+    if (used + widths[index] + (chosen.size > 0 ? TAB_GAP : 0) > budget) break
+    place(index)
+  }
+
+  return {
+    visible: all.filter((index) => chosen.has(index)),
+    overflow: all.filter((index) => !chosen.has(index)),
+  }
+}
+
+/** What a row of these tabs measures, gaps between them included. */
+function rowWidth(widths: readonly number[], indices: readonly number[]): number {
+  if (indices.length === 0) return 0
+  const tabs = indices.reduce((total, index) => total + widths[index], 0)
+  return tabs + TAB_GAP * (indices.length - 1)
+}

--- a/frontend/src/components/pages/tabFit.ts
+++ b/frontend/src/components/pages/tabFit.ts
@@ -41,11 +41,17 @@ export interface TabLayout {
 /**
  * The tabs that fit in `available` px, given each tab's natural width.
  *
- * **The page being viewed is always one of them.** When it sits past the point
- * where the strip runs out, it takes the place of the leading tabs that would
- * otherwise have filled the space — the operator is never left looking at a
- * header that does not say where they are. Everything else fills in from the
- * front, in document order.
+ * **The page being viewed comes first.** When it sits past the point where the
+ * strip runs out, it takes the place of the leading tabs that would otherwise
+ * have filled the space, so the operator is not left looking at a header that
+ * does not say where they are. Everything else fills in from the front, in
+ * document order.
+ *
+ * When even that page will not fit, the space goes to whatever does, and on a
+ * phone — where the masthead and the badge leave the strip almost nothing —
+ * that is nothing at all, so the strip comes back **empty**. Either way, saying
+ * where the operator is falls to the menu button, which takes the page's name;
+ * a tab forced through the clip edge would claim to say it and fail.
  */
 export function fitTabs(
   widths: readonly number[],
@@ -68,9 +74,10 @@ export function fitTabs(
     chosen.add(index)
   }
 
-  // The active tab is not negotiable, so its width comes off the top — even when
-  // it is the only thing that fits, and even when it does not.
-  if (active !== null) place(active)
+  // The active tab gets first refusal on the space — but only if it fits.
+  // Forcing it on would put a tab through the clip edge, which reads as a
+  // rendering fault rather than as a header with no room.
+  if (active !== null && widths[active] <= budget) place(active)
 
   for (const index of all) {
     if (chosen.has(index)) continue

--- a/frontend/src/hooks/useDashboardConfiguration.ts
+++ b/frontend/src/hooks/useDashboardConfiguration.ts
@@ -1,6 +1,7 @@
 /**
  * The configuration lifecycle: load it once at boot, save it when the operator
- * asks, and keep whatever the operator needs telling about.
+ * asks, remove it when they reset, and keep whatever the operator needs telling
+ * about.
  *
  * Two rules shape everything here, both from the fact that the configuration is
  * **instance-scoped** — one document shared by everyone who opens the dashboard:
@@ -19,27 +20,38 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  deleteStoredConfiguration,
   fetchStoredConfiguration,
   saveStoredConfiguration,
+  type ResetOutcome,
   type SaveOutcome,
 } from '@/lib/dashboard/client'
 import { loadDashboardConfiguration, type ConfigurationFallbackReason } from '@/lib/dashboard/load'
 import type { MigrationPath } from '@/lib/dashboard/migrations'
 import type { ConfigurationNotice } from '@/lib/dashboard/notices'
+import { defaultDashboardDocument } from '@/lib/dashboard/preset'
 import type { DashboardDocument } from '@/lib/dashboard/schema'
 
-type SaveFailureNotice = 'save-failed' | 'too-large' | null
+type WriteFailureNotice = 'save-failed' | 'too-large' | 'reset-failed' | null
 
 /**
  * How a save's outcome reads to the operator. Read-only is not here: it is a
  * property of the instance rather than of the attempt, and it has its own
  * standing notice as long as it holds.
  */
-const SAVE_FAILURE_NOTICE: Record<SaveOutcome['status'], SaveFailureNotice> = {
+const SAVE_FAILURE_NOTICE: Record<SaveOutcome['status'], WriteFailureNotice> = {
   saved: null,
   'read-only': null,
   'too-large': 'too-large',
   failed: 'save-failed',
+}
+
+/** The same, for a reset. It is a different sentence because it is a different
+ *  thing that did not happen: nothing was removed, rather than nothing stored. */
+const RESET_FAILURE_NOTICE: Record<ResetOutcome['status'], WriteFailureNotice> = {
+  reset: null,
+  'read-only': null,
+  failed: 'reset-failed',
 }
 
 export interface DashboardConfigurationState {
@@ -59,6 +71,11 @@ export interface DashboardConfigurationState {
    * server never accepted.
    */
   save: (document: DashboardDocument) => Promise<SaveOutcome['status']>
+  /**
+   * Removes the stored document, putting every page back to the default preset.
+   * Destructive and unrecoverable, so the caller confirms first.
+   */
+  reset: () => Promise<ResetOutcome['status']>
 }
 
 /**
@@ -73,7 +90,7 @@ export function useDashboardConfiguration(path?: MigrationPath): DashboardConfig
   const [fallback, setFallback] = useState<ConfigurationFallbackReason | null>(null)
   const [unavailable, setUnavailable] = useState(false)
   const [readOnly, setReadOnly] = useState(false)
-  const [saveFailure, setSaveFailure] = useState<SaveFailureNotice>(null)
+  const [writeFailure, setWriteFailure] = useState<WriteFailureNotice>(null)
   const pathRef = useRef(path)
 
   useEffect(() => {
@@ -112,7 +129,7 @@ export function useDashboardConfiguration(path?: MigrationPath): DashboardConfig
 
       const outcome = await saveStoredConfiguration(next)
       setReadOnly(outcome.readOnly)
-      setSaveFailure(SAVE_FAILURE_NOTICE[outcome.status])
+      setWriteFailure(SAVE_FAILURE_NOTICE[outcome.status])
 
       if (outcome.status === 'saved') {
         // What was stored is now what this build wrote, so any complaint about
@@ -128,14 +145,36 @@ export function useDashboardConfiguration(path?: MigrationPath): DashboardConfig
     [readOnly],
   )
 
+  const reset = useCallback(async (): Promise<ResetOutcome['status']> => {
+    if (readOnly) return 'read-only'
+
+    const outcome = await deleteStoredConfiguration()
+    setReadOnly(outcome.readOnly)
+    setWriteFailure(RESET_FAILURE_NOTICE[outcome.status])
+
+    if (outcome.status === 'reset') {
+      // The preset is held rather than re-fetched: it is exactly what a read of
+      // the now-absent document would resolve to, and going back to the server
+      // for an answer already known is a round trip the operator waits through.
+      setDocument(defaultDashboardDocument())
+      // Every complaint about the stored document described one that no longer
+      // exists — including one written by a build this cannot read, which is
+      // what makes a reset the way out of a rollback.
+      setFallback(null)
+      setUnavailable(false)
+    }
+
+    return outcome.status
+  }, [readOnly])
+
   const notices = useMemo((): ConfigurationNotice[] => {
     const list: ConfigurationNotice[] = []
     if (fallback) list.push(fallback)
     if (unavailable) list.push({ kind: 'unavailable' })
     if (readOnly) list.push({ kind: 'read-only' })
-    if (saveFailure) list.push({ kind: saveFailure })
+    if (writeFailure) list.push({ kind: writeFailure })
     return list
-  }, [fallback, unavailable, readOnly, saveFailure])
+  }, [fallback, unavailable, readOnly, writeFailure])
 
-  return { document, notices, readOnly, save }
+  return { document, notices, readOnly, save, reset }
 }

--- a/frontend/src/hooks/useRoute.ts
+++ b/frontend/src/hooks/useRoute.ts
@@ -3,14 +3,43 @@ import { parseRoute, type Route } from '@/lib/dashboard/routes'
 
 /**
  * The view the browser's current path names, kept current across history
- * navigation. `popstate` covers back/forward; a programmatic `pushState` must
- * be followed by dispatching a `popstate` event, which is the deal the future
- * in-app navigation (#85) signs up to — no custom event channel until someone
- * actually navigates.
+ * navigation. `popstate` covers back/forward; a programmatic `pushState` is
+ * followed by dispatching a `popstate` event — see `navigateTo` — so in-app
+ * navigation needs no custom event channel of its own.
  */
 export function useRoute(): Route {
   const pathname = useSyncExternalStore(subscribe, readPathname)
   return useMemo(() => parseRoute(pathname), [pathname])
+}
+
+/**
+ * Goes to another page without reloading the document.
+ *
+ * The browser fires `popstate` for its own back and forward, but not for a
+ * `pushState` — so this raises it, which is what `useRoute` subscribes to. Doing
+ * it here rather than in a store keeps the browser's history as the one source
+ * of truth for which page is showing: the URL is the state, so a reload, a
+ * bookmark and a back button all land in the same place.
+ *
+ * Navigating to where you already are is a no-op rather than a history entry, so
+ * clicking the tab you are on does not fill the back button with itself.
+ */
+export function navigateTo(pathname: string): void {
+  if (pathname === window.location.pathname) return
+  window.history.pushState(null, '', pathname)
+  window.dispatchEvent(new PopStateEvent('popstate'))
+}
+
+/**
+ * Corrects the current URL in place, without a history entry.
+ *
+ * This is what a rename does: the id in the path still matches, so the page has
+ * not changed and pressing back should leave the page rather than undo a slug.
+ */
+export function replacePath(pathname: string): void {
+  if (pathname === window.location.pathname) return
+  window.history.replaceState(null, '', pathname)
+  window.dispatchEvent(new PopStateEvent('popstate'))
 }
 
 function subscribe(onChange: () => void): () => void {

--- a/frontend/src/hooks/useRoute.ts
+++ b/frontend/src/hooks/useRoute.ts
@@ -25,9 +25,7 @@ export function useRoute(): Route {
  * clicking the tab you are on does not fill the back button with itself.
  */
 export function navigateTo(pathname: string): void {
-  if (pathname === window.location.pathname) return
-  window.history.pushState(null, '', pathname)
-  window.dispatchEvent(new PopStateEvent('popstate'))
+  go(pathname, 'push')
 }
 
 /**
@@ -37,8 +35,15 @@ export function navigateTo(pathname: string): void {
  * not changed and pressing back should leave the page rather than undo a slug.
  */
 export function replacePath(pathname: string): void {
+  go(pathname, 'replace')
+}
+
+function go(pathname: string, how: 'push' | 'replace'): void {
   if (pathname === window.location.pathname) return
-  window.history.replaceState(null, '', pathname)
+
+  if (how === 'push') window.history.pushState(null, '', pathname)
+  else window.history.replaceState(null, '', pathname)
+
   window.dispatchEvent(new PopStateEvent('popstate'))
 }
 

--- a/frontend/src/lib/dashboard/client.test.ts
+++ b/frontend/src/lib/dashboard/client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   CONFIGURATION_URL,
   READ_ONLY_HEADER,
+  deleteStoredConfiguration,
   fetchStoredConfiguration,
   saveStoredConfiguration,
 } from './client'
@@ -169,5 +170,51 @@ describe('saveStoredConfiguration', () => {
       status: 'failed',
       readOnly: false,
     })
+  })
+})
+
+describe('deleteStoredConfiguration', () => {
+  it('deletes the document rather than writing the preset over it', async () => {
+    // The reset is an absence, not a document: that is what lets a preset
+    // reworded in a later release reach every dashboard that was ever reset.
+    const fetchMock = respondWith(new Response(null, { status: 204, headers: writable }))
+
+    expect(await deleteStoredConfiguration()).toEqual({ status: 'reset', readOnly: false })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(CONFIGURATION_URL)
+    expect(init?.method).toBe('DELETE')
+    expect(init?.body).toBeUndefined()
+  })
+
+  it('reports read-only when the instance cannot write at all', async () => {
+    respondWith(
+      new Response('Dashboard configuration storage is read-only', {
+        status: 503,
+        headers: readOnly,
+      }),
+    )
+
+    expect(await deleteStoredConfiguration()).toEqual({ status: 'read-only', readOnly: true })
+  })
+
+  it('reports a failure when the removal itself failed', async () => {
+    respondWith(
+      new Response('Failed to delete the dashboard configuration', {
+        status: 500,
+        headers: writable,
+      }),
+    )
+
+    expect(await deleteStoredConfiguration()).toEqual({ status: 'failed', readOnly: false })
+  })
+
+  it('reports a failure when the server cannot be reached', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))),
+    )
+
+    expect(await deleteStoredConfiguration()).toEqual({ status: 'failed', readOnly: false })
   })
 })

--- a/frontend/src/lib/dashboard/client.ts
+++ b/frontend/src/lib/dashboard/client.ts
@@ -53,6 +53,18 @@ export interface SaveOutcome {
   readOnly: boolean
 }
 
+/** How a reset ended. */
+export interface ResetOutcome {
+  status:
+    /** The document is gone, so the dashboard is back to the default preset. */
+    | 'reset'
+    /** This instance cannot write at all; no retry will change that. */
+    | 'read-only'
+    /** The removal failed — a permission, a dropped connection. Worth retrying. */
+    | 'failed'
+  readOnly: boolean
+}
+
 /** Reads the stored document. Never throws: every failure is a state above. */
 export async function fetchStoredConfiguration(): Promise<StoredConfiguration> {
   let response: Response
@@ -98,6 +110,31 @@ export async function saveStoredConfiguration(document: DashboardDocument): Prom
   // over the header if the two ever disagree.
   if (response.status === 503) return { status: 'read-only', readOnly: true }
   if (response.status === 413) return { status: 'too-large', readOnly }
+  return { status: 'failed', readOnly }
+}
+
+/**
+ * Removes the stored document. Never throws.
+ *
+ * A reset is a deletion rather than a write of the preset, because "nothing is
+ * configured" and "reset to the default" are deliberately the same state on
+ * disk — so a preset reworded in a later release reaches every dashboard that
+ * was reset, instead of freezing today's arrangement into a document forever.
+ */
+export async function deleteStoredConfiguration(): Promise<ResetOutcome> {
+  let response: Response
+  try {
+    response = await fetch(CONFIGURATION_URL, { method: 'DELETE' })
+  } catch {
+    return { status: 'failed', readOnly: false }
+  }
+
+  const readOnly = isReadOnly(response)
+
+  if (response.ok) return { status: 'reset', readOnly }
+  // As with a write, the server answers 503 only for storage it knows is
+  // unwritable, so trust it over the header if the two ever disagree.
+  if (response.status === 503) return { status: 'read-only', readOnly: true }
   return { status: 'failed', readOnly }
 }
 

--- a/frontend/src/lib/dashboard/notices.ts
+++ b/frontend/src/lib/dashboard/notices.ts
@@ -25,3 +25,5 @@ export type ConfigurationNotice =
   | { kind: 'save-failed' }
   /** The last save was refused for the document's size; retrying will not help. */
   | { kind: 'too-large' }
+  /** The last reset did not remove the stored document, which is still there. */
+  | { kind: 'reset-failed' }

--- a/frontend/src/lib/dashboard/pages.test.ts
+++ b/frontend/src/lib/dashboard/pages.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { addPage, removePage, renamePage } from './pages'
+import { DASHBOARD_SCHEMA_VERSION, type DashboardDocument, type DashboardPage } from './schema'
+
+function documentOf(...pages: Array<Partial<DashboardPage>>): DashboardDocument {
+  return {
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: pages.map((page, index) => ({
+      id: page.id ?? `page-${index + 1}`,
+      name: page.name ?? `Page ${index + 1}`,
+      panels: page.panels ?? [],
+    })),
+  }
+}
+
+const names = (document: DashboardDocument) => document.pages.map((page) => page.name)
+const ids = (document: DashboardDocument) => document.pages.map((page) => page.id)
+
+describe('addPage', () => {
+  it('appends an empty page, so the operator drops straight into an edit session on it', () => {
+    const outcome = addPage(documentOf({ id: 'overview', name: 'Overview' }))
+
+    expect(outcome.document.pages).toHaveLength(2)
+    expect(outcome.document.pages[1]?.panels).toEqual([])
+    expect(outcome.document.pages[1]?.id).toBe(outcome.pageId)
+  })
+
+  it('names the page after its position, which is what the schema calls an unnamed one', () => {
+    const outcome = addPage(documentOf({ id: 'overview', name: 'Overview' }))
+
+    expect(names(outcome.document)).toEqual(['Overview', 'Page 2'])
+  })
+
+  it('skips a positional name the operator already used, rather than making two “Page 2” tabs', () => {
+    const outcome = addPage(documentOf({ name: 'Overview' }, { name: 'Page 3' }))
+
+    expect(names(outcome.document)).toEqual(['Overview', 'Page 3', 'Page 4'])
+  })
+
+  it('derives the id from the name, so the URL reads as the page did when it was made', () => {
+    const outcome = addPage(documentOf({ id: 'overview', name: 'Overview' }), 'Training View')
+
+    expect(outcome.pageId).toBe('training-view')
+    expect(names(outcome.document)).toEqual(['Overview', 'Training View'])
+  })
+
+  it('never reuses an id, because two pages on one id is two pages at one URL', () => {
+    const outcome = addPage(documentOf({ id: 'training-view', name: 'Training View' }), 'Training View')
+
+    expect(outcome.pageId).toBe('training-view-2')
+    expect(ids(outcome.document)).toEqual(['training-view', 'training-view-2'])
+  })
+
+  it('falls back to a positional id when the name has nothing a URL can carry', () => {
+    const outcome = addPage(documentOf({ id: 'overview' }), '???')
+
+    expect(outcome.pageId).toBe('page')
+    expect(outcome.document.pages[1]?.name).toBe('???')
+  })
+
+  it('leaves the other pages untouched, panels and all', () => {
+    const before = documentOf({ id: 'overview', name: 'Overview' })
+    const outcome = addPage(before)
+
+    expect(outcome.document.pages[0]).toBe(before.pages[0])
+    expect(outcome.document.version).toBe(before.version)
+  })
+})
+
+describe('renamePage', () => {
+  it('renames the page named and nothing else', () => {
+    const next = renamePage(documentOf({ id: 'a', name: 'Overview' }, { id: 'b', name: 'Logs' }), 'b', 'Debugging')
+
+    expect(names(next)).toEqual(['Overview', 'Debugging'])
+  })
+
+  it('keeps the id, which is the whole point of the id being separate from the name', () => {
+    const next = renamePage(documentOf({ id: 'overview', name: 'Overview' }), 'overview', 'Wall Display')
+
+    expect(ids(next)).toEqual(['overview'])
+  })
+
+  it('trims what the operator typed', () => {
+    const next = renamePage(documentOf({ id: 'a', name: 'Overview' }), 'a', '  Wall Display  ')
+
+    expect(names(next)).toEqual(['Wall Display'])
+  })
+
+  it('refuses a blank name, because a page with no name has no tab to click', () => {
+    const before = documentOf({ id: 'a', name: 'Overview' })
+
+    expect(renamePage(before, 'a', '   ')).toBe(before)
+  })
+
+  it('is the same document back when no page has that id', () => {
+    const before = documentOf({ id: 'a', name: 'Overview' })
+
+    expect(renamePage(before, 'gone', 'Anything')).toBe(before)
+  })
+})
+
+describe('removePage', () => {
+  /** Narrows the outcome, so a spec reads the removal rather than the union. */
+  function removed(document: DashboardDocument, pageId: string) {
+    const outcome = removePage(document, pageId)
+    if (outcome.status !== 'removed') throw new Error(`expected a removal, got ${outcome.status}`)
+    return outcome
+  }
+
+  it('removes the page and lands on the one before it', () => {
+    const outcome = removed(documentOf({ id: 'a' }, { id: 'b' }, { id: 'c' }), 'c')
+
+    expect(ids(outcome.document)).toEqual(['a', 'b'])
+    expect(outcome.nextPageId).toBe('b')
+  })
+
+  it('lands on the page after when the first one goes, so there is always somewhere to be', () => {
+    expect(removed(documentOf({ id: 'a' }, { id: 'b' }), 'a').nextPageId).toBe('b')
+  })
+
+  it('refuses the last page, which would leave the dashboard with nothing to show', () => {
+    expect(removePage(documentOf({ id: 'only' }), 'only')).toEqual({ status: 'last-page' })
+  })
+
+  it('changes nothing for a page the document does not have', () => {
+    const outcome = removed(documentOf({ id: 'a' }, { id: 'b' }), 'gone')
+
+    expect(ids(outcome.document)).toEqual(['a', 'b'])
+    expect(outcome.nextPageId).toBe('a')
+  })
+})

--- a/frontend/src/lib/dashboard/pages.ts
+++ b/frontend/src/lib/dashboard/pages.ts
@@ -1,0 +1,149 @@
+/**
+ * The page list an operator keeps by hand: making a page, naming it, and
+ * throwing one away.
+ *
+ * Pages are how one dashboard holds more than one arrangement — a training view
+ * and an idle health view, kept side by side instead of one being chosen
+ * permanently. Everything here is pure, and every function is a **replacement**:
+ * a document in, a document out, with the pages that were not touched kept by
+ * identity.
+ *
+ * Unlike a panel edit, a page edit is not part of an edit session. Creating,
+ * renaming and deleting are each a deliberate, named request rather than a
+ * side effect of dragging, so they are written when they are made — see
+ * `GridPageContent`, which is where that decision is carried out.
+ *
+ * Two invariants live here rather than in the UI, because they are properties of
+ * the document and every future caller needs them:
+ *
+ * - **A page id is never reused.** It is what a page's URL is built from, so two
+ *   pages sharing one would be two pages at one address.
+ * - **The last page cannot be deleted.** A document with no pages has nothing to
+ *   render; starting over is what a reset is for, and it asks first.
+ */
+
+import { pageSlug } from './routes'
+import type { DashboardDocument, DashboardPage } from './schema'
+
+/** A page was made; `pageId` is the one to navigate to. */
+export interface AddPageOutcome {
+  document: DashboardDocument
+  pageId: string
+}
+
+/**
+ * The document with one more page at the end, empty.
+ *
+ * Empty rather than pre-populated: a new page exists because the preset's
+ * arrangement is not the one wanted, so seeding it with the preset's panels
+ * would be work to undo. The operator lands on it and adds what they came for.
+ *
+ * `name` is optional because creating a page and naming it are separate moves —
+ * the tab appears first, and renaming it is the same action as renaming any
+ * other page.
+ */
+export function addPage(document: DashboardDocument, name?: string): AddPageOutcome {
+  const chosen = name?.trim() || unusedPageName(document.pages)
+  const pageId = unusedPageId(document.pages, chosen)
+
+  return {
+    pageId,
+    document: { ...document, pages: [...document.pages, { id: pageId, name: chosen, panels: [] }] },
+  }
+}
+
+/**
+ * The document with one page renamed. The **id is untouched**, which is the
+ * whole reason it is separate from the name: a kiosk browser pointed at the page
+ * comes back to it after the rename.
+ *
+ * A blank name is refused rather than stored. There is nothing to click on a tab
+ * with no name, and unlike a panel title — which falls back to its type's
+ * default — a page has no second name to fall back to.
+ */
+export function renamePage(
+  document: DashboardDocument,
+  pageId: string,
+  name: string,
+): DashboardDocument {
+  const trimmed = name.trim()
+  const page = document.pages.find((candidate) => candidate.id === pageId)
+  if (!page || trimmed.length === 0 || trimmed === page.name) return document
+
+  return {
+    ...document,
+    pages: document.pages.map((candidate) =>
+      candidate.id === pageId ? { ...candidate, name: trimmed } : candidate,
+    ),
+  }
+}
+
+/** What became of a request to delete a page. */
+export type RemovePageOutcome =
+  | {
+      status: 'removed'
+      document: DashboardDocument
+      /** The page to show next — the neighbour of the one that went. */
+      nextPageId: string
+    }
+  /** The only page there is. Deleting it would leave nothing to render. */
+  | { status: 'last-page' }
+
+/**
+ * The document without one page, and where the operator goes instead.
+ *
+ * The page before it, or the one after when the first page went. Somewhere
+ * concrete either way: dropping the operator on a URL that names nothing would
+ * turn a delete into an error page.
+ */
+export function removePage(document: DashboardDocument, pageId: string): RemovePageOutcome {
+  if (document.pages.length <= 1) return { status: 'last-page' }
+
+  const position = document.pages.findIndex((page) => page.id === pageId)
+  const pages = document.pages.filter((page) => page.id !== pageId)
+  // Below zero is a page the document never had; the first remaining page is as
+  // good an answer as any, and better than none.
+  const neighbour = pages[Math.max(0, position - 1)] ?? pages[0]
+
+  return { status: 'removed', document: { ...document, pages }, nextPageId: neighbour.id }
+}
+
+/** Whether deleting is available at all, so the control can say why it is not. */
+export function canRemovePage(document: DashboardDocument): boolean {
+  return document.pages.length > 1
+}
+
+/**
+ * A name nothing else holds, following the numbering the schema itself uses for
+ * a page that arrived without one. It starts past the end of the list, so the
+ * name usually matches the tab's position — and it skips anything taken, because
+ * two identically named tabs are indistinguishable to the operator clicking one.
+ */
+function unusedPageName(pages: readonly DashboardPage[]): string {
+  const taken = new Set(pages.map((page) => page.name))
+
+  for (let position = pages.length + 1; ; position++) {
+    const candidate = `Page ${position}`
+    if (!taken.has(candidate)) return candidate
+  }
+}
+
+/**
+ * An id nothing else holds, derived from the name so the URL reads as the page
+ * did when it was made — the preset's own `overview` is the same shape.
+ *
+ * It is derived **once, at creation**, and never again: from here on the id and
+ * the name are independent, which is what lets the URL survive a rename.
+ */
+function unusedPageId(pages: readonly DashboardPage[], name: string): string {
+  const taken = new Set(pages.map((page) => page.id))
+  // A name of nothing but punctuation slugs to nothing, and every page still
+  // needs an address.
+  const base = pageSlug(name) || 'page'
+  if (!taken.has(base)) return base
+
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${base}-${suffix}`
+    if (!taken.has(candidate)) return candidate
+  }
+}

--- a/frontend/src/test/configurationServer.ts
+++ b/frontend/src/test/configurationServer.ts
@@ -26,16 +26,32 @@ export interface ConfigurationServerOptions {
   getStatus?: number
   /** The write's status: 204 stored, 503 read-only, 413 too large, 500 failed. */
   putStatus?: number
+  /** The reset's status: 204 removed, 503 read-only, 500 failed. */
+  deleteStatus?: number
 }
 
-/** Installs the stub as the global `fetch` and hands it back for assertions. */
+/**
+ * Installs the stub as the global `fetch` and hands it back for assertions.
+ *
+ * It **holds what was written**, the way the real server does: an accepted write
+ * is what a later read returns, and an accepted reset makes reads report nothing
+ * stored again. A stub that answered from the original bytes forever would let a
+ * spec claim a round trip it never made.
+ */
 export function serveConfiguration(options: ConfigurationServerOptions = {}): FetchMock {
-  const { document = null, readOnly = false, getStatus, putStatus = 204 } = options
+  const { document = null, readOnly = false, getStatus, putStatus = 204, deleteStatus = 204 } =
+    options
   const headers = { [READ_ONLY_HEADER]: String(readOnly) }
+  let stored = document
 
   const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
     if (init?.method === 'PUT') {
+      if (accepted(putStatus)) stored = String(init.body)
       return Promise.resolve(new Response(null, { status: putStatus, headers }))
+    }
+    if (init?.method === 'DELETE') {
+      if (accepted(deleteStatus)) stored = null
+      return Promise.resolve(new Response(null, { status: deleteStatus, headers }))
     }
     if (getStatus !== undefined && getStatus !== 200) {
       return Promise.resolve(
@@ -43,14 +59,19 @@ export function serveConfiguration(options: ConfigurationServerOptions = {}): Fe
       )
     }
     return Promise.resolve(
-      document === null
+      stored === null
         ? new Response(null, { status: 204, headers })
-        : new Response(document, { status: 200, headers }),
+        : new Response(stored, { status: 200, headers }),
     )
   })
 
   vi.stubGlobal('fetch', fetchMock)
   return fetchMock
+}
+
+/** Whether the server took it — anything but 2xx leaves the document alone. */
+function accepted(status: number): boolean {
+  return status >= 200 && status < 300
 }
 
 /** Installs a `fetch` that never reaches the server at all. */
@@ -65,6 +86,11 @@ export function configurationWrites(fetchMock: FetchMock): string[] {
   return fetchMock.mock.calls
     .filter(([, init]) => init?.method === 'PUT')
     .map(([, init]) => String(init?.body))
+}
+
+/** How many resets the code under test issued. */
+export function configurationResets(fetchMock: FetchMock): number {
+  return fetchMock.mock.calls.filter(([, init]) => init?.method === 'DELETE').length
 }
 
 /**


### PR DESCRIPTION
Closes #85.

An operator who wants a "training view" and an "idle health view" keeps both instead of choosing one permanently. Pages are named arrangements in the same instance-scoped document, switched from tabs in the header, each at its own URL.

## What this adds

| Layer | What it does |
| --- | --- |
| `lib/dashboard/pages.ts` | Pure `addPage` / `renamePage` / `removePage` / `canRemovePage` over the document |
| `components/pages/tabFit.ts` | Pure "which tabs fit the header, which go in the menu" from measured widths |
| `components/pages/PageTabs` | The tab strip and its overflow menu; tabs are real links to page URLs |
| `components/pages/PagesMenu` | Create, rename, delete, and the confirmed reset-everything |
| `components/pages/PageBar` | Writes each page edit, then decides where the operator lands |
| `client.ts` / `useDashboardConfiguration` | `DELETE /api/dashboard` and `reset()`, with a `reset-failed` notice |
| `useRoute` | `navigateTo` / `replacePath` — pushState plus popstate, no reload |

## Decisions worth reviewing

**Page edits are written when they are made**, unlike a layout change. A drag is one of hundreds of intermediate positions and needs a session to hold it; "create a page" is already the deliberate, named request that a save button would only ask the operator to repeat. Nothing navigates until the write is accepted, so a refused save leaves the operator where they were rather than on a page the server has never heard of.

**The page bar goes quiet while a layout is being edited.** The edit session lives in the page below and dies with it, so switching tabs mid-edit would silently discard work the operator has just been told is unsaved. Not asked for by #85; the alternative is a data-loss trap, and story 17 in #70 covers it.

**The last page cannot be deleted** — a document with no pages has nothing to render. Starting over is what the reset is for, and it asks first.

**A reset is a deletion, not a write of the preset.** "Nothing is configured" and "reset to the default" are deliberately the same state on disk, so a preset reworded in a later release reaches every dashboard that was ever reset. It is also the way back from a rollback: the banner describes a stored document the reset removed.

**The masthead drops its second word below `sm`.** #85 says the header's visual identity is preserved, so this is the one line in the diff that argues with the ticket. At 390px the title and the connection badge are both fixed-width and took the entire header, leaving the tab strip measured at 1.3px — no navigation at all on a phone. The green *Spark* mark stays; reverting is one class if you would rather keep the full title and accept that.

## Testing

659 unit specs and 20 browser specs, per the seams #70 sets out.

The browser project earns its keep here: which tabs fit is decided from measured widths on a ResizeObserver path, and jsdom measures every box as 0×0, so in the unit project every tab always fits and the overflow menu never appears. Three faults were found only by rendering it for real — an inline anchor whose padding overflowed its line box and got clipped, a fit rule that forced the active tab through the clip edge, and an overflow menu inside the clipping box whose popover therefore painted nothing.

`npm run lint`, `npm run build`, `npm test -- --run`, `npm run test:browser` all green. No Rust, Docker or deployment files touched.

## Follow-ups, deliberately not here

- On a URL naming a deleted page the Pages menu is hidden, so reset-everything is unreachable from that screen. The tab strip still lists every real page, so it is one click away rather than a dead end.
- The overflow button labelled with a page name reads as a pill rather than as a dropdown. It carries `aria-expanded`; a chevron would signal it better.
