### PR TITLE
test(frontend): browser-mode suite for drag, resize and stacking

### DIFF
--- a/frontend/src/__tests__/App.editMode.test.tsx
+++ b/frontend/src/__tests__/App.editMode.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../test/configurationServer'
 import { gridSubstitute } from '../test/gridSubstitute'
 import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+import { GRID_COLUMNS, GRID_MAX_ROWS } from '../lib/dashboard/grid'
 import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
 import type { MetricsSnapshot } from '../types/metrics'
 
@@ -130,7 +131,7 @@ describe('entering and leaving edit mode', () => {
     expect(gridSubstitute.acceptsLayoutChanges()).toBe(true)
     // The row cap becomes the engine's business for the session, which is what
     // makes running out of room a state rather than a scrollbar.
-    expect(gridSubstitute.options().maxRow).toBe(8)
+    expect(gridSubstitute.options().maxRow).toBe(GRID_MAX_ROWS)
   })
 
   it('puts the page back to static when the session ends', async () => {
@@ -141,7 +142,10 @@ describe('entering and leaving edit mode', () => {
     await userEvent.click(discard())
 
     expect(gridSubstitute.options().staticGrid).toBe(true)
-    expect(gridSubstitute.options().maxRow).toBe(0)
+    // The cap is off — as the row count a page can never reach, one per cell,
+    // and never as zero, which the library reads as a cap of none and compacts
+    // the whole page into.
+    expect(gridSubstitute.options().maxRow).toBe(GRID_COLUMNS * GRID_MAX_ROWS)
     expect(editLayout()).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/browser/editMode.browser.test.tsx
+++ b/frontend/src/__tests__/browser/editMode.browser.test.tsx
@@ -6,6 +6,7 @@ import { FOLLOW } from '@/lib/dashboard/bindings'
 import type { PanelGeometry } from '@/lib/dashboard/grid'
 import { DEFAULT_TIME_WINDOW, type DashboardPage } from '@/lib/dashboard/schema'
 import type { PanelType } from '@/lib/dashboard/panels'
+import { dragPanelBy, measuredPanel, resizePanelBy } from '@/test/gridEngine'
 
 // Out of room, in a real layout engine (#83). Everything about this is
 // measurement: the engine refuses a move by simulating it and keeping the old
@@ -17,10 +18,8 @@ import type { PanelType } from '@/lib/dashboard/panels'
 // suite; this is the criterion that is #83's own, and the fiddliest interaction
 // in the rework.
 //
-// The drag is driven with **mouse** events, not pointer events: the library
-// binds mousedown on the item's content and then move and release on the
-// document. Pointer-based helpers silently do nothing, which looks exactly like
-// a library defect.
+// How a gesture is driven — mouse events, not pointer events — belongs to
+// `test/gridEngine.ts`, which every spec that drives a real grid shares.
 
 function page(panels: Array<[string, PanelType, PanelGeometry]>): DashboardPage {
   return {
@@ -46,71 +45,6 @@ function Harness({ content, width = 800 }: { content: DashboardPage; width?: num
   )
 }
 
-/** Drags an element by a pixel offset, the way the library listens for it. */
-function dragBy(element: Element, dx: number, dy: number) {
-  const box = element.getBoundingClientRect()
-  dragFrom(element, { clientX: box.left + box.width / 2, clientY: box.top + box.height / 2 }, dx, dy)
-}
-
-/**
- * Pulls a panel's bottom-right corner by a pixel offset.
- *
- * The grab starts at the panel's own corner rather than at the handle's box: the
- * library autohides the handle, so it measures 0×0 until hovered, and a resize
- * that begins at the origin is one the library reads as dragging the corner in
- * from the far left — it shrinks the panel sideways instead.
- */
-function resizeBy(item: HTMLElement, dx: number, dy: number) {
-  const box = item.getBoundingClientRect()
-  const handle = item.querySelector('.ui-resizable-se')!
-  dragFrom(handle, { clientX: box.right, clientY: box.bottom }, dx, dy)
-}
-
-function dragFrom(
-  element: Element,
-  from: { clientX: number; clientY: number },
-  dx: number,
-  dy: number,
-) {
-  const at = (fraction: number) => ({
-    clientX: from.clientX + dx * fraction,
-    clientY: from.clientY + dy * fraction,
-    bubbles: true,
-    button: 0,
-  })
-
-  element.dispatchEvent(new MouseEvent('mousedown', { ...from, bubbles: true, button: 0 }))
-  // Several moves: the library needs to pass its own start threshold before it
-  // is dragging at all, and the last one is what the drop is judged against.
-  for (const fraction of [0.1, 0.4, 0.7, 1]) {
-    document.dispatchEvent(new MouseEvent('mousemove', at(fraction)))
-  }
-  document.dispatchEvent(new MouseEvent('mouseup', at(1)))
-}
-
-/**
- * The named item, once the grid has actually been measured.
- *
- * Every drag here is expressed in the item's own height, so a drag started
- * before the ResizeObserver has fired covers a different number of rows than it
- * means to — which looks exactly like the feature not working. A four-row panel
- * in an eight-row grid is half the grid tall; the pre-measurement fallback row
- * height is not.
- */
-async function measuredItem(container: HTMLElement, id: string): Promise<HTMLElement> {
-  const item = container.querySelector(`[gs-id="${id}"]`) as HTMLElement
-
-  await waitFor(() => {
-    const grid = container.querySelector('.grid-stack')!.getBoundingClientRect()
-    // Half the grid, less a margin's worth. The item's own size lags the row
-    // height by a frame, so "taller than the fallback" is not enough of a
-    // condition — it passes while the panel is still catching up.
-    expect(item.getBoundingClientRect().height).toBeGreaterThan(grid.height * 0.45)
-  })
-
-  return item
-}
-
 describe('a move the page has no room for', () => {
   it('is refused, and says so instead of snapping back in silence', async () => {
     // A page filled to its cap, and filled unevenly, so there is nothing the
@@ -131,8 +65,8 @@ describe('a move the page has no room for', () => {
 
     // Half its own height is two of the four rows it covers: enough to run the
     // page past its cap, whatever the measured row height turned out to be.
-    const item = await measuredItem(container, 'bottom')
-    act(() => dragBy(item.querySelector('.grid-stack-item-content')!, 0, item.offsetHeight / 2))
+    const item = await measuredPanel(container, 'bottom')
+    act(() => dragPanelBy(item, 0, item.offsetHeight / 2))
 
     await waitFor(() => {
       expect(getByRole('alert').textContent).toMatch(/No room for “Memory” there/)
@@ -157,10 +91,11 @@ describe('a move the page has no room for', () => {
     await waitFor(() => expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(2))
     act(() => getByRole('button', { name: 'Edit layout' }).click())
 
-    // Upward, onto the panel above: room the page does have, once the engine
-    // has moved the other one.
-    const item = await measuredItem(container, 'bottom')
-    act(() => dragBy(item.querySelector('.grid-stack-item-content')!, 0, -item.offsetHeight / 2))
+    // Upward onto the panel above, by the whole of its own height: the top
+    // half of a page whose halves are the same size, which is room the page
+    // does have — once the engine has moved the other panel into the bottom.
+    const item = await measuredPanel(container, 'bottom')
+    act(() => dragPanelBy(item, 0, -item.offsetHeight))
 
     await waitFor(() => {
       expect(container.querySelector('[gs-id="bottom"]')?.getAttribute('gs-y')).not.toBe('4')
@@ -185,8 +120,8 @@ describe('a resize the page has no room for', () => {
 
     // The corner the library makes resizable in edit mode, pulled down by half
     // the panel — two more rows the page does not have.
-    const item = await measuredItem(container, 'bottom')
-    act(() => resizeBy(item, 0, item.offsetHeight / 2))
+    const item = await measuredPanel(container, 'bottom')
+    act(() => resizePanelBy(item, 0, item.offsetHeight / 2))
 
     await waitFor(() => {
       expect(getByRole('alert').textContent).toMatch(/No room for “Memory” there/)

--- a/frontend/src/__tests__/browser/gridPage.browser.test.tsx
+++ b/frontend/src/__tests__/browser/gridPage.browser.test.tsx
@@ -7,6 +7,7 @@ import type { PanelGeometry } from '@/lib/dashboard/grid'
 import { defaultDashboardDocument } from '@/lib/dashboard/preset'
 import { DEFAULT_TIME_WINDOW, type DashboardPage } from '@/lib/dashboard/schema'
 import type { PanelType } from '@/lib/dashboard/panels'
+import { panelGeometry } from '@/test/gridEngine'
 
 // The real grid engine, which only a real layout engine can drive: the #79
 // acceptance criteria that depend on measurement. Fit-to-viewport (row height
@@ -42,23 +43,6 @@ function Harness({ width, height, content }: { width: number; height: number; co
   )
 }
 
-/** The engine's geometry for each item, with gridstack's sparse defaults filled in. */
-function itemGeometry(container: HTMLElement): Map<string, PanelGeometry> {
-  const found = new Map<string, PanelGeometry>()
-  for (const el of container.querySelectorAll('.grid-stack-item')) {
-    const id = el.getAttribute('gs-id')
-    if (!id) continue
-    found.set(id, {
-      x: Number(el.getAttribute('gs-x') ?? 0),
-      y: Number(el.getAttribute('gs-y') ?? 0),
-      // The library omits values equal to its defaults — missing means 1.
-      w: Number(el.getAttribute('gs-w') ?? 1),
-      h: Number(el.getAttribute('gs-h') ?? 1),
-    })
-  }
-  return found
-}
-
 describe('the grid page in a real layout engine', () => {
   it('fits the viewport: the measured container height is divided into rows, and a full page does not overflow', async () => {
     const content = page([
@@ -89,13 +73,13 @@ describe('the grid page in a real layout engine', () => {
     const { container, rerender } = render(<Harness width={800} height={480} content={content} />)
 
     await waitFor(() => {
-      expect(itemGeometry(container).get('right')).toMatchObject({ x: 6, y: 0, w: 6 })
+      expect(panelGeometry(container).get('right')).toMatchObject({ x: 6, y: 0, w: 6 })
     })
 
     // Narrow: both panels full-width in one column, stacked in reading order.
     rerender(<Harness width={360} height={480} content={content} />)
     await waitFor(() => {
-      const items = itemGeometry(container)
+      const items = panelGeometry(container)
       expect(items.get('left')).toMatchObject({ x: 0, w: 1, h: 5 })
       expect(items.get('right')).toMatchObject({ x: 0, w: 1, h: 5 })
       const ys = [items.get('left')!.y, items.get('right')!.y].sort((a, b) => a - b)
@@ -105,7 +89,7 @@ describe('the grid page in a real layout engine', () => {
     // Wide again: the authored desktop layout, not a recompacted approximation.
     rerender(<Harness width={800} height={480} content={content} />)
     await waitFor(() => {
-      const items = itemGeometry(container)
+      const items = panelGeometry(container)
       expect(items.get('left')).toMatchObject({ x: 0, y: 0, w: 6, h: 5 })
       expect(items.get('right')).toMatchObject({ x: 6, y: 0, w: 6, h: 5 })
     })
@@ -131,7 +115,7 @@ describe('the grid page in a real layout engine', () => {
 
     rerender(<Harness width={390} height={800} content={preset} />)
     await waitFor(() => {
-      const items = itemGeometry(container)
+      const items = panelGeometry(container)
       expect(items.size).toBe(preset.panels.length)
       for (const [id, geometry] of items) {
         expect(geometry, id).toMatchObject({ x: 0, w: 1 })

--- a/frontend/src/__tests__/browser/rearranging.browser.test.tsx
+++ b/frontend/src/__tests__/browser/rearranging.browser.test.tsx
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { GridPageEditor } from '@/components/grid/GridPageEditor'
+import { useDashboardConfiguration } from '@/hooks/useDashboardConfiguration'
+import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
+import { withPagePanels } from '@/lib/dashboard/editing'
+import { DASHBOARD_SCHEMA_VERSION } from '@/lib/dashboard/schema'
+import {
+  configurationWrites,
+  serveConfiguration,
+  type FetchMock,
+} from '@/test/configurationServer'
+import { dragPanelBy, measuredPanel, panelGeometry, resizePanelBy } from '@/test/gridEngine'
+
+// What a real drag is worth: the geometry it leaves on disk (#87).
+//
+// This is the spec the whole browser project exists for. Everywhere else the
+// grid library is the jsdom substitute, and a spec tells it a panel moved — so
+// the chain from "the operator dragged something" to "these bytes were stored"
+// is asserted from its second link onward, and a library upgrade that stopped
+// dragging altogether would break nothing. The library's React wrapper is very
+// new and declares no React peer dependency, so nothing warns either.
+//
+// Here a mouse drags a panel across a real layout engine and the assertion is
+// on the PUT body and on what a reload comes back to. **Mouse events, not
+// pointer events** — see `test/gridEngine.ts`, which owns that gotcha.
+//
+// The configuration goes over the real client, against the same stub server the
+// jsdom specs use: it holds what it was given, so a reload here is a real round
+// trip rather than a spec handing itself the answer.
+//
+// Deliberately three cases, because the project they run in costs CI a browser
+// download:
+//
+//   - a drag, saved and reloaded
+//   - a resize, saved and reloaded
+//   - a narrowed window, which must never write the column it derives
+//
+// Two of #87's criteria were already met by the time it was written. The row
+// cap refusing a drop is `editMode.browser.test.tsx`'s, from #83, and is not
+// restated. The collapse and restore of an authored layout is
+// `gridPage.browser.test.tsx`'s, from #79 — the third case here crosses that
+// ground again on its way to the thing only a saveable page can be asked: that
+// the column it derives is never the one that gets written.
+//
+// Panel types are covered through the application seam in the jsdom suite —
+// there are no per-panel browser tests, and there should not be.
+
+function storedDocument(panels: unknown[]): string {
+  return JSON.stringify({
+    version: DASHBOARD_SCHEMA_VERSION,
+    pages: [{ id: 'watch', name: 'Watch', panels }],
+  })
+}
+
+/** Two panels side by side, filling the top half of the page. */
+function sideBySide(): unknown[] {
+  return [
+    { id: 'cpu', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+    { id: 'mem', type: 'memory', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+  ]
+}
+
+/**
+ * The dashboard as the application wires it: the configuration hook over the
+ * real client, and the editor saving the page back into the whole document.
+ *
+ * Not `App` itself, for the reason every spec in this directory renders a
+ * component instead: the browser project runs no Tailwind build, so the classes
+ * that give the app its height do nothing, and a grid told to fill an auto-height
+ * parent halves its own row height on every measurement until it vanishes. The
+ * box below is what Tailwind would have given it. Everything under that box is
+ * the real thing.
+ */
+function Dashboard({ width = 1024 }: { width?: number }) {
+  const { document: stored, readOnly, save } = useDashboardConfiguration()
+  const page = stored?.pages[0]
+
+  return (
+    <MetricsStoreProvider>
+      <div style={{ width, height: 640 }}>
+        {stored && page && (
+          <GridPageEditor
+            page={page}
+            readOnly={readOnly}
+            onSave={(panels) => save(withPagePanels(stored, page.id, panels))}
+          />
+        )}
+      </div>
+    </MetricsStoreProvider>
+  )
+}
+
+const editLayout = () => screen.getByRole('button', { name: 'Edit layout' })
+const saveLayout = () => screen.getByRole('button', { name: 'Save layout' })
+
+/** Renders the dashboard and waits for the stored page to have been laid out. */
+async function openDashboard(panelCount: number, width?: number): Promise<HTMLElement> {
+  const { container } = render(<Dashboard width={width} />)
+  await waitFor(() =>
+    expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(panelCount),
+  )
+  return container
+}
+
+/** The geometry each panel of the one page has, in the write already waited for. */
+function savedGeometry(fetchMock: FetchMock): Map<string, unknown> {
+  const [written] = configurationWrites(fetchMock)
+  const panels = JSON.parse(written).pages[0].panels as Array<Record<string, unknown>>
+  return new Map(panels.map((panel) => [String(panel.id), panel.geometry]))
+}
+
+describe('a panel dragged across a real grid', () => {
+  it('is stored where it was dropped, and a reload comes back to it', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(sideBySide()) })
+    const container = await openDashboard(2)
+
+    act(() => editLayout().click())
+
+    // Straight down by its own height: the four rows that take it from the top
+    // half of the page to the bottom one.
+    const item = await measuredPanel(container, 'mem')
+    act(() => dragPanelBy(item, 0, item.offsetHeight))
+
+    await waitFor(() => {
+      expect(panelGeometry(container).get('mem')).toEqual({ x: 6, y: 4, w: 6, h: 4 })
+    })
+
+    await userEvent.click(saveLayout())
+
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    // The panel that was dragged, and the one that was not.
+    const saved = savedGeometry(fetchMock)
+    expect(saved.get('mem')).toEqual({ x: 6, y: 4, w: 6, h: 4 })
+    expect(saved.get('cpu')).toEqual({ x: 0, y: 0, w: 6, h: 4 })
+
+    // And the page still looks like what was stored: ending the session takes
+    // the row cap off the engine, which must not be an occasion to compact the
+    // arrangement that was just saved.
+    expect(panelGeometry(container).get('mem')).toEqual({ x: 6, y: 4, w: 6, h: 4 })
+
+    // A reload against the same server, which is now answering with the bytes
+    // it took: the arrangement survives the round trip it was saved for.
+    cleanup()
+    const reloaded = await openDashboard(2)
+    expect(panelGeometry(reloaded).get('mem')).toEqual({ x: 6, y: 4, w: 6, h: 4 })
+  })
+})
+
+describe('a panel resized on a real grid', () => {
+  it('is stored at the size it was pulled to, and a reload comes back to it', async () => {
+    // One panel, so the resize has room to grow into rather than a neighbour to
+    // push around: what is being asserted is the gesture, not the reflow.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'cpu', type: 'cpu-utilization', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+    const container = await openDashboard(1)
+
+    act(() => editLayout().click())
+
+    // One column wider and one row taller, in the panel's own units.
+    const item = await measuredPanel(container, 'cpu')
+    act(() => resizePanelBy(item, item.offsetWidth / 6, item.offsetHeight / 4))
+
+    await waitFor(() => {
+      expect(panelGeometry(container).get('cpu')).toEqual({ x: 0, y: 0, w: 7, h: 5 })
+    })
+
+    await userEvent.click(saveLayout())
+
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    expect(savedGeometry(fetchMock).get('cpu')).toEqual({ x: 0, y: 0, w: 7, h: 5 })
+
+    cleanup()
+    const reloaded = await openDashboard(1)
+    expect(panelGeometry(reloaded).get('cpu')).toEqual({ x: 0, y: 0, w: 7, h: 5 })
+  })
+})
+
+describe('a window narrow enough to stack the page', () => {
+  it('never writes the column it derived, and gives the saved layout back on the way out', async () => {
+    // The hazard this guards is silent and permanent: the single column is
+    // derived from the authored layout, and a save that caught it would replace
+    // every colleague's desktop arrangement with one phone's. jsdom cannot get
+    // near it — the collapse runs on measured width, which there is always 0.
+    const fetchMock = serveConfiguration({ document: storedDocument(sideBySide()) })
+    const { container, rerender } = render(<Dashboard />)
+    await waitFor(() => expect(container.querySelectorAll('.grid-stack-item')).toHaveLength(2))
+
+    act(() => editLayout().click())
+    const item = await measuredPanel(container, 'mem')
+    act(() => dragPanelBy(item, 0, item.offsetHeight))
+    await waitFor(() => {
+      expect(panelGeometry(container).get('mem')).toEqual({ x: 6, y: 4, w: 6, h: 4 })
+    })
+    await userEvent.click(saveLayout())
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+
+    // A phone-width window: one column, every panel across it.
+    rerender(<Dashboard width={360} />)
+    await waitFor(() => {
+      const stacked = panelGeometry(container)
+      expect(stacked.get('cpu')).toMatchObject({ x: 0, w: 1 })
+      expect(stacked.get('mem')).toMatchObject({ x: 0, w: 1 })
+    })
+
+    // Wide again: the layout that was saved, not the column that was displayed.
+    rerender(<Dashboard width={1024} />)
+    await waitFor(() => {
+      expect(panelGeometry(container).get('mem')).toEqual({ x: 6, y: 4, w: 6, h: 4 })
+    })
+    expect(panelGeometry(container).get('cpu')).toEqual({ x: 0, y: 0, w: 6, h: 4 })
+
+    // And the stack was never stored: still the one write, from the drag.
+    expect(configurationWrites(fetchMock)).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -28,6 +28,21 @@ import { GridPanel } from './GridPanel'
 const FALLBACK_CELL_HEIGHT = 80
 
 /**
+ * The row cap outside an edit session: high enough to be no cap at all.
+ *
+ * Zero is the library's own word for "no limit" — but only when a grid is
+ * built with it. Handed to `updateOptions` it is read as a limit first, and
+ * every page taller than zero rows is compacted to fit it: leaving edit mode
+ * would snap the whole page upward, authored gaps and all, and show an
+ * arrangement nobody saved until the next reload.
+ *
+ * A number the engine can never exceed avoids both. The collapsed column is
+ * the tallest a page ever gets, and it cannot be taller than one row per cell
+ * — panels do not overlap, so their heights sum to at most the whole grid.
+ */
+const UNCAPPED_ROWS = GRID_COLUMNS * GRID_MAX_ROWS
+
+/**
  * Where the pointer was when the grid raised a gesture event.
  *
  * The library hands its own synthetic event to the callback, carrying the
@@ -108,9 +123,10 @@ export function GridPage({
       // a desktop-width grid. Outside one it must stay off: the engine clamps
       // every node into the cap when it re-adds them during a column change,
       // and the single-column stack legitimately needs more rows than the cap.
-      // Zero, not undefined — `updateOptions` ignores an absent maxRow, so
-      // leaving edit mode has to say the cap is gone in as many words.
-      maxRow: draggable ? GRID_MAX_ROWS : 0,
+      // A number, not undefined — `updateOptions` ignores an absent maxRow, so
+      // leaving edit mode has to say the cap is gone in as many words — and not
+      // zero, which it would read as a cap of none; see `UNCAPPED_ROWS`.
+      maxRow: draggable ? GRID_MAX_ROWS : UNCAPPED_ROWS,
       cellHeight,
       margin: 3,
       // Authored gaps are authored. Without floating, the engine compacts

--- a/frontend/src/test/gridEngine.ts
+++ b/frontend/src/test/gridEngine.ts
@@ -1,0 +1,112 @@
+/**
+ * Driving and reading a real grid, for the specs that run in a real browser.
+ *
+ * Only the browser project ever loads this: the unit project swaps the library
+ * for `gridstack.tsx`'s substitute, because jsdom has no layout engine and so
+ * has nothing to drag. One copy, for the same reason `configurationServer.ts`
+ * is one copy — two spellings of "this is how the library listens for a drag"
+ * is how the specs drift from the library they exist to guard.
+ *
+ * **Drags are driven with mouse events, not pointer events.** The library binds
+ * mousedown on the item's content element and then move and release on the
+ * document. Pointer-based helpers silently do nothing, which looks exactly like
+ * a library defect and costs an afternoon to tell apart from one.
+ */
+
+import { expect } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import { type PanelGeometry } from '@/lib/dashboard/grid'
+
+/**
+ * The engine's geometry for each panel, with gridstack's sparse defaults filled
+ * in — what the document would store if the layout were saved as it stands.
+ */
+export function panelGeometry(container: HTMLElement): Map<string, PanelGeometry> {
+  const found = new Map<string, PanelGeometry>()
+
+  for (const el of container.querySelectorAll('.grid-stack-item')) {
+    const id = el.getAttribute('gs-id')
+    if (!id) continue
+    found.set(id, {
+      x: Number(el.getAttribute('gs-x') ?? 0),
+      y: Number(el.getAttribute('gs-y') ?? 0),
+      // The library omits values equal to its defaults — missing means 1.
+      w: Number(el.getAttribute('gs-w') ?? 1),
+      h: Number(el.getAttribute('gs-h') ?? 1),
+    })
+  }
+
+  return found
+}
+
+/**
+ * The named panel, once the grid has actually been measured.
+ *
+ * Every gesture here is expressed in the panel's own size, so one started
+ * before the row height has settled covers a different number of rows than it
+ * means to — which looks exactly like the feature not working, and lands as a
+ * drop the page had no room for.
+ */
+export async function measuredPanel(container: HTMLElement, id: string): Promise<HTMLElement> {
+  const item = container.querySelector(`[gs-id="${id}"]`) as HTMLElement
+
+  await waitFor(() => {
+    const grid = container.querySelector('.grid-stack')!
+    // The row height the engine settled on, from the variable it lays every
+    // item out with. Absent until the container has been measured, which parses
+    // as NaN and fails the comparison — which is the point.
+    const cellHeight = Number.parseFloat(
+      getComputedStyle(grid).getPropertyValue('--gs-cell-height'),
+    )
+    // The panel is as tall as the rows the engine has it covering. Its rendered
+    // box lags the row height by an animation rather than a frame, so this waits
+    // for the box the gesture will be expressed in, not merely a plausible one.
+    const rows = Number(item.getAttribute('gs-h') ?? 1)
+    expect(Math.abs(item.getBoundingClientRect().height - rows * cellHeight)).toBeLessThan(1)
+  })
+
+  return item
+}
+
+/** Drags a panel by a pixel offset, the way the library listens for it. */
+export function dragPanelBy(item: HTMLElement, dx: number, dy: number): void {
+  const grip = item.querySelector('.grid-stack-item-content')!
+  const box = grip.getBoundingClientRect()
+  dragFrom(grip, { clientX: box.left + box.width / 2, clientY: box.top + box.height / 2 }, dx, dy)
+}
+
+/**
+ * Pulls a panel's bottom-right corner by a pixel offset.
+ *
+ * The grab starts at the panel's own corner rather than at the handle's box:
+ * the library autohides the handle, so it measures 0×0 until hovered, and a
+ * resize that begins at the origin is one the library reads as dragging the
+ * corner in from the far left — it shrinks the panel sideways instead.
+ */
+export function resizePanelBy(item: HTMLElement, dx: number, dy: number): void {
+  const box = item.getBoundingClientRect()
+  const handle = item.querySelector('.ui-resizable-se')!
+  dragFrom(handle, { clientX: box.right, clientY: box.bottom }, dx, dy)
+}
+
+function dragFrom(
+  element: Element,
+  from: { clientX: number; clientY: number },
+  dx: number,
+  dy: number,
+): void {
+  const at = (fraction: number) => ({
+    clientX: from.clientX + dx * fraction,
+    clientY: from.clientY + dy * fraction,
+    bubbles: true,
+    button: 0,
+  })
+
+  element.dispatchEvent(new MouseEvent('mousedown', { ...from, bubbles: true, button: 0 }))
+  // Several moves: the library needs to pass its own start threshold before it
+  // is dragging at all, and the last one is what the drop is judged against.
+  for (const fraction of [0.1, 0.4, 0.7, 1]) {
+    document.dispatchEvent(new MouseEvent('mousemove', at(fraction)))
+  }
+  document.dispatchEvent(new MouseEvent('mouseup', at(1)))
+}


### PR DESCRIPTION
Closes #87.

The browser-mode suite that guards what jsdom structurally cannot reach.
Everywhere else the grid library is the jsdom substitute and a spec *tells*
it a panel moved, so the chain from "the operator dragged something" to
"these bytes were stored" is asserted from its second link onward. A
library upgrade that stopped drag working would break no test anywhere —
and the grid's React wrapper is very new and declares no React peer
dependency, so nothing would warn either.

### The suite

`frontend/src/__tests__/browser/rearranging.browser.test.tsx`, three cases,
kept to three because the project costs CI a browser download:

- a panel dragged with real mouse events, saved, and reloaded — asserted on
  the PUT body and on what a second mount of the same stub server comes
  back to, so nothing here is a spec handing itself the answer
- a panel resized by its corner, saved and reloaded the same way
- a window narrowed to a phone's, which stacks the page into one column and
  must never write it — the column is derived from the authored layout, and
  a save that caught it would replace every colleague's desktop arrangement
  with one phone's

Two of #87's acceptance criteria were already met when it came to be
written, and are not restated: the row cap refusing a drop is
`editMode.browser.test.tsx`'s, from #83, and the collapse and restore of an
authored layout is `gridPage.browser.test.tsx`'s, from #79. Panel types stay
covered through the application seam in the jsdom suite — there are no
per-panel browser tests, and there should not be.

### A fix it found, which is why this PR is not test-only

`fix(frontend): stop the page compacting when edit mode ends` is a
user-visible behaviour change that came out of writing the suite, so it
ships as a patch release under a test ticket. Worth reading on its own:

Leaving an edit session hands gridstack `maxRow: 0` — its own word for "no
limit", but only when a grid is *built* with it. Handed to `updateOptions`
it is read as a limit first, and every page taller than zero rows is
compacted to fit it. Saving a rearranged page snapped every panel back to
the top of the grid; discarding did the same to a layout that had never
changed. The document held what the operator arranged, so a reload healed
it, which is how it survived #83. `float: true` exists precisely to stop the
engine doing this on load; nothing was stopping it on the way out.

The cap is now lifted as a row count the engine can never reach — one row
per cell. Panels do not overlap, so their heights sum to at most that even
when the responsive collapse stacks every one of them into a single column,
which is the case the cap has to stay out of the way of and the reason it
cannot simply stay at eight.

Revert it and two of the three new tests fail. If you would rather it were
traceable on its own, say so and I will split it out under its own issue.

### Also here

`frontend/src/test/gridEngine.ts` gathers the one way a spec drives a real
grid — the mouse-event drag (pointer events silently do nothing, which
looks exactly like a library defect), the resize from the panel's own
corner, the geometry read, and the wait for a measured panel. It had been
spelled out in each browser spec that needed it, and this was the third
caller.

The wait got tightened on the way: it compared the panel against the grid
element's height, which is only as tall as the rows a page happens to use,
so on a half-full page it passed while the panel was still animating to a
third of its final size — and every gesture was then expressed in pixels
meaning a different number of rows than the spec asked for. It now waits for
the row height the engine settled on, times the rows the panel covers. That
makes #83's reflow case a genuine two-row drag rather than the one row it
was accidentally performing; at exactly half a panel's overlap the engine
leaves the two where they are, so that drag is now by the panel's whole
height, where the swap it is about is unambiguous.

### Verification

`npm run lint`, `tsc -b`, 623 unit specs, 24 browser specs, `npm run build`
— all green, and each of the three commits is green on its own. No Rust
changed. Also run on the DGX Spark against the real backend: dragging,
saving and discarding now leave the page where the operator put it.
