### PR TITLE
docs: domain context, ADRs and configuration-file operator documentation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,14 @@ An inference server on the host, detected by process scan or the Docker API and
 polled for Prometheus metrics. Identified to the backend by its **endpoint**;
 identified in the UI by type and endpoint together, since a host can run several
 of the same type.
-_Avoid_: server, model, provider, backend (the backend is the Rust process)
+_Avoid_: server, model, backend (the backend is the Rust process)
+
+**Provider**:
+The organization that published a model, taken from its HuggingFace-style org
+prefix and used to pick the logo beside it. Not a synonym for engine — one engine
+serves models from many providers, though the older
+`SPARK_DASHBOARD_PROVIDER_API_KEY` flag uses the word that way.
+_Avoid_: vendor, org, publisher
 
 **GPU index**:
 The integer NVML reports for a device, and the identity a panel pins to. GPUs

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,171 @@
+# Spark Dashboard
+
+A live observability tool for a DGX Spark host: what the hardware and the
+inference engines on it are doing right now. A Rust backend collects metrics and
+serves an embedded React frontend; the frontend renders them as an arrangement
+of panels the operator owns and the server stores.
+
+This is a **single context**. The backend and the frontend share one domain and
+one wire format, so there is one glossary for both. Architecture decisions live
+in [`docs/adr/`](./docs/adr/).
+
+## Language
+
+### Who and what
+
+**Operator**:
+The person running the dashboard on their own machine. There are no accounts,
+roles or per-user state — every operator on an instance sees the same thing.
+_Avoid_: user, admin, viewer
+
+**Engine**:
+An inference server on the host, detected by process scan or the Docker API and
+polled for Prometheus metrics. Identified to the backend by its **endpoint**;
+identified in the UI by type and endpoint together, since a host can run several
+of the same type.
+_Avoid_: server, model, provider, backend (the backend is the Rust process)
+
+**GPU index**:
+The integer NVML reports for a device, and the identity a panel pins to. GPUs
+have no other stable key.
+_Avoid_: device id, GPU name
+
+**Metrics contract**:
+The JSON snapshot shape the backend broadcasts over the WebSocket and the
+frontend types mirror. It is the project's **only** cross-language contract —
+see [ADR-0002](./docs/adr/0002-configuration-is-an-opaque-document.md).
+_Avoid_: API schema, protocol
+
+### The dashboard an operator arranges
+
+**Panel**:
+One metric in one rectangle on the grid — the unit an operator moves, resizes,
+retitles, adds and removes. Panels are fine-grained on purpose: one per metric,
+not a handful of fixed composite cards.
+_Avoid_: card, widget, tile
+
+**Panel type**:
+Which panel a panel is (`gpu-temperature`, `engine-latency`, `logs`, …). The ids
+are persisted verbatim in the configuration, so renaming one is a migration
+rather than a refactor. `frontend/src/lib/dashboard/panels.ts` is the list.
+_Avoid_: panel kind, panel variant
+
+**Page**:
+One named arrangement of panels, with its own stable id and URL. Pages are how
+one dashboard holds a training view and an idle health view side by side. Header
+**tabs** switch between them; a tab is the control, not the thing.
+_Avoid_: tab, view, screen, dashboard (singular)
+
+**Geometry**:
+A panel's placement in grid cells — `x`, `y`, `w`, `h` on a 12-column grid with a
+hard row cap. Row height is derived from the measured container at render time
+and is never persisted.
+_Avoid_: position, layout (a layout is the whole page's arrangement), size
+
+**Binding**:
+What a panel points at: a GPU by index, an engine by endpoint, or the sentinel
+**`follow`**. A binding whose target is absent renders a placeholder keeping its
+grid slot; silent substitution is prohibited.
+_Avoid_: data source, target (a target is what a binding resolves *to*), filter
+
+**Follow**:
+The default binding, and the sentinel every panel in the preset carries. It
+resolves to the **page selection**, which is what makes one static preset correct
+on a one-GPU laptop and on a four-GPU server.
+_Avoid_: auto, inherit, default binding
+
+**Page selection**:
+The GPU and engine a page's `follow` panels resolve against. What the operator
+chose is stored sparsely, so an absent key means "never chose" rather than "chose
+nothing".
+_Avoid_: current GPU, active engine, global filter
+
+**Time window**:
+How much history a panel's chart covers (`5m`, `10m`, `15m`). Per panel, not per
+page: a spike and a trend belong on the same page.
+_Avoid_: range, timespan, zoom
+
+**Edit mode**:
+The explicit mode in which panels can be dragged, resized, added and removed,
+ended by **Save layout** or **Discard**. Outside it panels are fully interactive
+and never move; inside it live motion freezes.
+_Avoid_: design mode, unlocked, edit state
+
+**Palette**:
+The list of every panel type an operator can add, opened in edit mode.
+Click-to-add places the panel in the first free slot, in reading order.
+_Avoid_: panel picker, library, add menu
+
+**Out of room**:
+The state of a page that cannot take a drop, a resize or a new panel without
+breaking the row cap. It is an outcome the operator is shown, never a silent
+no-op.
+_Avoid_: full, overflow, no space
+
+**Preset**:
+The one-page arrangement rendered when nothing is stored — a static document, not
+one generated from the host it lands on. "Fresh install" and "reset" are the same
+state: the document does not exist.
+_Avoid_: default layout, template, seed, factory settings
+
+### What is stored, and where
+
+**Dashboard configuration**:
+The single, instance-scoped, versioned JSON document holding every page and every
+panel. Shared by everyone who opens the instance, last write wins. `document` is
+the accepted short form in frontend code (`DashboardDocument`).
+_Avoid_: settings, preferences, layout file, per-user config
+
+**Schema version**:
+The integer at the head of the configuration, present since the first release.
+Migrations run in memory on load; there is no down-migration
+([ADR-0003](./docs/adr/0003-instance-scoped-last-write-wins-configuration.md)
+covers why neither is written back).
+_Avoid_: config version, revision
+
+**State directory**:
+The one writable directory the server owns, holding `dashboards.json`. Defaults
+to `/var/lib/spark-dashboard` — a systemd `StateDirectory=` grant, a Docker named
+volume — and moves with `--state-dir` / `SPARK_DASHBOARD_STATE_DIR`.
+_Avoid_: data directory, config directory, storage path
+
+**Read-only mode**:
+What the dashboard runs in when the state directory was not writable at startup:
+reads work, writes are refused with `503`, every `/api/dashboard` response
+carries `x-spark-dashboard-read-only: true`, and a banner says so. Falling back
+to browser-local storage is prohibited.
+_Avoid_: degraded mode, offline mode
+
+## Out of scope
+
+Recorded so it is not re-argued. Each of these was considered during the
+dashboard rework (#68, spec #70) and deliberately left out.
+
+- **Import and export of the configuration.** Sharing the document would turn
+  its schema into a public contract and multiply the migration burden for a thin
+  use case on a single-instance tool. The file's location is documented instead
+  (README, `deploy/docker/docker.md`): copying it is the backup story.
+- **Per-user layouts.** They require an identity system this project
+  deliberately does not have. See
+  [ADR-0003](./docs/adr/0003-instance-scoped-last-write-wins-configuration.md).
+- **Conflict resolution between concurrent editors.** Last write wins is the
+  documented semantic; there is no locking and no "someone else changed this"
+  affordance. Same ADR.
+- **Server-side understanding of the configuration.** No validation, no typed
+  schema, no rendering — the server stores opaque bytes and enforces a size cap.
+  See [ADR-0002](./docs/adr/0002-configuration-is-an-opaque-document.md).
+- **Undo and redo inside edit mode.** Discarding the edit session is the
+  substitute; undo over a grid with collision-driven reflow is disproportionately
+  deep for the benefit.
+- **Hand-authored mobile layouts.** The narrow-viewport layout is *derived*:
+  panels collapse to a single column in desktop reading order, and widening
+  restores the authored layout exactly rather than a recompacted approximation.
+- **A panel-count limit separate from the row cap.** A page that cannot fit
+  another cell cannot fit another panel; one cap, one explanation.
+- **Alerting, per-panel thresholds, and cost accounting.** See
+  `.out-of-scope/cost-analysis.md` for the last of those.
+- **Flip-card chart interactions.** A glanceability decision, not a sequencing
+  one — see `.out-of-scope/flip-card-charts.md`, which also records that layout
+  contributions are no longer turned away now that arrangement is configuration.
+- **Subpath deployment behind a reverse proxy.** Broken independently of the
+  rework (assets are absolute-rooted); not regressed by it and not fixed by it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,16 @@ cp dev/.env.example .env       # edit with your remote host's user/host
 See [`dev/README.md`](./dev/README.md) for what each script does and what
 environment variables are required.
 
+## Before you build something
+
+- [`CONTEXT.md`](./CONTEXT.md) — the project's vocabulary (panel, page, binding,
+  preset, state directory), and what is deliberately **out of scope**. Worth a
+  read before opening an issue or a PR for a feature; a few of the obvious ones
+  were considered and turned down for reasons recorded there.
+- [`docs/adr/`](./docs/adr/) — architecture decision records. If a piece of the
+  design looks arbitrary, the reasoning is probably there. If you want to
+  contradict one, say so in the PR rather than changing it quietly.
+
 ## Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -504,6 +504,10 @@ real NVML/procfs parsing on Linux, with compile-time stubs on other platforms.
 │   ├── docker-dev.sh           Containerized build/deploy harness
 │   ├── .env.example            Dev configuration template
 │   └── README.md               Operator docs
+├── docs/
+│   ├── adr/                    Architecture decision records
+│   └── agents/                 Agent-facing workflow docs
+├── CONTEXT.md                  Domain glossary, and what is out of scope
 ├── LICENSE                     MIT
 ├── CONTRIBUTING.md
 └── Cargo.toml

--- a/README.md
+++ b/README.md
@@ -293,6 +293,32 @@ Override the location with `--state-dir` / `SPARK_DASHBOARD_STATE_DIR` — under
 systemd that also needs a unit override, since `ProtectSystem=strict` leaves the
 granted state directory the only writable path.
 
+**Backing it up is copying the file.** There is deliberately no import/export
+feature; the location is documented instead, so an operator can copy a
+configuration to another host or keep a snapshot before experimenting:
+
+```bash
+# systemd
+sudo cp /var/lib/spark-dashboard/dashboards.json ~/dashboards.backup.json
+sudo systemctl stop spark-dashboard                                   # restore
+sudo install -o spark-dashboard -g spark-dashboard -m 644 \
+  ~/dashboards.backup.json /var/lib/spark-dashboard/dashboards.json
+sudo systemctl start spark-dashboard
+
+# Docker — see deploy/docker/docker.md for the volume commands
+```
+
+Stop the service first so the copy cannot land under a write, and **reload any
+open dashboard afterwards**: a browser still holding the pre-restore document
+would put it straight back on its next save.
+
+> **The document's format is internal and subject to change.** It is the
+> frontend's own versioned state, not a stable contract
+> ([ADR-0002](./docs/adr/0002-configuration-is-an-opaque-document.md)) — copy the
+> file whole, don't generate or hand-edit it. A document written by a newer build
+> is refused by an older one, which falls back to the default preset with a
+> banner rather than failing.
+
 ```
 GET    /api/dashboard   the document, or 204 when none is stored
 PUT    /api/dashboard   replaces it wholesale (204 on success)

--- a/deploy/docker/docker.md
+++ b/deploy/docker/docker.md
@@ -101,7 +101,18 @@ without a shell in the container (there isn't one):
 docker volume inspect spark-dashboard-state         # where it lives on the host
 docker run --rm -v spark-dashboard-state:/state -w /state \
   busybox cat dashboards.json > dashboards.backup.json
+
+# restore, keeping the runtime uid's ownership; reload open dashboards after
+docker compose stop spark-dashboard
+docker run --rm -i -v spark-dashboard-state:/state -u 65532:65532 \
+  busybox sh -c 'cat > /state/dashboards.json' < dashboards.backup.json
+docker compose start spark-dashboard
 ```
+
+**The document's format is internal and subject to change** — copy the file
+whole, don't generate or hand-edit it. There is no import/export feature, on
+purpose; see
+[ADR-0002](../../docs/adr/0002-configuration-is-an-opaque-document.md).
 
 With plain `docker run`, pass the volume yourself — otherwise the configuration
 lives on the container's writable layer and dies with the container:

--- a/docs/adr/0001-gridstack-as-the-grid-engine.md
+++ b/docs/adr/0001-gridstack-as-the-grid-engine.md
@@ -1,0 +1,74 @@
+# Gridstack as the grid engine, pinned exactly
+
+**Status:** accepted (2026-09)
+
+The dashboard needs a grid that drags, resizes, refuses a drop when a page is out
+of room, and collapses to one column on a narrow viewport without destroying the
+authored desktop layout. We adopted **`gridstack`**, pinned to an exact version
+(`13.2.0` at the time of writing) in `frontend/package.json`, and rejected the
+better-known `react-grid-layout` — the obvious choice, which is why this is
+written down.
+
+## Why not react-grid-layout
+
+Three **open** defects landed squarely on the stack this design requires:
+
+- **#2271** — `Maximum update depth exceeded`, an infinite render loop in
+  `ResponsiveGridLayout` on container-width changes with fractional pixels,
+  reproducing on the project's own demo and reported as a v2 regression. The
+  container-measurement-driven responsive path is not a corner of this design; it
+  *is* this design, because fit-to-viewport derives row height from the measured
+  container.
+- **#2268** — React 19 plus `react-draggable@4.7.0` makes drag and resize
+  silently unresponsive, and the dependency range floats straight into it. Needs
+  an npm `overrides` pin.
+- **#2266** — `process is not defined` under Vite. Needs a `define:` block.
+
+Its own CI still ran React 18. Adopting it meant budgeting for three workarounds
+on a stack it did not test.
+
+Also ruled out: `@dnd-kit/*` (drag primitives, no layout engine),
+`react-resizable-panels` (nested split panes), `react-mosaic-component` /
+`dockview` / `flexlayout-react` (tiling and dock managers, not grids), and the
+unmaintained `muuri-react` / `golden-layout` / `react-grid-dnd`.
+
+## What the spike proved
+
+Gridstack's React wrapper was new, so adoption was gated on a browser spike
+against the real stack — React 19 under `StrictMode`, with live recharts children
+re-rendering at 20 Hz inside grid items. All of it passed: no StrictMode widget
+duplication, live chart children surviving the library's DOM manipulation
+(items are rendered through portals that keep the subtree mounted), no leaks
+across repeated mount/unmount, runtime `cellHeight()` for fit-to-viewport,
+`maxRow` + `willItFit()` for out-of-room rejection, real drag, and responsive
+column collapse.
+
+The strongest result was the last one: widening the container back restored the
+*authored* layout exactly rather than a recompacted approximation, which is
+precisely what the derived mobile layout requires — on the same
+`ResizeObserver` path that is broken in `react-grid-layout` #2271.
+
+## Consequences
+
+- **The version is pinned exactly, and stays pinned.** Two reasons, and the
+  second outlives the first. At adoption the newest line did not hold npm's
+  `latest` dist-tag — `13.0.2` did — so a range or a bare `npm i gridstack`
+  resolved *backwards*, to a line the spike never covered. That has since
+  resolved (`latest` is `13.2.0`, the pinned version), but the standing reason
+  has not: gridstack declares no React peer dependency at all, so npm will never
+  warn on a React major bump. Re-run the browser-mode suite on any React or
+  gridstack upgrade; that suite (`*.browser.test.tsx`, the `frontend-browser` CI
+  job) exists for this reason and is the only thing that would catch a silently
+  broken drag. A dependency sweep may move the pin, but not turn it into a range.
+- **`save()` omits gridstack's own defaults.** A panel at `w:1, h:1` serializes
+  with neither key. `readGeometry` therefore treats missing width and height as
+  one, and writing is dense on purpose, so a future migration never has to guess
+  what was elided.
+- **Drags are driven with `MouseEvent`, not PointerEvents.** Gridstack binds
+  `mousedown` on `.grid-stack-item-content`, then `mousemove`/`mouseup` on the
+  document. `userEvent.pointer` silently does nothing, which looks exactly like a
+  library defect and cost real debugging time in the spike.
+- **The grid's dimensions have one source.** `GRID_COLUMNS` and `GRID_MAX_ROWS`
+  in `frontend/src/lib/dashboard/grid.ts` configure the library; the library
+  answers the same "will it fit" question during a drag, and two independent
+  answers would disagree the moment either changed.

--- a/docs/adr/0002-configuration-is-an-opaque-document.md
+++ b/docs/adr/0002-configuration-is-an-opaque-document.md
@@ -1,0 +1,36 @@
+# The server stores the dashboard configuration as an opaque document
+
+**Status:** accepted (2026-09)
+
+The server persists the dashboard configuration as **opaque bytes**: it never
+parses, validates, migrates or understands the contents. `GET`, `PUT` and
+`DELETE /api/dashboard` move one file, `<state-dir>/dashboards.json`, in and out
+of the state directory under a 1 MiB cap. All schema knowledge — the panel types,
+the geometry, the bindings, the version and every migration — lives in the
+frontend (`frontend/src/lib/dashboard/`).
+
+The reason is that the project already has exactly one cross-language contract,
+the metrics wire format, and a typed configuration on the server would make two.
+Every panel type added, every field added to a panel, would then be a change to
+Rust structs, Rust tests, TypeScript types and TypeScript tests at once — for a
+document the server has no reason to read. The schema changes with the UI,
+because it *is* the UI's state; keeping it on the side that changes with it means
+one migration path rather than two that can disagree.
+
+## Consequences
+
+- **The server cannot reject a bad document.** It enforces a size cap and
+  nothing else, so a hand-edited or truncated file reaches the frontend, which
+  reads tolerantly and falls back to the preset with a visible reason rather than
+  throwing. That tolerance is a requirement of this decision, not a nicety.
+- **Migration is a frontend obligation, permanently.** Migrations run in memory
+  on load and are persisted only on the next operator-initiated save, so merely
+  opening an upgraded dashboard never rewrites a document that colleagues on the
+  older build are still reading.
+- **The document's shape is internal.** No API consumer is promised anything
+  about it, which is what keeps a versioned schema affordable and is why
+  import/export is out of scope — see `CONTEXT.md`.
+- **Deployment files, not the server, keep the path honest.** Since the server
+  has no opinion on the contents, the only thing that can drift is *where* the
+  file lives; `src/deploy_files.rs` asserts the systemd unit, the Dockerfile and
+  the Compose file all agree with `DEFAULT_STATE_DIR`.

--- a/docs/adr/0003-instance-scoped-last-write-wins-configuration.md
+++ b/docs/adr/0003-instance-scoped-last-write-wins-configuration.md
@@ -1,0 +1,39 @@
+# One instance-scoped configuration, last write wins
+
+**Status:** accepted (2026-09)
+
+There is **one** dashboard configuration per instance, shared by everyone who
+opens it, and concurrent saves resolve by **last write wins**. There are no
+per-user layouts, no locking, no merge, and no "someone else changed this"
+affordance.
+
+This follows from the product, not from expedience: the dashboard has no
+authentication and is not gaining any — it is a tool an operator points at their
+own machine. Per-user layouts would require an identity system to hang them on,
+and building conflict resolution for a document whose only writers are people who
+already share root on the same host would be machinery in front of a problem
+nobody has. An operator sharing a machine gets the semantic they already
+understand from the machine's own configuration files: the last person to save
+wins, and there is one answer to "what does this dashboard look like".
+
+## Consequences
+
+- **Writes are atomic, so the race is decided cleanly.** The bytes land in a
+  uniquely named temporary file in the state directory, are flushed, and are
+  renamed over the target — concurrent writers race to be last rather than
+  corrupting each other, and a crash mid-write leaves the old document or the new
+  one, never a truncated file that would brick the dashboard for every viewer at
+  once.
+- **Edit mode is explicit and there is no autosave.** With a configuration this
+  shared, a stray drag would mutate what everyone sees, and an intermediate drag
+  position must never become shared state.
+- **Reading never writes.** A document that needed migrating is migrated in
+  memory and persisted only on the next save the operator asked for; an
+  auto-write-back would let one upgraded viewer lock out everyone still on the
+  previous build.
+- **An unwritable state directory is visible, not routed around.** The dashboard
+  runs read-only with a banner rather than falling back to browser-local storage,
+  because a per-browser copy of an instance-scoped document is a second source of
+  truth that nobody can see.
+- **Resetting is confirmed and total.** `DELETE /api/dashboard` removes the one
+  document there is, for everyone, which is why the UI asks first.


### PR DESCRIPTION
Closes #88.

The documentation the frontend rework owed. `panel`, `page`, `binding`, `preset` and `state directory` are vocabulary the code and every future ticket now lean on, and nothing defined them anywhere; three decisions from #68/#70 were only legible as code comments; and the configuration file's location stands in place of an import/export feature, so it has to be documented as such.

## What's here

- **`CONTEXT.md`** at the repo root — the glossary (operator, engine, provider, GPU index, metrics contract, panel, panel type, page, geometry, binding, follow, page selection, time window, edit mode, palette, out of room, preset, dashboard configuration, schema version, state directory, read-only mode), each with the synonyms to avoid, plus the out-of-scope record: import/export, per-user layouts, undo/redo, hand-authored mobile layouts, a separate panel-count limit, conflict resolution and server-side understanding of the configuration.
- **`docs/adr/0001`–`0003`** — gridstack over `react-grid-layout` (three open defects on this exact stack, including the infinite render loop in the container-measurement responsive path this design is built on); the server storing the configuration as opaque bytes rather than adding a second cross-language contract; one instance-scoped configuration with last-write-wins, which follows from having no authentication.
- **Operator docs** — backup and restore per deployment in `README.md` (systemd) and `deploy/docker/docker.md` (Docker), both marking the format internal and subject to change, pointing at ADR-0002 for why there is no export feature.
- Pointers from `CONTRIBUTING.md` and the README's project tree, so a contributor meets the out-of-scope list before writing a PR rather than after it's closed.

## Verification

Documentation only — no file outside `*.md`, so every `ci.yml` filter (`src/**`, `Cargo.*`, `frontend/**`, `deploy/host/**`, `Dockerfile`, `docker-compose*.yml`) misses this and all four jobs skip.

The commands were not left unverified, though. The **Docker backup/restore round trip was run on the DGX Spark** against a build of this branch:

- the image's pre-created `/var/lib/spark-dashboard` seeded the fresh named volume as `65532:65532 drwxr-x---`, as `docker.md` claims;
- `GET /api/dashboard` returned `204` + `x-spark-dashboard-read-only: false` before anything was saved, and an unmatched `/api` path returned `404 text/plain`;
- a layout saved from the UI landed as `dashboards.json`, `-rw-r--r-- 65532:65532` — the server's own `0644`, which is why the systemd restore documents `-m 644`;
- after a second save added a panel, the documented `compose stop` → `busybox` write as uid 65532 → `compose start` restored a byte-identical document, and the added panel was gone.

Reviewed on both axes (repo standards + issue #88's acceptance criteria) before pushing; the findings — over-long glossary entries, the "format is internal" statement duplicated across four files, a missing stop/start in the Docker restore, the wrong file mode, an overstated `x-spark-dashboard-read-only` scope, and the ADR omitting the dist-tag reason for the exact version pin — are all folded in.

**Rebase-merge**, per the repo's rule. All four commits are `docs:`, so no version bump and no changelog entry.