### PR TITLE
feat(frontend): render the five panel types the palette offered

### DIFF
--- a/frontend/src/__tests__/App.enginePanels.test.tsx
+++ b/frontend/src/__tests__/App.enginePanels.test.tsx
@@ -8,7 +8,13 @@ import {
 } from '../test/configurationServer'
 import { MockWebSocket, substituteWebSocket } from '../test/websocket'
 import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
-import type { EngineMetrics, EngineSnapshot, MetricsSnapshot, ModelInfo } from '../types/metrics'
+import type {
+  EngineMetrics,
+  EngineSnapshot,
+  InferenceRequestData,
+  MetricsSnapshot,
+  ModelInfo,
+} from '../types/metrics'
 
 // The engine panels through the application seam (#81): real routing, real
 // configuration loading, real registry, store and binding resolution, with the
@@ -596,5 +602,119 @@ describe('the engine panels on a grid page', () => {
     receive(makeSnapshot(1000, [makeEngine(ALPHA)]))
     expect(screen.queryByText('Waiting for metrics')).not.toBeInTheDocument()
     expect(within(region('Decode Throughput')).getByText('120.0')).toBeInTheDocument()
+  })
+})
+
+// The engine type the palette offered and no build rendered (#110), through the
+// same seam as the seven above.
+describe('the inference-request timeline', () => {
+  /** Four finished requests, including a cold start that a mean would hide
+   *  behind — the outlier is the point of showing them individually. */
+  const REQUESTS: InferenceRequestData[] = [
+    { start_ms: 590_000, end_ms: 600_000, tokens_per_sec: 100, ttft_ms: 200 },
+    { start_ms: 595_000, end_ms: 599_000, tokens_per_sec: 120, ttft_ms: 300 },
+    { start_ms: 400_000, end_ms: 410_000, tokens_per_sec: 1, ttft_ms: 2400 },
+    { start_ms: 560_000, end_ms: 570_000, tokens_per_sec: 140, ttft_ms: 400 },
+  ]
+
+  /** The timeline's own rows inside one panel, in the order they are drawn. */
+  function requestRows(panelName: string): HTMLElement[] {
+    const list = within(region(panelName)).getByRole('list', { name: 'Inference requests' })
+    return within(list).getAllByRole('listitem')
+  }
+
+  function timelinePanel(extra: Record<string, unknown> = {}): unknown {
+    return { id: 'timeline', type: 'inference-timeline', geometry: { x: 0, y: 0, w: 6, h: 4 }, ...extra }
+  }
+
+  it('draws every request in the window, and summarizes them by median', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument([timelinePanel()]) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(600_000, [makeEngine(ALPHA, { recent_requests: REQUESTS })]))
+
+    const timeline = region('Inference Requests')
+    expect(within(timeline).getByText('Requests')).toBeInTheDocument()
+    expect(within(timeline).getByText('4')).toBeInTheDocument()
+    // Medians, not means: the cold start at 1 tok/s would drag a mean to 90.
+    expect(within(timeline).getByText('110.0')).toBeInTheDocument()
+    expect(within(timeline).getByText('350')).toBeInTheDocument()
+
+    // One row per request, newest first — the only place in the dashboard the
+    // requests themselves are visible rather than an aggregate over them.
+    const rows = requestRows('Inference Requests')
+    expect(rows).toHaveLength(4)
+    expect(rows.map((row) => row.textContent)).toEqual(['100.0', '120.0', '140.0', '1.0'])
+
+    expect(screen.queryByText('This panel is not available yet.')).not.toBeInTheDocument()
+  })
+
+  it('shows a pinned engine only its own requests', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        timelinePanel({ id: 'alpha', title: 'Alpha timeline' }),
+        {
+          id: 'beta',
+          type: 'inference-timeline',
+          title: 'Beta timeline',
+          binding: { kind: 'engine', endpoint: BETA },
+          geometry: { x: 6, y: 0, w: 6, h: 4 },
+        },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(600_000, [
+        makeEngine(ALPHA, { recent_requests: REQUESTS }),
+        makeEngine(BETA, {
+          recent_requests: [
+            { start_ms: 599_000, end_ms: 600_000, tokens_per_sec: 7, ttft_ms: 50 },
+          ],
+        }),
+      ]),
+    )
+
+    // Never the other engine's requests under this engine's name.
+    expect(within(region('Alpha timeline')).getByText('4')).toBeInTheDocument()
+    expect(within(region('Beta timeline')).getByText('1')).toBeInTheDocument()
+    expect(requestRows('Beta timeline').map((row) => row.textContent)).toEqual(['7.0'])
+    expect(within(region('Alpha timeline')).queryByText('7.0')).not.toBeInTheDocument()
+  })
+
+  it('says the window was quiet rather than drawing an empty axis', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument([timelinePanel()]) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(600_000, [makeEngine(ALPHA)]))
+
+    const timeline = region('Inference Requests')
+    expect(within(timeline).getByText('No requests finished in the last 5m.')).toBeInTheDocument()
+    // The tiles still stand, saying nothing happened rather than nothing loaded.
+    expect(within(timeline).getByText('0')).toBeInTheDocument()
+    expect(within(timeline).getAllByText('N/A')).toHaveLength(2)
+  })
+
+  it('keeps the slot of a panel pinned to an engine that is gone, naming it', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        timelinePanel({ binding: { kind: 'engine', endpoint: 'http://localhost:9999' } }),
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(600_000, [makeEngine(ALPHA, { recent_requests: REQUESTS })]))
+
+    // Named, never silently substituted — another engine's requests under this
+    // panel's title would be worse than no requests at all.
+    expect(
+      within(region('Inference Requests')).getByText(
+        'No engine at http://localhost:9999 — repoint this panel.',
+      ),
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/App.gridPage.test.tsx
+++ b/frontend/src/__tests__/App.gridPage.test.tsx
@@ -98,30 +98,11 @@ describe('the grid page route', () => {
     expect(screen.queryByText('This panel is not available yet.')).not.toBeInTheDocument()
   })
 
-  it('keeps the slot of a panel type this build has not implemented yet', async () => {
-    // The vocabulary names more panels than the registry implements — the
-    // inference timeline is still to come — and a preset written by a newer
-    // build can place one this build has never rendered. It keeps its slot
-    // rather than reflowing the arrangement around it.
-    const fetchMock = serveConfiguration({
-      document: storedDocument([
-        { id: 'a', type: 'inference-timeline', geometry: { x: 0, y: 0, w: 6, h: 4 } },
-        { id: 'b', type: 'memory', geometry: { x: 6, y: 0, w: 6, h: 4 } },
-      ]),
-    })
-    visit('/pages/watch')
-
-    render(<App />)
-    await configurationSettles(fetchMock)
-
-    expect(
-      within(screen.getByRole('region', { name: 'Inference Requests' })).getByText(
-        'This panel is not available yet.',
-      ),
-    ).toBeInTheDocument()
-    expect(screen.getByRole('region', { name: 'Memory' })).toBeInTheDocument()
-  })
-
+  // The spec that stood here placed an `inference-timeline` panel to watch a
+  // known-but-unimplemented type keep its slot. Every type in the vocabulary
+  // has a component now (#110), so there is none left to place; the registry
+  // is held against the vocabulary in `panelRegistry.test` instead, and the
+  // spec below covers the one placeholder a build can still reach.
   it('keeps an unknown panel type’s slot with a placeholder naming the type', async () => {
     const fetchMock = serveConfiguration({
       document: storedDocument([

--- a/frontend/src/__tests__/App.hardwarePanels.test.tsx
+++ b/frontend/src/__tests__/App.hardwarePanels.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '../test/configurationServer'
 import { MockWebSocket, substituteWebSocket } from '../test/websocket'
 import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
-import type { GpuMetrics, MetricsSnapshot } from '../types/metrics'
+import type { GpuEventData, GpuMetrics, MetricsSnapshot } from '../types/metrics'
 
 // The hardware panels through the application seam (#80): real routing, real
 // configuration loading, real registry, store and subscriptions, with the
@@ -81,7 +81,11 @@ function makeGpu(index: number, overrides: Partial<GpuMetrics> = {}): GpuMetrics
   }
 }
 
-function makeSnapshot(ts: number, gpus?: GpuMetrics[]): MetricsSnapshot {
+function makeSnapshot(
+  ts: number,
+  gpus?: GpuMetrics[],
+  gpuEvents: GpuEventData[] = [],
+): MetricsSnapshot {
   return {
     timestamp_ms: ts,
     gpu: gpus?.[0] ?? makeGpu(0),
@@ -108,7 +112,7 @@ function makeSnapshot(ts: number, gpus?: GpuMetrics[]): MetricsSnapshot {
     disk: { name: 'nvme0n1', read_bytes_per_sec: 12 * MIB, write_bytes_per_sec: 3.5 * MIB },
     network: { name: 'enp1s0', rx_bytes_per_sec: 900 * KIB, tx_bytes_per_sec: 2 * MIB },
     engines: [],
-    gpu_events: [],
+    gpu_events: gpuEvents,
   }
 }
 
@@ -292,5 +296,192 @@ describe('the hardware panels on a grid page', () => {
       within(region('GPU Temp')).getByText('GPU 3 is not on this host.'),
     ).toBeInTheDocument()
     expect(within(region('Memory')).getByText('50')).toBeInTheDocument()
+  })
+})
+
+// The four hardware types the palette offered and no build rendered (#110),
+// through the same seam as the eight above. They are grouped apart because the
+// eight are #80's block and these round it out — nothing about the seam differs.
+describe('the hardware panels the palette offered before anything rendered them', () => {
+  /** All four, tiled inside the 12×8 grid. */
+  function remainingHardwarePanels(): unknown[] {
+    return [
+      { id: 'vram', type: 'gpu-memory', geometry: { x: 0, y: 0, w: 3, h: 4 } },
+      { id: 'fan', type: 'gpu-fan', geometry: { x: 3, y: 0, w: 3, h: 4 } },
+      { id: 'events', type: 'gpu-events', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+      { id: 'cores', type: 'cpu-cores', geometry: { x: 0, y: 4, w: 6, h: 4 } },
+    ]
+  }
+
+  const THROTTLING: GpuEventData = {
+    timestamp_ms: 1000,
+    gpu_index: 0,
+    event_type: 'thermal',
+    detail: 'Thermal throttling active',
+  }
+
+  it('renders every one of them from the live snapshot', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(remainingHardwarePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, undefined, [THROTTLING]))
+
+    // VRAM: the used share, and the two figures it is a share of — a
+    // percentage alone does not say whether the next model fits.
+    const vram = region('GPU Memory')
+    expect(within(vram).getByText('50')).toBeInTheDocument()
+    expect(within(vram).getByText('24.0 GB / 48.0 GB')).toBeInTheDocument()
+
+    // Fan: the speed as a percentage of its maximum.
+    expect(within(region('GPU Fan')).getByText('30')).toBeInTheDocument()
+
+    // Events: what the driver reported, how serious, and how long ago.
+    const events = region('GPU Events')
+    expect(within(events).getByText('Thermal throttling active')).toBeInTheDocument()
+    expect(within(events).getByText('thermal')).toBeInTheDocument()
+    expect(within(events).getByText('0s ago')).toBeInTheDocument()
+
+    // Cores: every core's own load, not just the aggregate.
+    const cores = region('CPU Cores')
+    expect(within(cores).getByText('10%')).toBeInTheDocument()
+    expect(within(cores).getByText('95%')).toBeInTheDocument()
+    expect(within(cores).getAllByRole('listitem')).toHaveLength(2)
+
+    // All four are implemented — no slot-keeping placeholders left.
+    expect(screen.queryByText('This panel is not available yet.')).not.toBeInTheDocument()
+  })
+
+  it('names the hardware each of them is reading', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(remainingHardwarePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000, undefined, [THROTTLING]))
+
+    for (const panel of ['GPU Memory', 'GPU Fan', 'GPU Events']) {
+      expect(within(region(panel)).getByText('NVIDIA Alpha 0'), panel).toBeInTheDocument()
+    }
+    expect(within(region('CPU Cores')).getByText('Grace CPU')).toBeInTheDocument()
+  })
+
+  it('waits quietly before the first snapshot, then fills in when it arrives', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(remainingHardwarePanels()) })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+
+    // Every one keeps its slot; none crashes on a metrics-null first render.
+    expect(screen.getAllByText('Waiting for metrics')).toHaveLength(4)
+
+    // The first snapshot must not trip the changed-hook-count trap.
+    receive(makeSnapshot(1000, undefined, [THROTTLING]))
+    expect(screen.queryByText('Waiting for metrics')).not.toBeInTheDocument()
+    expect(within(region('GPU Memory')).getByText('50')).toBeInTheDocument()
+  })
+
+  it('says so rather than drawing a zero when the device reports neither', async () => {
+    // The unified-memory SoCs: NVML has no device pool and no fan for them, so
+    // a gauge at 0% would report hardware that is not there.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'vram', type: 'gpu-memory', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+        { id: 'fan', type: 'gpu-fan', geometry: { x: 6, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [
+        makeGpu(0, { memory_total_bytes: null, memory_used_bytes: null, fan_speed_percent: null }),
+      ]),
+    )
+
+    expect(
+      within(region('GPU Memory')).getByText('This GPU does not report its own memory pool.'),
+    ).toBeInTheDocument()
+    expect(within(region('GPU Fan')).getByText('This GPU has no fan to report.')).toBeInTheDocument()
+  })
+
+  it('shows each GPU only its own events, and keeps a pin to a GPU that is gone', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'first', type: 'gpu-events', geometry: { x: 0, y: 0, w: 4, h: 4 } },
+        {
+          id: 'second',
+          type: 'gpu-events',
+          title: 'Second GPU events',
+          binding: { kind: 'gpu', index: 1 },
+          geometry: { x: 4, y: 0, w: 4, h: 4 },
+        },
+        {
+          id: 'gone',
+          type: 'gpu-events',
+          title: 'Absent GPU events',
+          binding: { kind: 'gpu', index: 3 },
+          geometry: { x: 8, y: 0, w: 4, h: 4 },
+        },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [makeGpu(0), makeGpu(1, { name: 'NVIDIA Beta 1' })], [
+        THROTTLING,
+        { timestamp_ms: 1000, gpu_index: 1, event_type: 'power_brake', detail: 'Power brake engaged' },
+      ]),
+    )
+
+    // Each panel shows the events of the GPU it resolved to — never the
+    // neighbour's, which would read as this GPU throttling.
+    const first = region('GPU Events')
+    expect(within(first).getByText('Thermal throttling active')).toBeInTheDocument()
+    expect(within(first).queryByText('Power brake engaged')).not.toBeInTheDocument()
+
+    const second = region('Second GPU events')
+    expect(within(second).getByText('Power brake engaged')).toBeInTheDocument()
+    expect(within(second).queryByText('Thermal throttling active')).not.toBeInTheDocument()
+
+    // The pinned-but-absent GPU keeps its slot and names what it lost.
+    expect(
+      within(region('Absent GPU events')).getByText('GPU 3 is not on this host.'),
+    ).toBeInTheDocument()
+  })
+
+  it('says the window was quiet rather than showing an empty list', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'events', type: 'gpu-events', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(makeSnapshot(1000))
+
+    // A healthy GPU reports nothing, which is the common case and has to read
+    // as good news rather than as a panel that failed to load.
+    expect(
+      within(region('GPU Events')).getByText('Nothing reported in the last 5m.'),
+    ).toBeInTheDocument()
+  })
+
+  it('says so when the host reports no per-core load', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'cores', type: 'cpu-cores', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+    const snapshot = makeSnapshot(1000)
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive({ ...snapshot, cpu: { ...snapshot.cpu, per_core: [] } })
+
+    expect(
+      within(region('CPU Cores')).getByText('This host reports no per-core load.'),
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/App.panelEditing.test.tsx
+++ b/frontend/src/__tests__/App.panelEditing.test.tsx
@@ -170,8 +170,8 @@ afterEach(() => {
 describe('the panel palette', () => {
   it('offers every panel type the dashboard can show', async () => {
     // Including the log panel, which is a panel here rather than a fixed
-    // drawer, and the types this build renders as placeholders — a palette
-    // that hid them would make the vocabulary unreachable.
+    // drawer. A palette that hid part of the vocabulary would make it
+    // unreachable; that the whole of it renders is `panelRegistry.test`.
     const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
     await editPage(fetchMock)
     await openPalette()

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  formatAge,
   formatBytes,
   formatCompactTokens,
   formatAcceptanceLength,
@@ -78,6 +79,26 @@ describe('formatEndpoint', () => {
     // whatever shape the endpoint came in.
     expect(formatEndpoint('localhost:8000')).toBe('localhost:8000')
     expect(formatEndpoint('')).toBe('')
+  })
+})
+
+describe('formatAge', () => {
+  it('reads in the coarsest unit that still says when', () => {
+    expect(formatAge(59_000, 60_000)).toBe('1s')
+    expect(formatAge(0, 59_000)).toBe('59s')
+    expect(formatAge(0, 60_000)).toBe('1m')
+    expect(formatAge(0, 59 * 60_000)).toBe('59m')
+    expect(formatAge(0, 60 * 60_000)).toBe('1h')
+  })
+
+  it('rounds down, so nothing reads as older than it is', () => {
+    expect(formatAge(0, 1999)).toBe('1s')
+  })
+
+  it('does not go negative on an event stamped past the newest sample', () => {
+    // Snapshots coalesce, so an event can carry a timestamp the reference
+    // reading has not caught up to yet.
+    expect(formatAge(5000, 1000)).toBe('0s')
   })
 })
 

--- a/frontend/src/__tests__/metricsHistoryStore.test.ts
+++ b/frontend/src/__tests__/metricsHistoryStore.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it, vi } from 'vitest'
-import { gpuSeries, MetricsHistoryStore } from '../lib/metricsHistoryStore'
-import type { EngineSnapshot, MetricsSnapshot } from '../types/metrics'
+import { gpuMemoryPercent, gpuSeries, MetricsHistoryStore } from '../lib/metricsHistoryStore'
+import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '../types/metrics'
+
+/** The GPU the snapshots below carry, for the specs that read one field of it. */
+const GPU: GpuMetrics = {
+  index: 0,
+  name: 'GPU 0',
+  utilization_percent: 11,
+  memory_total_bytes: 24,
+  memory_used_bytes: 6,
+  temperature_celsius: 40,
+  power_watts: 100,
+  power_limit_watts: 300,
+  clock_graphics_mhz: 1800,
+  clock_sm_mhz: 1800,
+  clock_memory_mhz: 9000,
+  fan_speed_percent: 30,
+}
 
 /** A snapshot at `ts` whose per-series values can be nulled out selectively. */
 function makeSnapshot(
@@ -15,20 +31,7 @@ function makeSnapshot(
   const { util = 11, temp = 40, engines = [], gpu_events = [] } = overrides
   return {
     timestamp_ms: ts,
-    gpu: {
-      index: 0,
-      name: 'GPU 0',
-      utilization_percent: util,
-      memory_total_bytes: 24,
-      memory_used_bytes: 6,
-      temperature_celsius: temp,
-      power_watts: 100,
-      power_limit_watts: 300,
-      clock_graphics_mhz: 1800,
-      clock_sm_mhz: 1800,
-      clock_memory_mhz: 9000,
-      fan_speed_percent: 30,
-    },
+    gpu: { ...GPU, utilization_percent: util, temperature_celsius: temp },
     cpu: { name: 'CPU', aggregate_percent: 25, per_core: [] },
     memory: {
       total_bytes: 128,
@@ -245,5 +248,36 @@ describe('gpuSeries', () => {
 
     expect(store.getChartData(gpuSeries('gpuUtil', 0, true)).map((p) => p.value)).toEqual([11])
     expect(store.getChartData(gpuSeries('gpuUtil', 0, false)).map((p) => p.value)).toEqual([11])
+  })
+
+  it('charts a GPU’s own memory and fan on both key shapes', () => {
+    // The two series behind the GPU Memory and GPU Fan panels (#110), which
+    // resolve their keys through `gpuSeries` like every other GPU panel.
+    const store = new MetricsHistoryStore()
+    store.ingest(makeSnapshot(1000))
+
+    // 6 of 24 bytes used, charted as the percentage the gauge shows.
+    expect(store.getChartData('gpuMemory').map((p) => p.value)).toEqual([25])
+    expect(store.getChartData(gpuSeries('gpuMemory', 0, true)).map((p) => p.value)).toEqual([25])
+    expect(store.getChartData('gpuFan').map((p) => p.value)).toEqual([30])
+    expect(store.getChartData(gpuSeries('gpuFan', 0, true)).map((p) => p.value)).toEqual([30])
+  })
+})
+
+describe('gpuMemoryPercent', () => {
+  it('is the used share of the device’s own pool', () => {
+    expect(gpuMemoryPercent({ ...GPU, memory_used_bytes: 6, memory_total_bytes: 24 })).toBe(25)
+  })
+
+  it('is absent on a GPU that reports no pool of its own', () => {
+    // The unified-memory SoCs: NVML answers NotSupported, and the host memory
+    // panel is the one with the numbers. A zero here would be a lie.
+    expect(gpuMemoryPercent({ ...GPU, memory_total_bytes: null })).toBeNull()
+    expect(gpuMemoryPercent({ ...GPU, memory_used_bytes: null })).toBeNull()
+    expect(gpuMemoryPercent({ ...GPU, memory_total_bytes: undefined })).toBeNull()
+  })
+
+  it('does not divide by a pool of zero bytes', () => {
+    expect(gpuMemoryPercent({ ...GPU, memory_total_bytes: 0 })).toBeNull()
   })
 })

--- a/frontend/src/__tests__/panelRegistry.test.tsx
+++ b/frontend/src/__tests__/panelRegistry.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { implementedPanelTypes, renderPanelContent } from '../components/grid/panelRegistry'
+import { PANEL_TYPE_IDS, defaultPanelTitle } from '../lib/dashboard/panels'
+import { DEFAULT_TIME_WINDOW } from '../lib/dashboard/schema'
+
+describe('the panel registry against the vocabulary', () => {
+  it('renders every type the palette offers', () => {
+    // The palette lists the whole vocabulary on purpose, so a type with no
+    // component is a box an operator adds and finds empty (#110). This spec is
+    // what stops that shipping again: a new type in `panels.ts` fails here
+    // until something renders it.
+    expect([...implementedPanelTypes()].sort()).toEqual([...PANEL_TYPE_IDS].sort())
+  })
+
+  it('has content for a panel of each type, not merely an entry', () => {
+    for (const type of PANEL_TYPE_IDS) {
+      const content = renderPanelContent({
+        id: type,
+        type,
+        geometry: { x: 0, y: 0, w: 3, h: 3 },
+        binding: { kind: 'follow' },
+        window: DEFAULT_TIME_WINDOW,
+      })
+      expect(content, defaultPanelTitle(type)).not.toBeNull()
+    }
+  })
+
+  it('still declines a type from a newer build', () => {
+    // The placeholder is kept for exactly this: a document written by a
+    // version that knows a panel this one does not.
+    expect(
+      renderPanelContent({
+        id: 'future',
+        type: 'gpu-voltage',
+        geometry: { x: 0, y: 0, w: 3, h: 3 },
+        binding: { kind: 'follow' },
+        window: DEFAULT_TIME_WINDOW,
+      }),
+    ).toBeNull()
+  })
+})

--- a/frontend/src/__tests__/theme.test.ts
+++ b/frontend/src/__tests__/theme.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { NVIDIA_THEME, THRESHOLDS, thresholdColor } from '../lib/theme'
+import {
+  NVIDIA_THEME,
+  THRESHOLDS,
+  coreUsageColor,
+  gpuEventColor,
+  thresholdColor,
+} from '../lib/theme'
 
 describe('theme', () => {
   it('NVIDIA_THEME.accent is NVIDIA green', () => {
@@ -30,6 +36,53 @@ describe('theme', () => {
 
     it('returns critical red at exactly the critical threshold', () => {
       expect(thresholdColor(85, 70, 85)).toBe('#ef4444')
+    })
+  })
+
+  describe('coreUsageColor', () => {
+    // More bands than `thresholdColor`, and dimmer at the bottom: a core grid
+    // is read as a texture, so an idle core has to recede rather than sit at
+    // full green beside a saturated one.
+    it('recedes below a tenth of a core', () => {
+      expect(coreUsageColor(0)).toBe('#27272a')
+      expect(coreUsageColor(9)).toBe('#27272a')
+    })
+
+    it('dims a core that is doing something but not much', () => {
+      expect(coreUsageColor(10)).toBe('#365314')
+      expect(coreUsageColor(39)).toBe('#365314')
+    })
+
+    it('reaches the accent at a busy core', () => {
+      expect(coreUsageColor(40)).toBe('#76B900')
+      expect(coreUsageColor(69)).toBe('#76B900')
+    })
+
+    it('warns, then alarms, on a saturated core', () => {
+      expect(coreUsageColor(70)).toBe('#eab308')
+      expect(coreUsageColor(89)).toBe('#eab308')
+      expect(coreUsageColor(90)).toBe('#ef4444')
+      expect(coreUsageColor(100)).toBe('#ef4444')
+    })
+  })
+
+  describe('gpuEventColor', () => {
+    it('alarms on the two an operator has to act on', () => {
+      // A cooling problem or a hardware fault.
+      expect(gpuEventColor('thermal')).toBe('#ef4444')
+      expect(gpuEventColor('xid')).toBe('#ef4444')
+    })
+
+    it('only warns on the machine working as configured', () => {
+      // Spending the alarm on a power cap would spend it on the ordinary case.
+      expect(gpuEventColor('throttle')).toBe('#eab308')
+      expect(gpuEventColor('power_brake')).toBe('#eab308')
+    })
+
+    it('warns rather than alarming on an event type it has never seen', () => {
+      // A newer driver, or a newer collector: an unrecognized event is still
+      // an event, and it must not read as more serious than a thermal one.
+      expect(gpuEventColor('some_future_reason')).toBe('#eab308')
     })
   })
 })

--- a/frontend/src/components/charts/CoreHeatmap.tsx
+++ b/frontend/src/components/charts/CoreHeatmap.tsx
@@ -1,16 +1,9 @@
 import React, { useState, useCallback } from 'react'
+import { coreUsageColor } from '@/lib/theme'
 import type { CoreMetrics } from '@/types/metrics'
 
 interface CoreHeatmapProps {
   cores: CoreMetrics[]
-}
-
-function coreColor(usage: number): string {
-  if (usage >= 90) return '#ef4444'
-  if (usage >= 70) return '#eab308'
-  if (usage >= 40) return '#76B900'
-  if (usage >= 10) return '#365314'
-  return '#27272a'
 }
 
 export const CoreHeatmap = React.memo(function CoreHeatmap({ cores }: CoreHeatmapProps) {
@@ -40,7 +33,7 @@ export const CoreHeatmap = React.memo(function CoreHeatmap({ cores }: CoreHeatma
           <div
             key={core.id}
             className="h-[6px] lg:h-[10px] 2xl:h-[12px] rounded-[1px] transition-colors duration-300"
-            style={{ backgroundColor: coreColor(core.usage_percent) }}
+            style={{ backgroundColor: coreUsageColor(core.usage_percent) }}
             onMouseEnter={(e) => handleMouseEnter(core, e)}
             onMouseLeave={handleMouseLeave}
           />

--- a/frontend/src/components/grid/PanelPalette.tsx
+++ b/frontend/src/components/grid/PanelPalette.tsx
@@ -6,8 +6,10 @@ import { BarButton } from './BarButton'
  * Every panel type the dashboard can show, as a list to add from.
  *
  * This is where the full vocabulary becomes reachable rather than only
- * preset-placed — including the types this build renders as a placeholder,
- * which are still real panels an operator may want a slot kept for.
+ * preset-placed. It lists the whole of it unconditionally, which is only safe
+ * because the registry covers the whole of it — a type offered here and
+ * rendered as an empty box is the bug #110 was; `panelRegistry.test` is what
+ * holds the two together.
  *
  * **Click-to-add, not drag-from-palette.** The chosen panel is placed in the
  * first free slot and dragged into position from there, so nothing has to be

--- a/frontend/src/components/grid/panelRegistry.tsx
+++ b/frontend/src/components/grid/panelRegistry.tsx
@@ -7,13 +7,15 @@
  * that keeps its grid slot. That is what lets the panel tickets land one at a
  * time against a preset that already names every type.
  *
- * The hardware panels (#80), the engine metric panels (#81) and the log panel
- * (#82) are implemented; the remaining types still render as placeholders.
+ * Nothing is lagging today — every type in the vocabulary has a component, and
+ * `panelRegistry.test` holds it that way. The lag is kept as an affordance for
+ * the next type to be named, not as a description of this build.
  */
 
 import type { ComponentType, ReactElement } from 'react'
 import { isKnownPanelType, type PanelType } from '@/lib/dashboard/panels'
 import type { DashboardPanel } from '@/lib/dashboard/schema'
+import { CpuCoresPanel } from './panels/CpuCoresPanel'
 import { CpuUtilizationPanel } from './panels/CpuUtilizationPanel'
 import { DiskIoPanel } from './panels/DiskIoPanel'
 import { EngineCachePanel } from './panels/EngineCachePanel'
@@ -28,9 +30,13 @@ import {
   EnginePrefillThroughputPanel,
 } from './panels/EngineThroughputPanel'
 import { GpuClockPanel } from './panels/GpuClockPanel'
+import { GpuEventsPanel } from './panels/GpuEventsPanel'
+import { GpuFanPanel } from './panels/GpuFanPanel'
+import { GpuMemoryPanel } from './panels/GpuMemoryPanel'
 import { GpuPowerPanel } from './panels/GpuPowerPanel'
 import { GpuTemperaturePanel } from './panels/GpuTemperaturePanel'
 import { GpuUtilizationPanel } from './panels/GpuUtilizationPanel'
+import { InferenceTimelinePanel } from './panels/InferenceTimelinePanel'
 import { LogsPanel } from './panels/LogsPanel'
 import { MemoryPanel } from './panels/MemoryPanel'
 import { NetworkIoPanel } from './panels/NetworkIoPanel'
@@ -46,7 +52,11 @@ const PANEL_CONTENT: Partial<Record<PanelType, ComponentType<PanelContentProps>>
   'gpu-temperature': GpuTemperaturePanel,
   'gpu-power': GpuPowerPanel,
   'gpu-clock': GpuClockPanel,
+  'gpu-memory': GpuMemoryPanel,
+  'gpu-fan': GpuFanPanel,
+  'gpu-events': GpuEventsPanel,
   'cpu-utilization': CpuUtilizationPanel,
+  'cpu-cores': CpuCoresPanel,
   memory: MemoryPanel,
   'disk-io': DiskIoPanel,
   'network-io': NetworkIoPanel,
@@ -59,7 +69,17 @@ const PANEL_CONTENT: Partial<Record<PanelType, ComponentType<PanelContentProps>>
   'engine-spec-decode': EngineSpecDecodePanel,
   'engine-status': EngineStatusPanel,
   'engines-overview': EnginesOverviewPanel,
+  'inference-timeline': InferenceTimelinePanel,
   logs: LogsPanel,
+}
+
+/**
+ * The panel types this build renders. Exported for the spec that holds the
+ * registry against the vocabulary: a type the palette offers and no component
+ * renders is a gap an operator only finds by adding an empty box (#110).
+ */
+export function implementedPanelTypes(): PanelType[] {
+  return Object.keys(PANEL_CONTENT) as PanelType[]
 }
 
 /**

--- a/frontend/src/components/grid/panels/CpuCoresPanel.tsx
+++ b/frontend/src/components/grid/panels/CpuCoresPanel.tsx
@@ -1,0 +1,69 @@
+import { useElementSize } from '@/hooks/useElementSize'
+import { useLatestSnapshot } from '@/hooks/useMetricsStore'
+import { coreUsageColor } from '@/lib/theme'
+import { usePanelDevice } from '../panelDevice'
+import { coreGridLayout } from './mode'
+import { PanelNotice } from './PanelNotice'
+import type { CoreMetrics } from '@/types/metrics'
+
+/**
+ * Every CPU core's load at once, given the whole panel.
+ *
+ * The CPU panel already carries this grid as a strip under its chart, which is
+ * enough to see *that* the load is uneven. This panel is for the question that
+ * follows — which cores, and by how much — so the cells get the whole box and
+ * label themselves once they are big enough to be read rather than only looked
+ * at. Host-wide, so nothing binds to it.
+ *
+ * The layout decision lives in `mode.ts`, where it is testable without a layout
+ * engine, on the same terms as the gauge panels' modes.
+ */
+export function CpuCoresPanel() {
+  const snapshot = useLatestSnapshot()
+  const [ref, size] = useElementSize<HTMLUListElement>()
+  const cores = snapshot?.cpu.per_core ?? []
+  const { columns, labelled } = coreGridLayout(size, cores.length)
+  usePanelDevice(snapshot?.cpu.name)
+
+  if (!snapshot) return <PanelNotice>Waiting for metrics</PanelNotice>
+  if (cores.length === 0) return <PanelNotice>This host reports no per-core load.</PanelNotice>
+
+  return (
+    <ul
+      ref={ref}
+      aria-label="CPU cores"
+      className="min-h-0 min-w-0 overflow-hidden grid gap-px"
+      // Inline: the height must hold anywhere the component renders — including
+      // the browser test project, which runs no Tailwind build — and the column
+      // count is computed from the measured box, so it cannot be a class.
+      style={{ height: '100%', gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
+      {cores.map((core) => (
+        <CoreCell key={core.id} core={core} labelled={labelled} />
+      ))}
+    </ul>
+  )
+}
+
+function CoreCell({ core, labelled }: { core: CoreMetrics; labelled: boolean }) {
+  const percent = Math.round(core.usage_percent)
+
+  return (
+    <li
+      // The title carries both readings at every size, so the cells that came
+      // out too small to label are still identifiable on hover.
+      title={`Core ${core.id}: ${percent}%`}
+      className="min-w-0 min-h-0 rounded-[2px] overflow-hidden flex items-center justify-between px-1 transition-colors duration-300"
+      style={{ backgroundColor: coreUsageColor(core.usage_percent) }}
+    >
+      {labelled && (
+        <>
+          <span className="text-[9px] font-mono text-zinc-100/70 truncate">{core.id}</span>
+          <span className="text-[10px] font-mono font-semibold tabular-nums text-zinc-50 truncate">
+            {percent}%
+          </span>
+        </>
+      )}
+    </li>
+  )
+}

--- a/frontend/src/components/grid/panels/GpuEventsPanel.tsx
+++ b/frontend/src/components/grid/panels/GpuEventsPanel.tsx
@@ -1,9 +1,10 @@
 import { useGpuEvents, useLatestSnapshot } from '@/hooks/useMetricsStore'
 import { formatAge } from '@/lib/format'
 import { gpuIndexOf } from '@/lib/identity'
-import { NVIDIA_THEME } from '@/lib/theme'
+import { gpuEventColor } from '@/lib/theme'
 import { usePanelDevice } from '../panelDevice'
-import { GpuPanelNotice } from './PanelNotice'
+import { PanelList } from './PanelList'
+import { GpuPanelNotice, PanelNotice } from './PanelNotice'
 import { useGpuPanel } from './useGpuPanel'
 import type { GpuEventData } from '@/types/metrics'
 import type { PanelContentProps } from '../panelRegistry'
@@ -16,10 +17,6 @@ import type { PanelContentProps } from '../panelRegistry'
  * happened or it did not, and the thing an operator needs is which one and how
  * long ago. It reads beside the temperature and power panels: those say the GPU
  * is at 88°C, this says the driver has started clipping its clocks over it.
- *
- * Sizes itself by scrolling rather than by dropping content the way the gauge
- * panels do. There is no reduced rendering of an event that is still an event,
- * and the newest are at the top, so a 1×1 cell shows the one that matters.
  */
 export function GpuEventsPanel({ panel }: PanelContentProps) {
   const resolution = useGpuPanel(panel)
@@ -42,35 +39,25 @@ export function GpuEventsPanel({ panel }: PanelContentProps) {
   const now = snapshot?.timestamp_ms ?? 0
 
   if (mine.length === 0) {
-    return (
-      <div className="h-full flex items-center justify-center text-center">
-        <p className="text-xs text-zinc-500">Nothing reported in the last {panel.window}.</p>
-      </div>
-    )
+    return <PanelNotice>Nothing reported in the last {panel.window}.</PanelNotice>
   }
 
+  // Sorted rather than reversed: a poll that detected three throttle reasons at
+  // once stamps them all with the same time, and a stable sort leaves those in
+  // the order the collector found them instead of inverting it.
+  const newestFirst = [...mine].sort((a, b) => b.timestamp_ms - a.timestamp_ms)
+
   return (
-    <ul className="h-full min-h-0 min-w-0 overflow-y-auto flex flex-col gap-0.5 pr-0.5">
-      {[...mine].reverse().map((event, i) => (
+    <PanelList label="GPU events">
+      {newestFirst.map((event, i) => (
         <EventRow key={`${event.timestamp_ms}-${event.event_type}-${i}`} event={event} now={now} />
       ))}
-    </ul>
+    </PanelList>
   )
 }
 
-/**
- * How serious an event is. Thermal slowdowns and Xid errors are the two the
- * operator has to act on — a hardware failure or a cooling problem — where a
- * power cap is the machine working as configured.
- */
-function eventColor(eventType: string): string {
-  return eventType === 'thermal' || eventType === 'xid'
-    ? NVIDIA_THEME.critical
-    : NVIDIA_THEME.warning
-}
-
 function EventRow({ event, now }: { event: GpuEventData; now: number }) {
-  const color = eventColor(event.event_type)
+  const color = gpuEventColor(event.event_type)
 
   return (
     <li className="flex items-baseline gap-1.5 min-w-0 leading-tight">

--- a/frontend/src/components/grid/panels/GpuEventsPanel.tsx
+++ b/frontend/src/components/grid/panels/GpuEventsPanel.tsx
@@ -1,0 +1,91 @@
+import { useGpuEvents, useLatestSnapshot } from '@/hooks/useMetricsStore'
+import { formatAge } from '@/lib/format'
+import { gpuIndexOf } from '@/lib/identity'
+import { NVIDIA_THEME } from '@/lib/theme'
+import { usePanelDevice } from '../panelDevice'
+import { GpuPanelNotice } from './PanelNotice'
+import { useGpuPanel } from './useGpuPanel'
+import type { GpuEventData } from '@/types/metrics'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * What one GPU has complained about inside the panel's window: thermal
+ * slowdowns, hardware throttling, power brakes.
+ *
+ * A list rather than a chart, because an event has no value to plot — it either
+ * happened or it did not, and the thing an operator needs is which one and how
+ * long ago. It reads beside the temperature and power panels: those say the GPU
+ * is at 88°C, this says the driver has started clipping its clocks over it.
+ *
+ * Sizes itself by scrolling rather than by dropping content the way the gauge
+ * panels do. There is no reduced rendering of an event that is still an event,
+ * and the newest are at the top, so a 1×1 cell shows the one that matters.
+ */
+export function GpuEventsPanel({ panel }: PanelContentProps) {
+  const resolution = useGpuPanel(panel)
+  const events = useGpuEvents(panel.window)
+  const snapshot = useLatestSnapshot()
+  // Above the early return, like every hook here — a panel whose binding has
+  // not resolved still has to call it, with nothing to report.
+  usePanelDevice(resolution.status === 'resolved' ? resolution.gpu.name : null)
+
+  if (resolution.status !== 'resolved') return <GpuPanelNotice resolution={resolution} />
+
+  const index = gpuIndexOf(resolution.gpu)
+  // `gpu_index` is nullable on the wire, and null means the primary GPU — the
+  // same normalization `gpuIndexOf` applies to the GPU itself, so an event the
+  // collector could not attribute lands on the panel showing GPU 0 rather than
+  // on none of them.
+  const mine = events.filter((event) => (event.gpu_index ?? 0) === index)
+  // The newest sample, not wall clock: the ages then hold still between
+  // snapshots instead of ticking under a dashboard nobody is touching.
+  const now = snapshot?.timestamp_ms ?? 0
+
+  if (mine.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center text-center">
+        <p className="text-xs text-zinc-500">Nothing reported in the last {panel.window}.</p>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="h-full min-h-0 min-w-0 overflow-y-auto flex flex-col gap-0.5 pr-0.5">
+      {[...mine].reverse().map((event, i) => (
+        <EventRow key={`${event.timestamp_ms}-${event.event_type}-${i}`} event={event} now={now} />
+      ))}
+    </ul>
+  )
+}
+
+/**
+ * How serious an event is. Thermal slowdowns and Xid errors are the two the
+ * operator has to act on — a hardware failure or a cooling problem — where a
+ * power cap is the machine working as configured.
+ */
+function eventColor(eventType: string): string {
+  return eventType === 'thermal' || eventType === 'xid'
+    ? NVIDIA_THEME.critical
+    : NVIDIA_THEME.warning
+}
+
+function EventRow({ event, now }: { event: GpuEventData; now: number }) {
+  const color = eventColor(event.event_type)
+
+  return (
+    <li className="flex items-baseline gap-1.5 min-w-0 leading-tight">
+      <span
+        className="shrink-0 rounded px-1 text-[9px] font-medium uppercase tracking-wider"
+        style={{ color, backgroundColor: `${color}1a` }}
+      >
+        {event.event_type.replace(/_/g, ' ')}
+      </span>
+      <span className="flex-1 min-w-0 truncate text-[11px] text-zinc-300" title={event.detail}>
+        {event.detail}
+      </span>
+      <span className="shrink-0 font-mono tabular-nums text-[10px] text-zinc-500">
+        {formatAge(event.timestamp_ms, now)} ago
+      </span>
+    </li>
+  )
+}

--- a/frontend/src/components/grid/panels/GpuFanPanel.tsx
+++ b/frontend/src/components/grid/panels/GpuFanPanel.tsx
@@ -1,0 +1,40 @@
+import { ArcGauge } from '@/components/gauges/ArcGauge'
+import { HBar } from '@/components/gauges/HBar'
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { gpuLabel } from './gpuLabel'
+import { GpuPanelNotice, PanelNotice } from './PanelNotice'
+import { HardwarePanelBody } from './HardwarePanelBody'
+import { useGpuPanelSeries } from './useGpuPanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * One GPU's fan speed, as a percentage of its maximum.
+ *
+ * No thresholds on the gauge: a fan at 100% is the cooling working, not a
+ * fault, and colouring it red would say the opposite. The temperature panel is
+ * where the alarming number lives — this one is read beside it, to tell a GPU
+ * that is hot because it is working from one that is hot because it is not
+ * being cooled.
+ *
+ * Passively cooled accelerators report no fan at all (NVML answers
+ * `NotSupported`), which the panel says rather than drawing a zero.
+ */
+export function GpuFanPanel({ panel }: PanelContentProps) {
+  const { resolution, data } = useGpuPanelSeries(panel, 'gpuFan')
+  if (resolution.status !== 'resolved') return <GpuPanelNotice resolution={resolution} />
+
+  const { gpu } = resolution
+  const percent = gpu.fan_speed_percent
+  if (percent === null) return <PanelNotice>This GPU has no fan to report.</PanelNotice>
+
+  const label = gpuLabel(resolution, 'Fan')
+
+  return (
+    <HardwarePanelBody
+      device={gpu.name}
+      compact={<HBar value={percent} label={label} unit="%" />}
+      gauge={(sizePx) => <ArcGauge value={percent} label={label} unit="%" size={sizePx} />}
+      chart={<TimeSeriesChart data={data} yDomain={[0, 100]} unit="%" seriesLabel="Fan" />}
+    />
+  )
+}

--- a/frontend/src/components/grid/panels/GpuMemoryPanel.tsx
+++ b/frontend/src/components/grid/panels/GpuMemoryPanel.tsx
@@ -29,7 +29,9 @@ export function GpuMemoryPanel({ panel }: PanelContentProps) {
     return <PanelNotice>This GPU does not report its own memory pool.</PanelNotice>
   }
 
-  // Narrowed into locals: the guard above does not reach the render callbacks.
+  // `percent` being non-null already means both of these are present, but the
+  // guard is on the derived value, so nothing propagates that back to the
+  // fields — hence the defaults rather than a narrowing.
   const used = gpu.memory_used_bytes ?? 0
   const total = gpu.memory_total_bytes ?? 0
   // A single filled segment rather than a threshold gauge: the legend is where

--- a/frontend/src/components/grid/panels/GpuMemoryPanel.tsx
+++ b/frontend/src/components/grid/panels/GpuMemoryPanel.tsx
@@ -1,0 +1,56 @@
+import { ArcGauge, type GaugeSegment } from '@/components/gauges/ArcGauge'
+import { HBar } from '@/components/gauges/HBar'
+import { TimeSeriesChart } from '@/components/charts/TimeSeriesChart'
+import { formatGiB } from '@/lib/format'
+import { gpuMemoryPercent } from '@/lib/metricsHistoryStore'
+import { NVIDIA_THEME } from '@/lib/theme'
+import { gpuLabel } from './gpuLabel'
+import { GpuPanelNotice, PanelNotice } from './PanelNotice'
+import { HardwarePanelBody } from './HardwarePanelBody'
+import { useGpuPanelSeries } from './useGpuPanel'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * One GPU's own memory: the used share of the device pool, with the two figures
+ * it is a share of.
+ *
+ * Distinct from the host `memory` panel, which is deliberately host-wide
+ * because a unified-memory machine has one pool. This one reads the device's
+ * NVML pool, which those machines do not report at all — hence the notice
+ * rather than a gauge stuck at zero.
+ */
+export function GpuMemoryPanel({ panel }: PanelContentProps) {
+  const { resolution, data } = useGpuPanelSeries(panel, 'gpuMemory')
+  if (resolution.status !== 'resolved') return <GpuPanelNotice resolution={resolution} />
+
+  const { gpu } = resolution
+  const percent = gpuMemoryPercent(gpu)
+  if (percent === null) {
+    return <PanelNotice>This GPU does not report its own memory pool.</PanelNotice>
+  }
+
+  // Narrowed into locals: the guard above does not reach the render callbacks.
+  const used = gpu.memory_used_bytes ?? 0
+  const total = gpu.memory_total_bytes ?? 0
+  // A single filled segment rather than a threshold gauge: the legend is where
+  // the GB figures go, and "22.4 GB / 48.0 GB" is what an operator sizing a
+  // model needs — a percentage alone does not say whether the next one fits.
+  const segments: GaugeSegment[] = [
+    {
+      value: used,
+      total,
+      color: NVIDIA_THEME.accent,
+      label: `${formatGiB(used, 1)} / ${formatGiB(total, 1)}`,
+    },
+  ]
+  const label = gpuLabel(resolution, 'VRAM')
+
+  return (
+    <HardwarePanelBody
+      device={gpu.name}
+      compact={<HBar label={label} unit="%" segments={segments} />}
+      gauge={(sizePx) => <ArcGauge label={label} unit="%" segments={segments} size={sizePx} />}
+      chart={<TimeSeriesChart data={data} yDomain={[0, 100]} unit="%" seriesLabel="VRAM" />}
+    />
+  )
+}

--- a/frontend/src/components/grid/panels/InferenceTimelinePanel.tsx
+++ b/frontend/src/components/grid/panels/InferenceTimelinePanel.tsx
@@ -11,7 +11,8 @@ import {
 import { NVIDIA_THEME } from '@/lib/theme'
 import { EnginePanelBody } from './EnginePanelBody'
 import { engineIdentity } from './engineLabel'
-import { EnginePanelNotice } from './PanelNotice'
+import { PanelList } from './PanelList'
+import { EnginePanelNotice, PanelNotice } from './PanelNotice'
 import { useEngineRequests } from './useEnginePanel'
 import type { InferenceRequestData } from '@/types/metrics'
 import type { PanelContentProps } from '../panelRegistry'
@@ -28,6 +29,13 @@ import type { PanelContentProps } from '../panelRegistry'
  *
  * The bars are positioned against the panel's window, so the axis is the same
  * one the charts beside it use and two panels can be read together.
+ *
+ * **No shipped backend fills `recent_requests` yet.** `EngineSnapshot` carries
+ * the field and the wire format is settled, but both construction sites in
+ * `src/engines/mod.rs` pass an empty vector — per-request metrics wait on the
+ * engine adapters. Until one lands, this panel is correct and empty on a real
+ * host, which is why the no-requests state is worded as a quiet window rather
+ * than as a fault.
  */
 export function InferenceTimelinePanel({ panel }: PanelContentProps) {
   const { target, requests } = useEngineRequests(panel)
@@ -53,16 +61,9 @@ export function InferenceTimelinePanel({ panel }: PanelContentProps) {
       }
       chart={
         count === 0 ? (
-          <div className="h-full flex items-center justify-center text-center">
-            <p className="text-xs text-zinc-500">
-              No requests finished in the last {panel.window}.
-            </p>
-          </div>
+          <PanelNotice>No requests finished in the last {panel.window}.</PanelNotice>
         ) : (
-          <ul
-            aria-label="Inference requests"
-            className="h-full min-h-0 min-w-0 overflow-y-auto flex flex-col gap-0.5 pr-0.5"
-          >
+          <PanelList label="Inference requests">
             {newestFirst(requests).map((request, i) => (
               <RequestRow
                 key={`${request.start_ms}-${request.end_ms}-${i}`}
@@ -70,7 +71,7 @@ export function InferenceTimelinePanel({ panel }: PanelContentProps) {
                 axis={axis}
               />
             ))}
-          </ul>
+          </PanelList>
         )
       }
     />

--- a/frontend/src/components/grid/panels/InferenceTimelinePanel.tsx
+++ b/frontend/src/components/grid/panels/InferenceTimelinePanel.tsx
@@ -1,0 +1,110 @@
+import { MetricTile } from '@/components/engines/EnginePanelPrimitives'
+import { useLatestSnapshot } from '@/hooks/useMetricsStore'
+import { formatAge, formatTps, formatTtft } from '@/lib/format'
+import {
+  newestFirst,
+  requestSummary,
+  timelineAxis,
+  timelineSpan,
+  type TimelineAxis,
+} from '@/lib/inferenceTimeline'
+import { NVIDIA_THEME } from '@/lib/theme'
+import { EnginePanelBody } from './EnginePanelBody'
+import { engineIdentity } from './engineLabel'
+import { EnginePanelNotice } from './PanelNotice'
+import { useEngineRequests } from './useEnginePanel'
+import type { InferenceRequestData } from '@/types/metrics'
+import type { PanelContentProps } from '../panelRegistry'
+
+/**
+ * The individual requests one engine finished inside the panel's window, each
+ * drawn where it happened.
+ *
+ * Every other engine panel shows an aggregate — tokens per second averaged over
+ * a poll, a latency percentile over a histogram. This one is the only place the
+ * requests themselves are visible, which is what answers the questions an
+ * aggregate cannot: whether the engine is serving one request at a time or
+ * twelve at once, and whether the slow p99 is one cold start or a steady tail.
+ *
+ * The bars are positioned against the panel's window, so the axis is the same
+ * one the charts beside it use and two panels can be read together.
+ */
+export function InferenceTimelinePanel({ panel }: PanelContentProps) {
+  const { target, requests } = useEngineRequests(panel)
+  const snapshot = useLatestSnapshot()
+  if (target.status !== 'resolved') return <EnginePanelNotice resolution={target} />
+
+  // The newest sample anchors the axis, not wall clock: the bars then hold
+  // still between snapshots rather than creeping leftward every frame.
+  const axis = timelineAxis(snapshot?.timestamp_ms ?? 0, panel.window)
+  const { count, medianTps, medianTtftMs } = requestSummary(requests)
+
+  return (
+    <EnginePanelBody
+      identity={engineIdentity(target)}
+      tiles={
+        <div className="grid grid-cols-3 gap-1.5">
+          <MetricTile label="Requests" value={String(count)} />
+          {/* Medians, because one cold start drags a mean far enough to
+              misreport the engine — and the bars below already show it. */}
+          <MetricTile label="Med tok/s" value={formatTps(medianTps)} />
+          <MetricTile label="Med TTFT" value={formatTtft(medianTtftMs)} unit="ms" />
+        </div>
+      }
+      chart={
+        count === 0 ? (
+          <div className="h-full flex items-center justify-center text-center">
+            <p className="text-xs text-zinc-500">
+              No requests finished in the last {panel.window}.
+            </p>
+          </div>
+        ) : (
+          <ul
+            aria-label="Inference requests"
+            className="h-full min-h-0 min-w-0 overflow-y-auto flex flex-col gap-0.5 pr-0.5"
+          >
+            {newestFirst(requests).map((request, i) => (
+              <RequestRow
+                key={`${request.start_ms}-${request.end_ms}-${i}`}
+                request={request}
+                axis={axis}
+              />
+            ))}
+          </ul>
+        )
+      }
+    />
+  )
+}
+
+function RequestRow({
+  request,
+  axis,
+}: {
+  request: InferenceRequestData
+  axis: TimelineAxis
+}) {
+  const { leftPercent, widthPercent } = timelineSpan(request, axis)
+  const seconds = Math.max(0, request.end_ms - request.start_ms) / 1000
+
+  return (
+    <li
+      className="flex items-center gap-1.5 min-w-0 shrink-0"
+      title={`${seconds.toFixed(1)}s · ${formatTps(request.tokens_per_sec)} tok/s · TTFT ${formatTtft(request.ttft_ms)}ms · ${formatAge(request.end_ms, axis.to)} ago`}
+    >
+      <span className="relative flex-1 min-w-0 h-2 rounded-sm bg-white/[0.04]">
+        <span
+          className="absolute inset-y-0 rounded-sm"
+          style={{
+            left: `${leftPercent}%`,
+            width: `${widthPercent}%`,
+            backgroundColor: NVIDIA_THEME.accent,
+          }}
+        />
+      </span>
+      <span className="shrink-0 w-12 text-right font-mono tabular-nums text-[10px] text-zinc-400">
+        {formatTps(request.tokens_per_sec)}
+      </span>
+    </li>
+  )
+}

--- a/frontend/src/components/grid/panels/PanelList.tsx
+++ b/frontend/src/components/grid/panels/PanelList.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+/**
+ * The body of a panel whose content is a list of rows rather than a chart — the
+ * GPU events, the inference requests.
+ *
+ * These panels size themselves by scrolling rather than by dropping content the
+ * way the gauge panels do. There is no reduced rendering of an event that is
+ * still an event, and the newest are at the top, so even a 1×1 cell shows the
+ * one that matters.
+ *
+ * The list is named, because a panel's rows are a second landmark inside a
+ * frame that already has one — the frame's title says which GPU, this says what
+ * the rows are.
+ */
+export function PanelList({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <ul
+      aria-label={label}
+      className="h-full min-h-0 min-w-0 overflow-y-auto flex flex-col gap-0.5 pr-0.5"
+    >
+      {children}
+    </ul>
+  )
+}

--- a/frontend/src/components/grid/panels/mode.test.ts
+++ b/frontend/src/components/grid/panels/mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { enginePanelMode, gaugeSizePx, hardwarePanelMode } from './mode'
+import { coreGridLayout, enginePanelMode, gaugeSizePx, hardwarePanelMode } from './mode'
 
 describe('hardwarePanelMode', () => {
   it('renders the richest layout while the box is unmeasured', () => {
@@ -45,6 +45,42 @@ describe('enginePanelMode', () => {
     // Engine panels have no gauge column competing for the width, so narrow is
     // not a reason to drop anything.
     expect(enginePanelMode({ width: 120, height: 300 })).toBe('full')
+  })
+})
+
+describe('coreGridLayout', () => {
+  it('renders the richest layout while the box is unmeasured', () => {
+    // jsdom reports 0×0, and so does the first frame before ResizeObserver
+    // fires — the same fallback the panel modes take.
+    expect(coreGridLayout({ width: 0, height: 0 }, 8)).toEqual({ columns: 4, labelled: true })
+  })
+
+  it('tiles a wide box in more columns than a square one', () => {
+    // Square cells are the goal: a row of slivers says nothing about which
+    // cores are busy.
+    expect(coreGridLayout({ width: 400, height: 100 }, 8).columns).toBe(6)
+    expect(coreGridLayout({ width: 200, height: 200 }, 8).columns).toBe(3)
+  })
+
+  it('never asks for more columns than there are cores', () => {
+    expect(coreGridLayout({ width: 400, height: 100 }, 2).columns).toBe(2)
+  })
+
+  it('labels the cells once they are big enough to read', () => {
+    // A 6×3 panel on a desktop viewport, on a 16-core host.
+    expect(coreGridLayout({ width: 480, height: 200 }, 16).labelled).toBe(true)
+  })
+
+  it('drops the labels when the cells come out as texture', () => {
+    // 96 cores in a 1×1 cell: a block of colour is all that fits, and it is
+    // still worth showing — the load is legible as a pattern.
+    const layout = coreGridLayout({ width: 100, height: 55 }, 96)
+    expect(layout.labelled).toBe(false)
+    expect(layout.columns).toBeGreaterThan(1)
+  })
+
+  it('survives a host that reports no cores at all', () => {
+    expect(coreGridLayout({ width: 400, height: 100 }, 0)).toEqual({ columns: 1, labelled: true })
   })
 })
 

--- a/frontend/src/components/grid/panels/mode.ts
+++ b/frontend/src/components/grid/panels/mode.ts
@@ -57,6 +57,51 @@ export function enginePanelMode({ height }: ElementSize): EnginePanelMode {
   return height > 0 && height < TILES_ONLY_BELOW_PX ? 'tiles' : 'full'
 }
 
+/** How the CPU-cores panel tiles its box. */
+export interface CoreGridLayout {
+  /** Cells per row. */
+  columns: number
+  /** Whether a cell has room for the core's own number and load, or is only
+   *  big enough to be a block of colour in the texture. */
+  labelled: boolean
+}
+
+/** The aspect ratio assumed for a box nothing has measured yet — wider than
+ *  tall, which is what a grid cell is at every preset size. */
+const UNMEASURED_ASPECT = 2
+
+/** A cell narrower than this cannot hold "63" and "100%" beside each other. */
+const LABEL_MIN_WIDTH_PX = 44
+/** A cell shorter than this cannot hold the two lines a label needs. */
+const LABEL_MIN_HEIGHT_PX = 26
+
+/**
+ * How to lay `cores` core cells out in a measured box: the column count that
+ * gets the cells closest to square, and whether they came out big enough to
+ * label.
+ *
+ * Square cells are the goal because the grid is read as a texture — a row of
+ * slivers says nothing about which cores are busy. A 96-core host in a 1×1
+ * cell therefore gets an unlabelled block of colour, and the same host across a
+ * 6×4 panel gets a labelled one, from the same component.
+ *
+ * Unmeasured boxes get the richest layout, the same fallback rule as
+ * `hardwarePanelMode`.
+ */
+export function coreGridLayout({ width, height }: ElementSize, cores: number): CoreGridLayout {
+  if (cores <= 0) return { columns: 1, labelled: true }
+
+  const measured = width > 0 && height > 0
+  const aspect = measured ? width / height : UNMEASURED_ASPECT
+  const columns = Math.min(cores, Math.max(1, Math.round(Math.sqrt(cores * aspect))))
+  if (!measured) return { columns, labelled: true }
+
+  const rows = Math.ceil(cores / columns)
+  const labelled =
+    width / columns >= LABEL_MIN_WIDTH_PX && height / rows >= LABEL_MIN_HEIGHT_PX
+  return { columns, labelled }
+}
+
 /**
  * The gauge column's square size for a measured content height: fill the row
  * up to the size the pre-grid dashboard capped its gauges at. Unmeasured

--- a/frontend/src/components/grid/panels/useEnginePanel.ts
+++ b/frontend/src/components/grid/panels/useEnginePanel.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useLatestSnapshot, useMetricsStore } from '@/hooks/useMetricsStore'
+import { useInferenceRequests, useLatestSnapshot, useMetricsStore } from '@/hooks/useMetricsStore'
 import { usePageSelection } from '@/hooks/usePageSelection'
 import { resolveEngineBinding } from '@/lib/dashboard/bindings'
 import { pageSelection } from '@/lib/dashboard/selection'
@@ -7,7 +7,7 @@ import { engineAvailability, engineMetricReader, type EngineMetricReader } from 
 import { engineKey } from '@/lib/identity'
 import { engineSeries, type DataPoint, type EngineSeriesName } from '@/lib/metricsHistoryStore'
 import type { DashboardPanel } from '@/lib/dashboard/schema'
-import type { EngineSnapshot } from '@/types/metrics'
+import type { EngineSnapshot, InferenceRequestData } from '@/types/metrics'
 
 /** Which engine a panel's binding names on this host, before anything is asked
  *  about whether that engine is serving. */
@@ -71,6 +71,28 @@ export function useEngineTarget(panel: DashboardPanel): EngineTargetResolution {
 
     return { status: 'resolved', engine: resolution.target, multiEngine: engines.length > 1 }
   }, [snapshot, chosen, panel.binding])
+}
+
+/**
+ * An inference-timeline panel's whole subscription in one call: the engine its
+ * binding names, and that engine's finished requests over the panel's own
+ * window. Every hook lives in here, above the caller's unresolved early return
+ * — the same shape as `useGpuPanelSeries`; while unresolved, the all-engines
+ * key keeps the subscription alive until a binding names one.
+ *
+ * Deliberately the raw target rather than `useEnginePanel`: requests are the
+ * engine's own record of what it served, and they stay worth reading when it
+ * has stopped serving — an engine that fell over an hour into a run is exactly
+ * when an operator wants to see what it was doing beforehand.
+ */
+export function useEngineRequests(panel: DashboardPanel): {
+  target: EngineTargetResolution
+  requests: InferenceRequestData[]
+} {
+  const target = useEngineTarget(panel)
+  const key = target.status === 'resolved' ? engineKey(target.engine) : undefined
+  const requests = useInferenceRequests(key, panel.window)
+  return { target, requests }
 }
 
 /**

--- a/frontend/src/components/grid/panels/useGpuPanel.ts
+++ b/frontend/src/components/grid/panels/useGpuPanel.ts
@@ -30,8 +30,12 @@ export type GpuPanelResolution =
  * A following panel resolves to the page-level GPU selection, which is the
  * primary GPU until the operator points the page somewhere else — so a page of
  * following panels moves to another GPU coherently, all at once.
+ *
+ * Exported for the panels that bind to a GPU without charting one of its
+ * series — the event list. Panels that do chart one take
+ * `useGpuPanelSeries`, which resolves and subscribes together.
  */
-function useGpuPanel(panel: DashboardPanel): GpuPanelResolution {
+export function useGpuPanel(panel: DashboardPanel): GpuPanelResolution {
   const snapshot = useLatestSnapshot()
   const { chosen } = usePageSelection()
 

--- a/frontend/src/hooks/useMetricsStore.ts
+++ b/frontend/src/hooks/useMetricsStore.ts
@@ -1,9 +1,14 @@
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from 'react'
-import { MetricsHistoryStore, type DataPoint } from '@/lib/metricsHistoryStore'
+import {
+  EVENTS_SERIES,
+  MetricsHistoryStore,
+  requestsSeries,
+  type DataPoint,
+} from '@/lib/metricsHistoryStore'
 import { useHeldWhileFrozen, useLiveMotion } from './useLiveMotion'
 import { DEFAULT_TIME_WINDOW } from '@/lib/dashboard/schema'
 import type { TimeWindow } from '@/types/events'
-import type { MetricsSnapshot } from '@/types/metrics'
+import type { GpuEventData, InferenceRequestData, MetricsSnapshot } from '@/types/metrics'
 
 /**
  * The metrics history store, provided through context rather than a module
@@ -39,18 +44,64 @@ export function useMetricSeries(
   window: TimeWindow = DEFAULT_TIME_WINDOW,
 ): DataPoint[] {
   const store = useMetricsStore()
+  const version = useSeriesVersion(series)
+  const data = useMemo(() => {
+    void version // the series changed; re-read the window
+    return store.getChartData(series, window)
+  }, [store, series, window, version])
+  return useHeldWhileFrozen(data)
+}
+
+/**
+ * The GPU events in the given window, re-rendering only when an event lands.
+ *
+ * Events are a discrete list rather than a series, so they cannot come through
+ * `useMetricSeries` — but they are subscribed and frozen on exactly the same
+ * terms, because a panel showing them is a panel like any other.
+ */
+export function useGpuEvents(window: TimeWindow = DEFAULT_TIME_WINDOW): GpuEventData[] {
+  const store = useMetricsStore()
+  const version = useSeriesVersion(EVENTS_SERIES)
+  const events = useMemo(() => {
+    void version // an event landed; re-read the window
+    return store.getEvents(window)
+  }, [store, window, version])
+  return useHeldWhileFrozen(events)
+}
+
+/**
+ * One engine's finished requests in the given window, on the same terms as
+ * `useGpuEvents`. `key` is an engine key as produced by `engineKey()`; omit it
+ * for every engine's requests.
+ */
+export function useInferenceRequests(
+  key?: string,
+  window: TimeWindow = DEFAULT_TIME_WINDOW,
+): InferenceRequestData[] {
+  const store = useMetricsStore()
+  const series = requestsSeries(key)
+  const version = useSeriesVersion(series)
+  const requests = useMemo(() => {
+    void version // a request landed; re-read the window
+    return store.getRequests(key, window)
+  }, [store, key, window, version])
+  return useHeldWhileFrozen(requests)
+}
+
+/**
+ * The version counter of one series, subscribed for as long as the dashboard
+ * is moving. The half of `useMetricSeries` that the event and request lists
+ * share with it — they differ only in what they read once it changes.
+ */
+function useSeriesVersion(series: string): number {
+  const store = useMetricsStore()
   const live = useLiveMotion()
   const subscribe = useCallback(
     (listener: () => void) => (live ? store.subscribe(series, listener) : noop),
     [store, series, live],
   )
   const getVersion = useCallback(() => store.seriesVersion(series), [store, series])
-  const version = useSyncExternalStore(subscribe, getVersion)
-  const data = useMemo(() => {
-    void version // the series changed; re-read the window
-    return store.getChartData(series, window)
-  }, [store, series, window, version])
-  return useHeldWhileFrozen(data)
+  return useSyncExternalStore(subscribe, getVersion)
 }
 
 /**

--- a/frontend/src/lib/dashboard/panels.ts
+++ b/frontend/src/lib/dashboard/panels.ts
@@ -62,6 +62,9 @@ export const PANEL_TYPES = {
   'gpu-clock': { binds: 'gpu', title: 'GPU Clock' },
   'gpu-memory': { binds: 'gpu', title: 'GPU Memory' },
   'gpu-fan': { binds: 'gpu', title: 'GPU Fan' },
+  // A discrete list rather than a series — but still windowed, unlike `logs`
+  // below: the history store keeps a bounded ring of events and filters it by
+  // the window, so choosing 15m over 5m genuinely shows the operator more.
   'gpu-events': { binds: 'gpu', title: 'GPU Events' },
 
   // ── Host-wide hardware ──────────────────────────────────────────────────
@@ -85,6 +88,9 @@ export const PANEL_TYPES = {
   'engine-requests': { binds: 'engine', title: 'Requests' },
   'engine-cache': { binds: 'engine', title: 'Cache' },
   'engine-spec-decode': { binds: 'engine', title: 'Speculative Decoding' },
+  // Windowed for the same reason as `gpu-events`, and it needs the window
+  // twice over: the requests are filtered by it, and the timeline draws each
+  // one against it as the axis it is positioned on.
   'inference-timeline': { binds: 'engine', title: 'Inference Requests' },
   // The log socket addresses an engine by endpoint, so logs bind like any
   // other engine panel instead of being a fixed drawer. A line of container

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -56,6 +56,23 @@ export function formatMhz(mhz: number | null): string {
   return `${Math.round(mhz)} MHz`
 }
 
+/**
+ * How long before `now` something happened, as the coarsest unit that still
+ * says it: `12s`, `3m`, `2h`.
+ *
+ * An age rather than a wall-clock time, because that is the question an
+ * operator is asking of a live dashboard — and because a clock time would have
+ * to be read against the viewer's own timezone, which the rest of the metrics
+ * on the page are free of. Anything not yet in the past reads as `0s`.
+ */
+export function formatAge(timestampMs: number, nowMs: number): string {
+  const seconds = Math.max(0, Math.floor((nowMs - timestampMs) / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.floor(minutes / 60)}h`
+}
+
 /** Get temperature color class: green <70, yellow 70-85, red >85 */
 export function tempColor(celsius: number | null): string {
   if (celsius === null) return 'text-zinc-500'

--- a/frontend/src/lib/inferenceTimeline.test.ts
+++ b/frontend/src/lib/inferenceTimeline.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  newestFirst,
+  requestSummary,
+  timelineAxis,
+  timelineSpan,
+  type TimelineAxis,
+} from './inferenceTimeline'
+import type { InferenceRequestData } from '@/types/metrics'
+
+function request(overrides: Partial<InferenceRequestData> = {}): InferenceRequestData {
+  return { start_ms: 0, end_ms: 1000, tokens_per_sec: 100, ttft_ms: 200, ...overrides }
+}
+
+/** A one-second axis, so a percentage reads as a millisecond count over ten. */
+const AXIS: TimelineAxis = { from: 0, to: 1000 }
+
+describe('timelineAxis', () => {
+  it('ends at the newest sample rather than at wall clock', () => {
+    // Anchoring on the data is what holds the bars still between snapshots,
+    // and what makes the rendering reproducible in a spec.
+    expect(timelineAxis(1_000_000, '5m')).toEqual({ from: 700_000, to: 1_000_000 })
+    expect(timelineAxis(1_000_000, '15m')).toEqual({ from: 100_000, to: 1_000_000 })
+  })
+})
+
+describe('timelineSpan', () => {
+  it('positions a request by when it happened', () => {
+    expect(timelineSpan(request({ start_ms: 500, end_ms: 750 }), AXIS)).toEqual({
+      leftPercent: 50,
+      widthPercent: 25,
+    })
+  })
+
+  it('clips a request that started before the window opened', () => {
+    // The part inside the window is true; dropping it would hide a
+    // long-running request entirely.
+    expect(timelineSpan(request({ start_ms: -5000, end_ms: 250 }), AXIS)).toEqual({
+      leftPercent: 0,
+      widthPercent: 25,
+    })
+  })
+
+  it('keeps a request that finished in milliseconds visible', () => {
+    // A bar of width zero would silently drop the request off the axis.
+    const span = timelineSpan(request({ start_ms: 100, end_ms: 100 }), AXIS)
+    expect(span.leftPercent).toBe(10)
+    expect(span.widthPercent).toBeGreaterThan(0)
+  })
+
+  it('keeps a request at the right edge on the axis', () => {
+    const span = timelineSpan(request({ start_ms: 1000, end_ms: 1000 }), AXIS)
+    expect(span.leftPercent + span.widthPercent).toBeLessThanOrEqual(100)
+    expect(span.widthPercent).toBeGreaterThan(0)
+  })
+
+  it('does not divide by a zero-width axis', () => {
+    // Before any snapshot has landed there is no window to position against.
+    const span = timelineSpan(request(), { from: 0, to: 0 })
+    expect(Number.isFinite(span.leftPercent)).toBe(true)
+    expect(Number.isFinite(span.widthPercent)).toBe(true)
+  })
+})
+
+describe('requestSummary', () => {
+  it('reports nothing rather than zero when no request finished', () => {
+    expect(requestSummary([])).toEqual({ count: 0, medianTps: null, medianTtftMs: null })
+  })
+
+  it('takes the median, so one cold start does not misreport the engine', () => {
+    const summary = requestSummary([
+      request({ tokens_per_sec: 100, ttft_ms: 200 }),
+      request({ tokens_per_sec: 110, ttft_ms: 210 }),
+      // The outlier: a mean would put throughput at 70 and TTFT near a second.
+      request({ tokens_per_sec: 1, ttft_ms: 2400 }),
+    ])
+    expect(summary).toEqual({ count: 3, medianTps: 100, medianTtftMs: 210 })
+  })
+
+  it('averages the middle pair on an even count', () => {
+    const summary = requestSummary([
+      request({ tokens_per_sec: 100, ttft_ms: 200 }),
+      request({ tokens_per_sec: 120, ttft_ms: 300 }),
+    ])
+    expect(summary.medianTps).toBe(110)
+    expect(summary.medianTtftMs).toBe(250)
+  })
+})
+
+describe('newestFirst', () => {
+  it('orders the requests the way they are read', () => {
+    const ordered = newestFirst([
+      request({ end_ms: 100 }),
+      request({ end_ms: 900 }),
+      request({ end_ms: 500 }),
+    ])
+    expect(ordered.map((r) => r.end_ms)).toEqual([900, 500, 100])
+  })
+
+  it('leaves the list it was given alone', () => {
+    const given = [request({ end_ms: 100 }), request({ end_ms: 900 })]
+    newestFirst(given)
+    expect(given.map((r) => r.end_ms)).toEqual([100, 900])
+  })
+})

--- a/frontend/src/lib/inferenceTimeline.ts
+++ b/frontend/src/lib/inferenceTimeline.ts
@@ -1,0 +1,97 @@
+import { TIME_WINDOW_SECONDS, type TimeWindow } from '@/types/events'
+import type { InferenceRequestData } from '@/types/metrics'
+
+/**
+ * The geometry and the summary behind the inference-request timeline, kept
+ * out of the component so both are testable without a layout engine — the same
+ * rule the panel modes in `components/grid/panels/mode.ts` follow.
+ */
+
+/** Where one request sits on the timeline's axis, as percentages of its width. */
+export interface TimelineSpan {
+  /** Distance from the left edge, 0–100. */
+  leftPercent: number
+  /** Width, 0–100, and never so small the bar disappears. */
+  widthPercent: number
+}
+
+/**
+ * A bar narrower than this is invisible, so a request that finished in
+ * milliseconds would silently drop off a 15-minute axis. It is drawn at the
+ * floor instead: the timeline's job is to say *when* requests happened and how
+ * they overlap, and a request that is there has to be visible to say it.
+ */
+const MIN_WIDTH_PERCENT = 0.8
+
+/** The window a timeline covers: the axis every span is positioned against. */
+export interface TimelineAxis {
+  /** Timestamp (ms) of the left edge. */
+  from: number
+  /** Timestamp (ms) of the right edge — the latest sample, not wall clock. */
+  to: number
+}
+
+/**
+ * The axis a panel's window describes, ending at the newest sample rather than
+ * at `Date.now()`. Anchoring on the data is what keeps the bars still between
+ * snapshots, and what makes the rendering reproducible in a spec.
+ */
+export function timelineAxis(latestMs: number, window: TimeWindow): TimelineAxis {
+  return { from: latestMs - TIME_WINDOW_SECONDS[window] * 1000, to: latestMs }
+}
+
+/**
+ * One request's bar on the axis. A request that started before the window
+ * opened is clipped to it rather than dropped — the part inside the window is
+ * true, and dropping it would hide a long-running request entirely.
+ */
+export function timelineSpan(request: InferenceRequestData, axis: TimelineAxis): TimelineSpan {
+  const span = Math.max(1, axis.to - axis.from)
+  const start = clampPercent(((request.start_ms - axis.from) / span) * 100)
+  const end = clampPercent(((request.end_ms - axis.from) / span) * 100)
+  return {
+    leftPercent: Math.min(start, 100 - MIN_WIDTH_PERCENT),
+    widthPercent: Math.max(MIN_WIDTH_PERCENT, end - start),
+  }
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(100, Math.max(0, value))
+}
+
+/** What the timeline's tiles say about the requests in the window. */
+export interface RequestSummary {
+  /** How many requests finished inside the window. */
+  count: number
+  /** Median generation throughput, null when there were no requests. */
+  medianTps: number | null
+  /** Median time to first token in ms, null when there were no requests. */
+  medianTtftMs: number | null
+}
+
+/**
+ * The window's requests summarized. Medians rather than means: a single slow
+ * cold-start request drags a mean far enough to misreport what the engine is
+ * doing, and the timeline beside the tiles already shows the outlier.
+ */
+export function requestSummary(requests: readonly InferenceRequestData[]): RequestSummary {
+  return {
+    count: requests.length,
+    medianTps: median(requests.map((r) => r.tokens_per_sec)),
+    medianTtftMs: median(requests.map((r) => r.ttft_ms)),
+  }
+}
+
+/** The median of the finite values, or null when there are none. */
+function median(values: readonly number[]): number | null {
+  const sorted = values.filter((v) => Number.isFinite(v)).sort((a, b) => a - b)
+  if (sorted.length === 0) return null
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+/** The window's requests newest-first, which is the order they are read in. */
+export function newestFirst(requests: readonly InferenceRequestData[]): InferenceRequestData[] {
+  return [...requests].sort((a, b) => b.end_ms - a.end_ms)
+}

--- a/frontend/src/lib/metricsHistoryStore.ts
+++ b/frontend/src/lib/metricsHistoryStore.ts
@@ -18,6 +18,8 @@ type MetricKey =
   | 'gpuTemp'
   | 'gpuPower'
   | 'gpuClockGraphics'
+  | 'gpuMemory'
+  | 'gpuFan'
   | 'cpuAggregate'
   | 'memoryUsedPercent'
   | 'diskRead'
@@ -30,6 +32,8 @@ const SYSTEM_METRIC_KEYS: MetricKey[] = [
   'gpuTemp',
   'gpuPower',
   'gpuClockGraphics',
+  'gpuMemory',
+  'gpuFan',
   'cpuAggregate',
   'memoryUsedPercent',
   'diskRead',
@@ -38,10 +42,23 @@ const SYSTEM_METRIC_KEYS: MetricKey[] = [
   'networkTx',
 ]
 
-const GPU_METRIC_KEYS: MetricKey[] = ['gpuUtil', 'gpuTemp', 'gpuPower', 'gpuClockGraphics']
+const GPU_METRIC_KEYS: MetricKey[] = [
+  'gpuUtil',
+  'gpuTemp',
+  'gpuPower',
+  'gpuClockGraphics',
+  'gpuMemory',
+  'gpuFan',
+]
 
 /** The per-GPU series. Narrower than `MetricKey`: only these exist per GPU. */
-export type GpuSeriesMetric = 'gpuUtil' | 'gpuTemp' | 'gpuPower' | 'gpuClockGraphics'
+export type GpuSeriesMetric =
+  | 'gpuUtil'
+  | 'gpuTemp'
+  | 'gpuPower'
+  | 'gpuClockGraphics'
+  | 'gpuMemory'
+  | 'gpuFan'
 
 /**
  * The series key for one GPU's metric. Multi-GPU hosts read the
@@ -139,9 +156,27 @@ function extractGpuValue(gpu: MetricsSnapshot['gpu'], key: MetricKey): number | 
       return gpu.power_watts
     case 'gpuClockGraphics':
       return gpu.clock_graphics_mhz
+    // Charted as a percentage of the device's own pool rather than as bytes:
+    // it is the reading the gauge shows, and it keeps the series comparable
+    // between GPUs of different sizes on one host.
+    case 'gpuMemory':
+      return gpuMemoryPercent(gpu)
+    case 'gpuFan':
+      return gpu.fan_speed_percent
     default:
       return null
   }
+}
+
+/**
+ * A GPU's used share of its own memory, 0–100. Null when the device reports
+ * no pool — NVML answers `NotSupported` for the unified-memory SoCs, where the
+ * host memory panel is the one that has the numbers.
+ */
+export function gpuMemoryPercent(gpu: MetricsSnapshot['gpu']): number | null {
+  const { memory_used_bytes: used, memory_total_bytes: total } = gpu
+  if (used === null || used === undefined || !total) return null
+  return (used / total) * 100
 }
 
 function extractValue(metrics: MetricsSnapshot, key: MetricKey): number | null {
@@ -150,6 +185,8 @@ function extractValue(metrics: MetricsSnapshot, key: MetricKey): number | null {
     case 'gpuTemp':
     case 'gpuPower':
     case 'gpuClockGraphics':
+    case 'gpuMemory':
+    case 'gpuFan':
       return extractGpuValue(metrics.gpu, key)
     case 'cpuAggregate':
       return metrics.cpu.aggregate_percent
@@ -335,7 +372,9 @@ export class MetricsHistoryStore {
     const systemBuffer = this.buffers[metric as MetricKey]
     if (systemBuffer) return systemBuffer
 
-    const gpuMatch = metric.match(/^gpu:(\d+):(gpuUtil|gpuTemp|gpuPower|gpuClockGraphics)$/)
+    const gpuMatch = metric.match(
+      /^gpu:(\d+):(gpuUtil|gpuTemp|gpuPower|gpuClockGraphics|gpuMemory|gpuFan)$/,
+    )
     if (gpuMatch) {
       return this.gpuBuffers[gpuMatch[1]]?.[gpuMatch[2] as MetricKey]
     }

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -32,3 +32,19 @@ export function thresholdColor(
   if (value >= warning) return NVIDIA_THEME.warning
   return NVIDIA_THEME.healthy
 }
+
+/**
+ * The fill of one CPU core cell at a given load.
+ *
+ * More bands than `thresholdColor` gives, and dimmer at the bottom of the
+ * scale: a core grid is read as a texture — which of them are hot, and whether
+ * the load is spread or piled on a few — so an idle core has to recede rather
+ * than sit at full green beside a saturated one.
+ */
+export function coreUsageColor(usagePercent: number): string {
+  if (usagePercent >= 90) return NVIDIA_THEME.critical
+  if (usagePercent >= 70) return '#eab308'
+  if (usagePercent >= 40) return NVIDIA_THEME.accent
+  if (usagePercent >= 10) return '#365314'
+  return '#27272a'
+}

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -43,8 +43,24 @@ export function thresholdColor(
  */
 export function coreUsageColor(usagePercent: number): string {
   if (usagePercent >= 90) return NVIDIA_THEME.critical
-  if (usagePercent >= 70) return '#eab308'
+  if (usagePercent >= 70) return NVIDIA_THEME.warning
   if (usagePercent >= 40) return NVIDIA_THEME.accent
+  // Below the accent, two shades the theme has no name for: a dim green for a
+  // core doing something, and the card's own surface for one doing nothing.
   if (usagePercent >= 10) return '#365314'
   return '#27272a'
+}
+
+/**
+ * How serious a GPU event is, by the driver's name for it.
+ *
+ * Thermal slowdowns and Xid errors are the two an operator has to act on — a
+ * cooling problem or a hardware fault. A power cap is the machine working as
+ * it was configured to, so it warns rather than alarms; colouring the two the
+ * same would spend the alarm on the ordinary case.
+ */
+export function gpuEventColor(eventType: string): string {
+  return eventType === 'thermal' || eventType === 'xid'
+    ? NVIDIA_THEME.critical
+    : NVIDIA_THEME.warning
 }


### PR DESCRIPTION
Closes #110.

The vocabulary named 23 panel types and the registry implemented 18. The palette lists the whole vocabulary on purpose, so an operator in edit mode could add "GPU Memory" and get a box saying *"This panel is not available yet."* — user story 13 of #70 half-kept.

| Type | Rendering |
|---|---|
| `gpu-memory` | Used share of the **device's** NVML pool, the gauge legend carrying `24.0 GB / 48.0 GB` — a percentage alone does not say whether the next model fits. Distinct from the host `memory` panel, which stays host-wide because a unified machine has one pool. |
| `gpu-fan` | Speed as a share of maximum, deliberately **without** thresholds: a fan at 100% is the cooling working, not a fault. |
| `gpu-events` | Severity chip, detail, and age, newest first. A list, because an event has no value to plot. |
| `cpu-cores` | Every core tiling the box, labelling itself once the cells are big enough to read. |
| `inference-timeline` | Each request drawn where it happened, over median summary tiles. |

## Decisions worth reviewing

**`windowed` stays `true` on both list panels**, against the ticket's suspicion that they should follow `logs`. `MetricsHistoryStore` filters the event ring and the request ring by the window, so choosing 15m over 5m genuinely shows more — and the timeline needs the window twice over, as the axis its bars are positioned on. `logs` remains the only `false`. Recorded as comments on both declarations.

**Two new per-GPU history series**, `gpuMemory` (charted as a percentage, so it is comparable between GPUs of different sizes) and `gpuFan`. Both flow through the existing `gpuSeries` key vocabulary, so a pinned panel on a multi-GPU host reads its own GPU's history. Frontend-only: every field was already on the wire.

**`PanelPlaceholder` is kept** — still the correct rendering for a type a *newer* config names. Its known-but-unimplemented branch is now unreachable, and `panelRegistry.test` holds it that way: a new type in `panels.ts` fails that spec until something renders it. The `App.gridPage` spec that used `inference-timeline` as its stand-in unimplemented type is removed, since no such type exists any more.

**One deviation from the ticket's letter.** It asked that `inference-timeline` resolve "the same way" as its siblings. It uses `EnginePanelNotice` as specified, but reads the raw engine target rather than `useEnginePanel` — request history is the engine's own record and stays worth reading when it has stopped serving, the same reason the log panel does it. Commented at the hook.

## A wrong fact in the ticket

#110 lists `EngineSnapshot.recent_requests` as *"data already on the wire"*. **It is not** — `src/engines/mod.rs:638` and `src/logs.rs:363` both pass `Vec::new()`, pending the engine adapters. The timeline panel is complete and correct, and will render "No requests finished in the last 5m." on a real host until a backend fills the field; that is why its empty state is worded as a quiet window rather than a fault. Noted on the component. The backend half is outside this ticket's frontend-only scope and wants an issue of its own — worth folding in when it happens: `ingest` pushes `recent_requests` with no dedupe, so a rolling "last N" per poll would multiply rows.

## Metrics contract

**N/A.** Every field was already on the wire and already in `types/metrics.ts`; no Rust shape, serde name, display rule or field changed.

## Checks

`npm run lint`, `npm run build`, `npm test -- --run` (667) and the browser project (24) all clean. No Rust changed. Browser specs were explicitly not expected here, but the `coreUsageColor` move touches what the existing ones render, so they were run.

Verified by hand against `--simulate-gpus 3` on a GPU-less host: live VRAM, fan and thermal events on the simulated GPUs, the "does not report" notices on the null stub GPU, and a pin to an absent GPU index keeping its slot.

**Rebase-merge, not squash** — both commits are Conventional and should land individually.
