### PR TITLE
feat(frontend): let each page choose its model — one, or all combined

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,10 +82,27 @@ on a one-GPU laptop and on a four-GPU server.
 _Avoid_: auto, inherit, default binding
 
 **Page selection**:
-The GPU and engine a page's `follow` panels resolve against. What the operator
-chose is stored sparsely, so an absent key means "never chose" rather than "chose
-nothing".
+The GPU and engine target a page's `follow` panels resolve against. Three layers,
+strongest first: what the operator chose this session (stored sparsely, so an
+absent key means "never chose" rather than "chose nothing"), the page's **page
+source**, then the host's defaults.
 _Avoid_: current GPU, active engine, global filter
+
+**Page source**:
+The persisted per-page default for what following engine panels show: one engine
+by endpoint, or **all models** — the aggregate. Absent means automatic (the host
+default), which is what every page starts as and what the preset ships with.
+Chosen from the **page config** control beside "Edit layout" and written the
+moment it is chosen, like a rename — not part of an edit session.
+_Avoid_: page filter, default engine (it may also be the aggregate), page binding
+
+**All models**:
+The combined view across every running engine: throughput and counters sum,
+latencies are request-weighted means (`lib/engineAggregate`). A following panel
+rendering it says so — a combined figure wearing no name would read as one
+engine's. Per-engine things (logs, engine identity, a pin) never aggregate.
+_Avoid_: global view, all engines (the panel type "All Engines" is the overview
+panel; the page source is about what following panels render)
 
 **Time window**:
 How much history a panel's chart covers (`5m`, `10m`, `15m`). Per panel, not per

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import { ConfigurationNotices } from './components/ConfigurationNotices'
 import { GridPageEditor } from './components/grid/GridPageEditor'
 import { PageBar } from './components/pages/PageBar'
 import { withPagePanels } from './lib/dashboard/editing'
+import { setPageSource } from './lib/dashboard/pages'
+import type { PageSource } from './lib/dashboard/pageSource'
 import type { SaveOutcome } from './lib/dashboard/client'
 import type { DashboardDocument, DashboardPage, DashboardPanel } from './lib/dashboard/schema'
 
@@ -50,6 +52,16 @@ function DashboardPageView({ pageId }: { pageId: string | null }) {
     [document, page, save],
   )
 
+  // A page edit, written when it is made — the same rule as renaming a page,
+  // carried out here because this is where the document and the save live.
+  const saveSource = useCallback(
+    (source: PageSource | null) =>
+      document && page
+        ? save(setPageSource(document, page.id, source))
+        : Promise.resolve<SaveOutcome['status']>('failed'),
+    [document, page, save],
+  )
+
   return (
     <div className="h-dvh flex flex-col bg-[#08080a] overflow-hidden">
       <AppHeader
@@ -81,6 +93,7 @@ function DashboardPageView({ pageId }: { pageId: string | null }) {
             page={page}
             readOnly={readOnly}
             onSave={savePanels}
+            onChangeSource={saveSource}
             onEditingChange={setEditing}
           />
         )}

--- a/frontend/src/__tests__/App.pageConfig.test.tsx
+++ b/frontend/src/__tests__/App.pageConfig.test.tsx
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+import {
+  configurationResponse,
+  configurationWrites,
+  serveConfiguration,
+  type FetchMock,
+} from '../test/configurationServer'
+import { gridSubstitute } from '../test/gridSubstitute'
+import { MockWebSocket, substituteWebSocket } from '../test/websocket'
+import { DASHBOARD_SCHEMA_VERSION } from '../lib/dashboard/schema'
+import type { EngineMetrics, EngineSnapshot, MetricsSnapshot } from '../types/metrics'
+
+// The page configuration control: what a page's following panels show — one
+// model, all of them combined, or the host default — chosen beside "Edit
+// layout" and written to the shared document the moment it is chosen, the way
+// a page rename is. Driven through the application seam: real configuration
+// loading and saving over the fetch stub, real panels reading the real store.
+substituteWebSocket()
+
+const GIB = 1_073_741_824
+
+const ALPHA = 'http://localhost:8000'
+const BETA = 'http://localhost:8001'
+
+function storedDocument(page: Record<string, unknown>): string {
+  return JSON.stringify({ version: DASHBOARD_SCHEMA_VERSION, pages: [page] })
+}
+
+/** A page of one following decode panel and one pinned to Alpha. */
+function watchPage(source?: unknown): Record<string, unknown> {
+  return {
+    id: 'watch',
+    name: 'Watch',
+    ...(source === undefined ? {} : { source }),
+    panels: [
+      { id: 'decode', type: 'engine-decode-throughput', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      {
+        id: 'pinned',
+        type: 'engine-decode-throughput',
+        title: 'Pinned to Alpha',
+        geometry: { x: 6, y: 0, w: 6, h: 4 },
+        binding: { kind: 'engine', endpoint: ALPHA },
+      },
+    ],
+  }
+}
+
+function engine(endpoint: string, model: string, tokensPerSec: number): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status: { type: 'Running' },
+    model: {
+      name: model,
+      parameter_size: null,
+      quantization: null,
+      precision: null,
+      tensor_type: null,
+      model_type: null,
+      pipeline_tag: null,
+    },
+    metrics: { tokens_per_sec: tokensPerSec } as EngineMetrics,
+    recent_requests: [],
+    deployment_mode: 'Native',
+  }
+}
+
+function snapshot(timestampMs = 1_000): MetricsSnapshot {
+  return {
+    timestamp_ms: timestampMs,
+    gpu: {
+      index: 0,
+      name: 'NVIDIA GB10',
+      utilization_percent: 40,
+      memory_total_bytes: 96 * GIB,
+      memory_used_bytes: 24 * GIB,
+      temperature_celsius: 55,
+      power_watts: 180,
+      power_limit_watts: 300,
+      clock_graphics_mhz: 1900,
+      clock_sm_mhz: 1900,
+      clock_memory_mhz: 8000,
+      fan_speed_percent: 30,
+    },
+    cpu: { name: 'Grace CPU', aggregate_percent: 25, per_core: [] },
+    memory: {
+      total_bytes: 128 * GIB,
+      display_total_bytes: 128 * GIB,
+      used_bytes: 64 * GIB,
+      available_bytes: 64 * GIB,
+      cached_bytes: 8 * GIB,
+      gpu_estimated_bytes: 24 * GIB,
+      gpu_memory_total_bytes: null,
+      gpu_memory_used_bytes: null,
+      is_unified: true,
+    },
+    disk: { name: 'nvme0n1', read_bytes_per_sec: 0, write_bytes_per_sec: 0 },
+    network: { name: 'enp1s0', rx_bytes_per_sec: 0, tx_bytes_per_sec: 0 },
+    engines: [engine(ALPHA, 'Qwen/Qwen3-8B', 120), engine(BETA, 'meta-llama/Llama-3-8B', 640)],
+    gpu_events: [],
+  }
+}
+
+function receive(metrics: MetricsSnapshot) {
+  act(() => MockWebSocket.instances[0].receive(JSON.stringify(metrics)))
+}
+
+async function openPage(fetchMock: FetchMock) {
+  window.history.replaceState(null, '', '/pages/watch')
+  render(<App />)
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+  await act(() => configurationResponse(fetchMock))
+}
+
+const pageConfigButton = () => screen.getByRole('button', { name: 'Page config' })
+const configuration = () => screen.getByRole('region', { name: 'Page configuration' })
+const followPanel = () => screen.getByRole('region', { name: 'Decode Throughput' })
+const pinnedPanel = () => screen.getByRole('region', { name: 'Pinned to Alpha' })
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  gridSubstitute.reset()
+})
+
+describe('the page configuration control', () => {
+  it('offers automatic, all models, and each model on the host', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(watchPage()) })
+    await openPage(fetchMock)
+    receive(snapshot())
+
+    await userEvent.click(pageConfigButton())
+
+    const options = within(configuration()).getAllByRole('button')
+    expect(options.map((option) => option.textContent)).toEqual([
+      'Automatic — first serving model',
+      'All models — combined',
+      'Qwen3-8B — vLLM localhost:8000',
+      'Llama-3-8B — vLLM localhost:8001',
+    ])
+    expect(options[0]).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('writes the choice immediately and the following panels move to the combined figures', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(watchPage()) })
+    await openPage(fetchMock)
+    receive(snapshot())
+
+    // Nothing configured: the page follows the first running engine.
+    expect(within(followPanel()).getByText('120.0')).toBeInTheDocument()
+
+    await userEvent.click(pageConfigButton())
+    await userEvent.click(
+      within(configuration()).getByRole('button', { name: 'All models — combined' }),
+    )
+
+    // One write, the moment the choice was made — no edit session, no save
+    // button — carrying the source on the page it configures.
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    const written = JSON.parse(configurationWrites(fetchMock)[0])
+    expect(written.pages[0].source).toEqual({ kind: 'all' })
+
+    // The choice landed and the popover's job is done.
+    await waitFor(() =>
+      expect(screen.queryByRole('region', { name: 'Page configuration' })).not.toBeInTheDocument(),
+    )
+
+    // The following panel shows the sum under the aggregate's own name — and
+    // the pinned panel stays on the engine its label promises.
+    expect(within(followPanel()).getByText('760.0')).toBeInTheDocument()
+    expect(within(followPanel()).getByText('All models')).toBeInTheDocument()
+    expect(within(followPanel()).getByText('2 of 2 serving')).toBeInTheDocument()
+    expect(within(pinnedPanel()).getByText('120.0')).toBeInTheDocument()
+  })
+
+  it('renders a stored all-models page as the combined view from the first paint', async () => {
+    // The kiosk case: the configuration is in the document, so nobody has to
+    // touch the control after a reboot.
+    const fetchMock = serveConfiguration({
+      document: storedDocument(watchPage({ kind: 'all' })),
+    })
+    await openPage(fetchMock)
+    receive(snapshot())
+
+    expect(within(followPanel()).getByText('760.0')).toBeInTheDocument()
+    expect(within(pinnedPanel()).getByText('120.0')).toBeInTheDocument()
+    expect(configurationWrites(fetchMock)).toHaveLength(0)
+  })
+
+  it('renders a stored default model and clears it on the way back to automatic', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument(watchPage({ kind: 'engine', endpoint: BETA })),
+    })
+    await openPage(fetchMock)
+    receive(snapshot())
+
+    // The page opens on the configured engine, not the host default.
+    expect(within(followPanel()).getByText('640.0')).toBeInTheDocument()
+
+    await userEvent.click(pageConfigButton())
+    await userEvent.click(
+      within(configuration()).getByRole('button', { name: 'Automatic — first serving model' }),
+    )
+
+    await waitFor(() => expect(configurationWrites(fetchMock)).toHaveLength(1))
+    // Automatic is the absence of the field, not a stored sentinel.
+    expect(JSON.parse(configurationWrites(fetchMock)[0]).pages[0]).not.toHaveProperty('source')
+    expect(within(followPanel()).getByText('120.0')).toBeInTheDocument()
+  })
+
+  it('keeps a configured engine that is not on this host on offer, marked', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument(watchPage({ kind: 'engine', endpoint: 'http://localhost:9999' })),
+    })
+    await openPage(fetchMock)
+    receive(snapshot())
+
+    await userEvent.click(pageConfigButton())
+
+    const dangling = within(configuration()).getByRole('button', {
+      name: 'http://localhost:9999 (not on this host)',
+    })
+    expect(dangling).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('says why nothing can be chosen on a read-only instance', async () => {
+    const fetchMock = serveConfiguration({
+      document: storedDocument(watchPage()),
+      readOnly: true,
+    })
+    await openPage(fetchMock)
+    receive(snapshot())
+
+    await userEvent.click(pageConfigButton())
+
+    expect(
+      within(configuration()).getByText(
+        'This dashboard is read-only, so the page cannot be reconfigured.',
+      ),
+    ).toBeInTheDocument()
+    for (const option of within(configuration()).getAllByRole('button')) {
+      expect(option).toBeDisabled()
+    }
+  })
+
+  it('withholds the control while a layout edit session is open', async () => {
+    // A source change writes the document immediately, and mid-session the
+    // document under the unsaved panels must hold still.
+    const fetchMock = serveConfiguration({ document: storedDocument(watchPage()) })
+    await openPage(fetchMock)
+    receive(snapshot())
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit layout' }))
+    expect(screen.queryByRole('button', { name: 'Page config' })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Discard' }))
+    expect(pageConfigButton()).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/metricsHistoryStore.test.ts
+++ b/frontend/src/__tests__/metricsHistoryStore.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { gpuMemoryPercent, gpuSeries, MetricsHistoryStore } from '../lib/metricsHistoryStore'
+import {
+  ALL_ENGINES_KEY,
+  engineSeries,
+  gpuMemoryPercent,
+  gpuSeries,
+  MetricsHistoryStore,
+} from '../lib/metricsHistoryStore'
 import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '../types/metrics'
 
 /** The GPU the snapshots below carry, for the specs that read one field of it. */
@@ -149,6 +155,45 @@ describe('MetricsHistoryStore windowed reads', () => {
       store.getChartData(engineSeries, '5m').length,
     )
     expect(store.getEvents('15m').length).toBeGreaterThan(store.getEvents('5m').length)
+  })
+})
+
+describe('MetricsHistoryStore all-engines aggregate series', () => {
+  it('ingests the combined series alongside the per-engine ones', () => {
+    const store = new MetricsHistoryStore()
+    store.ingest(
+      makeSnapshot(1_000, {
+        engines: [makeEngine(100), { ...makeEngine(150), endpoint: 'http://localhost:8001' }],
+      }),
+    )
+
+    // The sum, under its own key — what a page configured for all models charts…
+    expect(store.getChartData(engineSeries('tps', ALL_ENGINES_KEY), '15m')).toEqual([
+      { timestamp: 1_000, value: 250 },
+    ])
+    // …with the per-engine series untouched beside it.
+    expect(store.getChartData('Vllm-http://localhost:8000:tps', '15m')).toEqual([
+      { timestamp: 1_000, value: 100 },
+    ])
+  })
+
+  it('notifies a subscriber of the aggregate series', () => {
+    const store = new MetricsHistoryStore()
+    const listener = vi.fn()
+    store.subscribe(engineSeries('tps', ALL_ENGINES_KEY), listener)
+
+    store.ingest(makeSnapshot(1_000, { engines: [makeEngine(100)] }))
+
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('ingests no aggregate sample when no engine is running', () => {
+    const store = new MetricsHistoryStore()
+    store.ingest(
+      makeSnapshot(1_000, { engines: [{ ...makeEngine(100), status: { type: 'Stopped' } }] }),
+    )
+
+    expect(store.getChartData(engineSeries('tps', ALL_ENGINES_KEY), '15m')).toEqual([])
   })
 })
 

--- a/frontend/src/__tests__/pageSelection.test.tsx
+++ b/frontend/src/__tests__/pageSelection.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { act, render, screen, within } from '@testing-library/react'
 import { useEffect } from 'react'
 import { GridPanel } from '@/components/grid/GridPanel'
+import { LogStreamProvider } from '@/hooks/LogStreamProvider'
 import { PageSelectionProvider } from '@/hooks/PageSelectionProvider'
 import { MetricsStoreProvider } from '@/hooks/MetricsStoreProvider'
 import { useMetricsStore } from '@/hooks/useMetricsStore'
@@ -179,6 +180,60 @@ describe('the page-level GPU selection', () => {
 
     click('Select GPU default')
     expect(within(region('GPU Utilization')).getByText('11')).toBeInTheDocument()
+  })
+})
+
+describe('a page configured for all models', () => {
+  function AllModelsPage() {
+    return (
+      <MetricsStoreProvider>
+        {/* The log stream store, because choosing one engine resolves the log
+            panel to a real stream — exactly what the yield-to-choice spec does. */}
+        <LogStreamProvider>
+          <Ingest />
+          <PageSelectionProvider source={{ kind: 'all' }}>
+            <SelectEngine endpoint={ALPHA} />
+            <GridPanel panel={panel('decode', 'engine-decode-throughput')} />
+            <GridPanel panel={panel('status', 'engine-status')} />
+            <GridPanel panel={panel('logs', 'logs')} />
+            <GridPanel
+              panel={{
+                ...panel('pinned-engine', 'engine-decode-throughput'),
+                title: 'Pinned to Alpha',
+                binding: { kind: 'engine', endpoint: ALPHA },
+              }}
+            />
+          </PageSelectionProvider>
+        </LogStreamProvider>
+      </MetricsStoreProvider>
+    )
+  }
+
+  it('shows the combined figures on following panels and leaves pins alone', () => {
+    render(<AllModelsPage />)
+
+    const decode = region('Decode Throughput')
+    expect(within(decode).getByText('760.0')).toBeInTheDocument()
+    // The combined figure wears the aggregate's own name, never an engine's.
+    expect(within(decode).getByText('All models')).toBeInTheDocument()
+    expect(within(region('Pinned to Alpha')).getByText('120.0')).toBeInTheDocument()
+  })
+
+  it('explains itself on the panels that are per-engine by nature', () => {
+    render(<AllModelsPage />)
+
+    expect(
+      within(region('Engine')).getByText(/Engine identity is per-engine/),
+    ).toBeInTheDocument()
+    expect(within(region('Logs')).getByText(/Logs are per-engine/)).toBeInTheDocument()
+  })
+
+  it('yields to a session choice, which is the operator asking for one engine now', () => {
+    render(<AllModelsPage />)
+
+    click(`Select ${ALPHA}`)
+
+    expect(within(region('Decode Throughput')).getByText('120.0')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/grid/EditModeBar.tsx
+++ b/frontend/src/components/grid/EditModeBar.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { GRID_MAX_ROWS } from '@/lib/dashboard/grid'
 import type { PanelType } from '@/lib/dashboard/panels'
 import { BarButton } from './BarButton'
@@ -28,6 +29,12 @@ interface EditModeBarProps {
   narrow: boolean
   /** What the page would not take, or null when nothing stands refused. */
   refused: Refusal | null
+  /**
+   * The page-level configuration control, shown beside “Edit layout”. Withheld
+   * while a session is open: a source change writes the document immediately,
+   * and mid-session the document under the unsaved panels must hold still.
+   */
+  pageConfig?: ReactNode
   onBegin: () => void
   onAdd: (type: PanelType) => void
   onSave: () => void
@@ -51,6 +58,7 @@ export function EditModeBar({
   saving,
   narrow,
   refused,
+  pageConfig,
   onBegin,
   onAdd,
   onSave,
@@ -82,7 +90,12 @@ export function EditModeBar({
             </BarButton>
           </>
         ) : (
-          !narrow && <BarButton onClick={onBegin}>Edit layout</BarButton>
+          <>
+            {/* Unlike editing, the page's configuration is not geometry, so it
+                stays available on the stacked column too. */}
+            {pageConfig}
+            {!narrow && <BarButton onClick={onBegin}>Edit layout</BarButton>}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -209,8 +209,9 @@ export function GridPage({
     >
       {/* The selection is per page and lives inside it: every following panel
           on this page reads the same GPU and engine, and a page mounted at
-          another id starts from the host's defaults again. */}
-      <PageSelectionProvider>
+          another id starts from its own configured source — or the host's
+          defaults — again. */}
+      <PageSelectionProvider source={page.source}>
         <GridStack
           options={options}
           onChange={draggable ? handleChange : undefined}

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -12,10 +12,12 @@ import {
   repointPanel,
   setPanelWindow,
 } from '@/lib/dashboard/editing'
+import type { PageSource } from '@/lib/dashboard/pageSource'
 import { defaultPanelTitle, type PanelType } from '@/lib/dashboard/panels'
 import type { DashboardPage, DashboardPanel } from '@/lib/dashboard/schema'
 import type { TimeWindow } from '@/types/events'
 import { EditModeBar, type Refusal } from './EditModeBar'
+import { PageConfig } from './PageConfig'
 import { PanelSettings } from './PanelSettings'
 import { isNarrow } from './breakpoint'
 import { GridPage, type GridEditing, type PanelChrome } from './GridPage'
@@ -39,6 +41,12 @@ interface GridPageEditorProps {
   /** Nothing can be written on this instance; the standing banner says why. */
   readOnly: boolean
   onSave: (panels: DashboardPanel[]) => Promise<SaveOutcome['status']>
+  /**
+   * Writes the page's source — what its following panels show by default.
+   * Immediate, like a page rename; not part of the edit session. Absent means
+   * nowhere to write it, and the control is withheld rather than dead.
+   */
+  onChangeSource?: (source: PageSource | null) => Promise<SaveOutcome['status']>
   /**
    * Whether a session is open, for the page list in the header. The session is a
    * working copy that dies with this component, so switching pages while one is
@@ -66,6 +74,7 @@ export function GridPageEditor({
   page,
   readOnly,
   onSave,
+  onChangeSource,
   onEditingChange,
 }: GridPageEditorProps) {
   const [session, setSession] = useState<EditSession | null>(null)
@@ -207,6 +216,11 @@ export function GridPageEditor({
         saving={saving}
         narrow={narrow}
         refused={refused}
+        pageConfig={
+          onChangeSource && (
+            <PageConfig source={page.source} readOnly={readOnly} onChange={onChangeSource} />
+          )
+        }
         onBegin={() => setSession({ panels: page.panels, refused: null, configuringId: null })}
         onAdd={add}
         onSave={() => void save()}

--- a/frontend/src/components/grid/PageConfig.tsx
+++ b/frontend/src/components/grid/PageConfig.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import { useDismissablePopover } from '@/hooks/useDismissablePopover'
+import { useLatestSnapshot } from '@/hooks/useMetricsStore'
+import {
+  pageSourceChoices,
+  pageSourceFromChoice,
+  type PageSource,
+  type PageSourceChoice,
+} from '@/lib/dashboard/pageSource'
+import type { SaveOutcome } from '@/lib/dashboard/client'
+import { BarButton } from './BarButton'
+
+interface PageConfigProps {
+  /** The page's stored source. Absent = automatic. */
+  source?: PageSource
+  /** No save can succeed on this instance; the standing banner says why. */
+  readOnly: boolean
+  /** Writes the choice to the document. Null puts the page back on automatic. */
+  onChange: (source: PageSource | null) => Promise<SaveOutcome['status']>
+}
+
+/**
+ * What this page shows by default: one model, all of them combined, or
+ * whatever the host is serving — the page-level dial the `follow` bindings
+ * were built to point at.
+ *
+ * It sits beside “Edit layout” but is deliberately not part of an edit
+ * session: choosing what a page shows is a deliberate, named request like
+ * renaming the page, so it is **written when it is made** (see
+ * `lib/dashboard/pages`), and it works without opening a session that locks
+ * the page list. The popover closes on a successful write and stays open over
+ * a failed one, so the operator is looking at the choice that did not take.
+ */
+export function PageConfig({ source, readOnly, onChange }: PageConfigProps) {
+  const { open, setOpen, toggle, containerRef } = useDismissablePopover<HTMLDivElement>()
+  // One write at a time: the loser of a race would be written from a document
+  // that never had the winner's change.
+  const [busy, setBusy] = useState(false)
+
+  const snapshot = useLatestSnapshot()
+  const { value, choices } = pageSourceChoices(source, snapshot?.engines ?? [])
+
+  const choose = async (choice: PageSourceChoice) => {
+    if (busy || choice.value === value) return
+    setBusy(true)
+    const status = await onChange(pageSourceFromChoice(choice.value))
+    setBusy(false)
+    if (status === 'saved') setOpen(false)
+  }
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <BarButton onClick={toggle}>Page config</BarButton>
+
+      {open && (
+        <section
+          aria-label="Page configuration"
+          className="absolute right-0 top-full z-20 mt-1 w-72 rounded-md border border-white/[0.08] bg-[#0d0d10] p-2 shadow-xl flex flex-col gap-1.5"
+        >
+          <p className="text-[11px] text-zinc-500 leading-snug">
+            What panels on this page show, unless they are pinned to an engine of their own.
+          </p>
+
+          {readOnly && (
+            <p className="text-[11px] text-amber-300/90 leading-snug">
+              This dashboard is read-only, so the page cannot be reconfigured.
+            </p>
+          )}
+
+          <div className="flex flex-col gap-1" role="group" aria-label="Model shown">
+            {choices.map((choice) => (
+              <SourceOption
+                key={choice.value}
+                choice={choice}
+                selected={choice.value === value}
+                disabled={readOnly || busy}
+                onChoose={() => void choose(choice)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function SourceOption({
+  choice,
+  selected,
+  disabled,
+  onChoose,
+}: {
+  choice: PageSourceChoice
+  selected: boolean
+  disabled: boolean
+  onChoose: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onChoose}
+      disabled={disabled}
+      aria-pressed={selected}
+      className={`w-full text-left px-2 py-1.5 rounded text-[11px] border transition-colors ${
+        selected
+          ? 'border-[#76B900]/50 bg-[#76B900]/10'
+          : disabled
+            ? 'border-white/[0.04] cursor-not-allowed'
+            : 'border-white/[0.08] hover:bg-white/[0.06]'
+      } ${
+        // An absent target stays offered — hiding it is how a page silently
+        // ends up showing something else — but it is marked as what it is.
+        choice.absent
+          ? 'text-amber-300'
+          : disabled && !selected
+            ? 'text-zinc-600'
+            : selected
+              ? 'text-zinc-100'
+              : 'text-zinc-300 hover:text-zinc-100'
+      }`}
+    >
+      {choice.label}
+    </button>
+  )
+}

--- a/frontend/src/components/grid/panels/EngineCachePanel.tsx
+++ b/frontend/src/components/grid/panels/EngineCachePanel.tsx
@@ -18,7 +18,9 @@ import type { PanelContentProps } from '../panelRegistry'
  */
 export function EngineCachePanel({ panel }: PanelContentProps) {
   const resolution = useEnginePanel(panel)
-  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+  if (resolution.status !== 'resolved' && resolution.status !== 'aggregate') {
+    return <EnginePanelNotice resolution={resolution} />
+  }
 
   const { metric, series } = resolution
   const kvPercent = metric('kv_cache_percent')

--- a/frontend/src/components/grid/panels/EngineLatencyPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineLatencyPanel.tsx
@@ -24,7 +24,9 @@ import type { PanelContentProps } from '../panelRegistry'
 export function EngineLatencyPanel({ panel }: PanelContentProps) {
   const resolution = useEnginePanel(panel)
   const [mode, setMode] = useLatencyMode()
-  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+  if (resolution.status !== 'resolved' && resolution.status !== 'aggregate') {
+    return <EnginePanelNotice resolution={resolution} />
+  }
 
   const { metric, series } = resolution
   const ttft = pickLatencyValue(mode, metric('ttft_ms'), metric('ttft_percentiles'))

--- a/frontend/src/components/grid/panels/EngineRequestsPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineRequestsPanel.tsx
@@ -16,7 +16,9 @@ import type { PanelContentProps } from '../panelRegistry'
  */
 export function EngineRequestsPanel({ panel }: PanelContentProps) {
   const resolution = useEnginePanel(panel)
-  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+  if (resolution.status !== 'resolved' && resolution.status !== 'aggregate') {
+    return <EnginePanelNotice resolution={resolution} />
+  }
 
   const { metric, series } = resolution
   const swapped = metric('swapped_requests')

--- a/frontend/src/components/grid/panels/EngineSloGoodputPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineSloGoodputPanel.tsx
@@ -26,6 +26,9 @@ import type { PanelContentProps } from '../panelRegistry'
 export function EngineSloGoodputPanel({ panel }: PanelContentProps) {
   const resolution = useEnginePanel(panel)
   const engine = resolution.status === 'resolved' ? resolution.engine : null
+  // Thresholds are per model, so the aggregate reads at the defaults: a page
+  // showing all models has no one model whose stored thresholds could honestly
+  // caption a combined figure. The control below is disabled on the same terms.
   const {
     thresholds,
     setThresholds,
@@ -33,7 +36,9 @@ export function EngineSloGoodputPanel({ panel }: PanelContentProps) {
     isCustomized,
   } = useSloSettings(engine && engineKey(engine), engine?.model?.name ?? null)
 
-  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+  if (resolution.status !== 'resolved' && resolution.status !== 'aggregate') {
+    return <EnginePanelNotice resolution={resolution} />
+  }
 
   const { metric } = resolution
   const ttft = recomputeGoodputPct(metric('ttft_buckets'), thresholds.ttftMs)
@@ -52,7 +57,7 @@ export function EngineSloGoodputPanel({ panel }: PanelContentProps) {
         <SloSettingsControl
           thresholds={thresholds}
           isCustomized={isCustomized}
-          disabled={resolution.engine.model === null}
+          disabled={engine === null || engine.model === null}
           onChange={setThresholds}
           onReset={reset}
         />

--- a/frontend/src/components/grid/panels/EngineSpecDecodePanel.tsx
+++ b/frontend/src/components/grid/panels/EngineSpecDecodePanel.tsx
@@ -15,7 +15,9 @@ import type { PanelContentProps } from '../panelRegistry'
  */
 export function EngineSpecDecodePanel({ panel }: PanelContentProps) {
   const resolution = useEnginePanel(panel)
-  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+  if (resolution.status !== 'resolved' && resolution.status !== 'aggregate') {
+    return <EnginePanelNotice resolution={resolution} />
+  }
 
   const { metric } = resolution
   const draftTokens = metric('spec_decode_draft_tokens_total')
@@ -28,6 +30,18 @@ export function EngineSpecDecodePanel({ panel }: PanelContentProps) {
   // The engine is named on a multi-engine host for the same reason its data
   // would be: with two engines on a page, "this engine" does not say which.
   if (draftTokens === null || draftTokens === 0) {
+    // Under the aggregate the counters are combined, so their absence speaks
+    // for every model at once and "this engine" would name nothing.
+    if (resolution.status === 'aggregate') {
+      return (
+        <PanelNotice>
+          {draftTokens === null
+            ? 'No model is using speculative decoding.'
+            : 'No model has drafted a token yet.'}
+        </PanelNotice>
+      )
+    }
+
     const subject = engineLabel(resolution) ?? 'This engine'
     return (
       <PanelNotice>

--- a/frontend/src/components/grid/panels/EngineStatusPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineStatusPanel.tsx
@@ -1,9 +1,8 @@
 import { getProviderLogo } from '@/lib/providerLogo'
-import { engineDisplayName, formatEndpoint, formatGpuIndexes } from '@/lib/format'
+import { engineDisplayName, formatEndpoint, formatGpuIndexes, shortModelName } from '@/lib/format'
 import type { EngineSnapshot } from '@/types/metrics'
 import { DeploymentChip, EngineChip, ProviderMark } from './engineIdentity'
-import { shortModelName } from './engineLabel'
-import { EnginePanelNotice } from './PanelNotice'
+import { EnginePanelNotice, PanelNotice } from './PanelNotice'
 import { usePanelDevice } from '../panelDevice'
 import { useEngineTarget } from './useEnginePanel'
 import type { PanelContentProps } from '../panelRegistry'
@@ -27,6 +26,18 @@ export function EngineStatusPanel({ panel }: PanelContentProps) {
   // there are none.
   const target = useEngineTarget(panel)
   usePanelDevice(target.status === 'resolved' ? formatEndpoint(target.engine.endpoint) : null)
+
+  // The identity of "all models" is no identity at all: there is no one model,
+  // status or deployment to describe. The "All Engines" overview panel is the
+  // panel for that question, so the notice points at it rather than pretending.
+  if (target.status === 'aggregate') {
+    return (
+      <PanelNotice>
+        This page shows all models. Engine identity is per-engine — pin this panel to one engine,
+        or use the “All Engines” panel.
+      </PanelNotice>
+    )
+  }
 
   if (target.status !== 'resolved') return <EnginePanelNotice resolution={target} />
 

--- a/frontend/src/components/grid/panels/EngineThroughputPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineThroughputPanel.tsx
@@ -56,7 +56,9 @@ export function EngineDecodeThroughputPanel({ panel }: PanelContentProps) {
 
 function ThroughputPanel({ panel, fields }: PanelContentProps & { fields: ThroughputFields }) {
   const resolution = useEnginePanel(panel)
-  if (resolution.status !== 'resolved') return <EnginePanelNotice resolution={resolution} />
+  if (resolution.status !== 'resolved' && resolution.status !== 'aggregate') {
+    return <EnginePanelNotice resolution={resolution} />
+  }
 
   const { metric, series } = resolution
   const live = series(fields.series.live)

--- a/frontend/src/components/grid/panels/InferenceTimelinePanel.tsx
+++ b/frontend/src/components/grid/panels/InferenceTimelinePanel.tsx
@@ -40,7 +40,12 @@ import type { PanelContentProps } from '../panelRegistry'
 export function InferenceTimelinePanel({ panel }: PanelContentProps) {
   const { target, requests } = useEngineRequests(panel)
   const snapshot = useLatestSnapshot()
-  if (target.status !== 'resolved') return <EnginePanelNotice resolution={target} />
+  // The aggregate renders here too: requests compose by interleaving, so the
+  // combined timeline is every engine's requests on one axis — the identity
+  // row says so, exactly as it does on the metric panels.
+  if (target.status !== 'resolved' && target.status !== 'aggregate') {
+    return <EnginePanelNotice resolution={target} />
+  }
 
   // The newest sample anchors the axis, not wall clock: the bars then hold
   // still between snapshots rather than creeping leftward every frame.

--- a/frontend/src/components/grid/panels/LogsPanel.tsx
+++ b/frontend/src/components/grid/panels/LogsPanel.tsx
@@ -1,7 +1,7 @@
 import { LogConsole } from '@/components/LogConsole'
 import { useLogStream } from '@/hooks/useLogStream'
 import { engineLabel } from './engineLabel'
-import { EnginePanelNotice } from './PanelNotice'
+import { EnginePanelNotice, PanelNotice } from './PanelNotice'
 import { useEngineTarget, type ResolvedEngineTarget } from './useEnginePanel'
 import type { PanelContentProps } from '../panelRegistry'
 
@@ -23,6 +23,18 @@ export function LogsPanel({ panel }: PanelContentProps) {
   // an operator opens its logs. Gating the panel on availability would hide the
   // output that explains why the engine is in that state.
   const target = useEngineTarget(panel)
+
+  // A log stream is one container's output; interleaving several would produce
+  // a transcript no engine ever wrote. So a page showing all models has no
+  // stream for a following log panel, and the way to one is a pin.
+  if (target.status === 'aggregate') {
+    return (
+      <PanelNotice>
+        This page shows all models. Logs are per-engine — pin this panel to one engine.
+      </PanelNotice>
+    )
+  }
+
   if (target.status !== 'resolved') return <EnginePanelNotice resolution={target} />
 
   // The stream is subscribed one component down, so switching engines remounts

--- a/frontend/src/components/grid/panels/engineLabel.ts
+++ b/frontend/src/components/grid/panels/engineLabel.ts
@@ -1,16 +1,6 @@
-import { engineDescription } from '@/lib/format'
+import { engineDescription, shortModelName } from '@/lib/format'
 import { getProviderLogo, type ProviderLogo } from '@/lib/providerLogo'
-import type { ResolvedEngineTarget } from './useEnginePanel'
-
-/**
- * Strip the `Organization/` prefix off a HuggingFace-style id, leaving the
- * model itself: `Qwen/Qwen3-8B` reads as `Qwen3-8B`. The organization is
- * already said by the provider mark beside it, so repeating it in the name
- * spends the width a long model id needs.
- */
-export function shortModelName(name: string): string {
-  return name.includes('/') ? name.slice(name.lastIndexOf('/') + 1) : name
-}
+import type { AggregateEngineTarget, ResolvedEngineTarget } from './useEnginePanel'
 
 /**
  * The engine a panel resolved to, named — or null on a host running a single
@@ -20,8 +10,15 @@ export function shortModelName(name: string): string {
  * showing. Two panels pinned to two engines otherwise differ only by their
  * position on the page, and a panel that has followed the page selection
  * somewhere else would look identical to one that has not.
+ *
+ * A panel following a page configured to show all models is named on the same
+ * terms: "All models" is what its numbers are, and a combined figure wearing no
+ * name would read as one engine's.
  */
-export function engineLabel(resolution: ResolvedEngineTarget): string | null {
+export function engineLabel(
+  resolution: ResolvedEngineTarget | AggregateEngineTarget,
+): string | null {
+  if (resolution.status === 'aggregate') return 'All models'
   return resolution.multiEngine ? engineDescription(resolution.engine) : null
 }
 
@@ -47,8 +44,22 @@ export interface EngineIdentity {
  * of them can legitimately serve the same model; the mark is the provider, at a
  * glance. All are absent on a single-engine host, where there is nothing to
  * tell apart and the row would only cost the panel height.
+ *
+ * The aggregate wears an identity **unconditionally**, single-engine hosts
+ * included: a combined figure is a different thing from an engine's own, and
+ * the row is the only place the panel says so.
  */
-export function engineIdentity(resolution: ResolvedEngineTarget): EngineIdentity {
+export function engineIdentity(
+  resolution: ResolvedEngineTarget | AggregateEngineTarget,
+): EngineIdentity {
+  if (resolution.status === 'aggregate') {
+    return {
+      label: `${resolution.running} of ${resolution.total} serving`,
+      model: 'All models',
+      logo: null,
+    }
+  }
+
   if (!resolution.multiEngine) return { label: null, model: null, logo: null }
 
   const { model } = resolution.engine

--- a/frontend/src/components/grid/panels/useEnginePanel.ts
+++ b/frontend/src/components/grid/panels/useEnginePanel.ts
@@ -3,11 +3,17 @@ import { useInferenceRequests, useLatestSnapshot, useMetricsStore } from '@/hook
 import { usePageSelection } from '@/hooks/usePageSelection'
 import { resolveEngineBinding } from '@/lib/dashboard/bindings'
 import { pageSelection } from '@/lib/dashboard/selection'
+import { aggregateEngineMetrics } from '@/lib/engineAggregate'
 import { engineAvailability, engineMetricReader, type EngineMetricReader } from '@/lib/engineMetrics'
 import { engineKey } from '@/lib/identity'
-import { engineSeries, type DataPoint, type EngineSeriesName } from '@/lib/metricsHistoryStore'
+import {
+  ALL_ENGINES_KEY,
+  engineSeries,
+  type DataPoint,
+  type EngineSeriesName,
+} from '@/lib/metricsHistoryStore'
 import type { DashboardPanel } from '@/lib/dashboard/schema'
-import type { EngineSnapshot, InferenceRequestData } from '@/types/metrics'
+import type { EngineMetrics, EngineSnapshot, InferenceRequestData } from '@/types/metrics'
 
 /** Which engine a panel's binding names on this host, before anything is asked
  *  about whether that engine is serving. */
@@ -21,12 +27,21 @@ export type EngineTargetResolution =
        *  to name the one it is showing. */
       multiEngine: boolean
     }
+  /**
+   * Every running engine at once: the page is configured for all models and
+   * this panel follows it. Only reached with at least one engine serving — a
+   * host running none is `unselected`, exactly as it is for a single target.
+   */
+  | { status: 'aggregate'; running: number; total: number }
   | { status: 'missing'; requested: string }
   | { status: 'unselected' }
   | { status: 'unreadable' }
 
 /** An engine a panel resolved its binding to. */
 export type ResolvedEngineTarget = Extract<EngineTargetResolution, { status: 'resolved' }>
+
+/** The all-engines aggregate a panel resolved its binding to. */
+export type AggregateEngineTarget = Extract<EngineTargetResolution, { status: 'aggregate' }>
 
 /** What an engine panel found at the other end of its binding. */
 export type EnginePanelResolution =
@@ -36,14 +51,23 @@ export type EnginePanelResolution =
       /** One of this engine's series over the panel's own time window. */
       series: (name: EngineSeriesName) => DataPoint[]
     })
+  /** The combined figures, read through the same reader and series shape a
+   *  single engine uses — which is what lets one panel render either. */
+  | (AggregateEngineTarget & {
+      metric: EngineMetricReader
+      series: (name: EngineSeriesName) => DataPoint[]
+    })
   /** The engine resolved, and has no metrics yet — starting, or loading a model. */
   | { status: 'starting'; engine: EngineSnapshot }
   /** The engine resolved and is not serving; `detail` says why. */
   | { status: 'offline'; engine: EngineSnapshot; detail: string }
-  | Exclude<EngineTargetResolution, { status: 'resolved' }>
+  | Exclude<EngineTargetResolution, { status: 'resolved' } | { status: 'aggregate' }>
 
-/** Everything but a resolved engine — what a panel hands to `EnginePanelNotice`. */
-export type EnginePanelNoticeState = Exclude<EnginePanelResolution, { status: 'resolved' }>
+/** Everything but a resolved target — what a panel hands to `EnginePanelNotice`. */
+export type EnginePanelNoticeState = Exclude<
+  EnginePanelResolution,
+  { status: 'resolved' } | { status: 'aggregate' }
+>
 
 /**
  * Which engine a panel's binding names, and nothing more.
@@ -56,7 +80,7 @@ export type EnginePanelNoticeState = Exclude<EnginePanelResolution, { status: 'r
  */
 export function useEngineTarget(panel: DashboardPanel): EngineTargetResolution {
   const snapshot = useLatestSnapshot()
-  const { chosen } = usePageSelection()
+  const { chosen, source } = usePageSelection()
 
   return useMemo(() => {
     if (!snapshot) return { status: 'waiting' }
@@ -65,20 +89,29 @@ export function useEngineTarget(panel: DashboardPanel): EngineTargetResolution {
     const resolution = resolveEngineBinding(
       panel.binding,
       engines,
-      pageSelection(snapshot, chosen).engineEndpoint,
+      pageSelection(snapshot, chosen, source).engineTarget,
     )
+    if (resolution.status === 'aggregate') {
+      const running = engines.filter((engine) => engine.status.type === 'Running').length
+      // An aggregate over a host serving nothing is not a row of zeros — it is
+      // the same "no inference engine running" state a single target has.
+      return running === 0
+        ? { status: 'unselected' }
+        : { status: 'aggregate', running, total: engines.length }
+    }
     if (resolution.status !== 'resolved') return resolution
 
     return { status: 'resolved', engine: resolution.target, multiEngine: engines.length > 1 }
-  }, [snapshot, chosen, panel.binding])
+  }, [snapshot, chosen, source, panel.binding])
 }
 
 /**
- * An inference-timeline panel's whole subscription in one call: the engine its
- * binding names, and that engine's finished requests over the panel's own
- * window. Every hook lives in here, above the caller's unresolved early return
- * — the same shape as `useGpuPanelSeries`; while unresolved, the all-engines
- * key keeps the subscription alive until a binding names one.
+ * An inference-timeline panel's whole subscription in one call: the target its
+ * binding names, and the finished requests over the panel's own window — one
+ * engine's, or, following a page configured for all models, every engine's
+ * together. Every hook lives in here, above the caller's unresolved early
+ * return — the same shape as `useGpuPanelSeries`; while unresolved, the
+ * all-engines key keeps the subscription alive until a binding names one.
  *
  * Deliberately the raw target rather than `useEnginePanel`: requests are the
  * engine's own record of what it served, and they stay worth reading when it
@@ -97,14 +130,15 @@ export function useEngineRequests(panel: DashboardPanel): {
 
 /**
  * What an engine panel renders on this host: its binding resolved against the
- * latest snapshot's engines, the reader for that engine's current values, and
+ * latest snapshot's engines, the reader for that target's current values, and
  * its chart series over the panel's own window.
  *
  * A following panel resolves to the page-level engine selection, so a page of
- * following panels shows one engine coherently and moves to another together.
- * A pinned panel resolves to its own engine and to nothing else — two panels
- * pinned to two engines sit side by side, and a pin to an engine that is gone
- * says so rather than showing the neighbour's numbers.
+ * following panels shows one engine coherently and moves to another together —
+ * or, on a page configured for all models, shows the combined figures. A pinned
+ * panel resolves to its own engine and to nothing else — two panels pinned to
+ * two engines sit side by side, and a pin to an engine that is gone says so
+ * rather than showing the neighbour's numbers.
  *
  * Series are read from the store during render rather than through a per-series
  * subscription: an engine panel shows current values as well as a chart, so it
@@ -113,10 +147,24 @@ export function useEngineRequests(panel: DashboardPanel): {
  */
 export function useEnginePanel(panel: DashboardPanel): EnginePanelResolution {
   const store = useMetricsStore()
+  const snapshot = useLatestSnapshot()
   const target = useEngineTarget(panel)
   const window = panel.window
 
   return useMemo(() => {
+    if (target.status === 'aggregate') {
+      // Recomputed from the snapshot the target was resolved against, so the
+      // tiles and the target agree; the series were ingested under the
+      // all-engines key by the same aggregation.
+      const metrics = aggregateEngineMetrics(snapshot?.engines ?? [])
+      if (!metrics) return { status: 'unselected' }
+
+      return {
+        ...target,
+        metric: <K extends keyof EngineMetrics>(key: K) => metrics[key],
+        series: (name) => store.getChartData(engineSeries(name, ALL_ENGINES_KEY), window),
+      }
+    }
     if (target.status !== 'resolved') return target
 
     const { engine } = target
@@ -132,5 +180,5 @@ export function useEnginePanel(panel: DashboardPanel): EnginePanelResolution {
       metric: engineMetricReader(engine),
       series: (name) => store.getChartData(engineSeries(name, key), window),
     }
-  }, [store, target, window])
+  }, [store, snapshot, target, window])
 }

--- a/frontend/src/hooks/PageSelectionProvider.tsx
+++ b/frontend/src/hooks/PageSelectionProvider.tsx
@@ -1,26 +1,38 @@
 import { useMemo, useState, type ReactNode } from 'react'
+import type { PageSource } from '@/lib/dashboard/pageSource'
 import { withSelectedEngine, withSelectedGpu, type SelectedTargets } from '@/lib/dashboard/selection'
 import { PageSelectionContext, type PageSelectionValue } from './usePageSelection'
 
 /**
  * Owns one page's selection.
  *
- * Session state, deliberately not part of the saved document: which GPU an
- * operator is looking at right now is not an arrangement they authored, and
- * writing it would make every glance at a second GPU a change to what everyone
- * else sees. It resets per page because the provider sits inside the page, which
- * is keyed by page id.
+ * The **chosen** targets are session state, deliberately not part of the saved
+ * document: which GPU an operator is looking at right now is not an arrangement
+ * they authored, and writing it would make every glance at a second GPU a
+ * change to what everyone else sees. It resets per page because the provider
+ * sits inside the page, which is keyed by page id.
+ *
+ * The **source** is the opposite — the page's persisted default, read from the
+ * document and merely carried through here so the panel hooks resolve both
+ * layers in one place.
  */
-export function PageSelectionProvider({ children }: { children: ReactNode }) {
+export function PageSelectionProvider({
+  source,
+  children,
+}: {
+  source?: PageSource
+  children: ReactNode
+}) {
   const [chosen, setChosen] = useState<SelectedTargets>({})
 
   const value = useMemo(
     (): PageSelectionValue => ({
       chosen,
+      ...(source === undefined ? {} : { source }),
       selectGpu: (index) => setChosen((current) => withSelectedGpu(current, index)),
       selectEngine: (endpoint) => setChosen((current) => withSelectedEngine(current, endpoint)),
     }),
-    [chosen],
+    [chosen, source],
   )
 
   return <PageSelectionContext.Provider value={value}>{children}</PageSelectionContext.Provider>

--- a/frontend/src/hooks/usePageSelection.ts
+++ b/frontend/src/hooks/usePageSelection.ts
@@ -1,18 +1,21 @@
 import { createContext, useContext } from 'react'
+import type { PageSource } from '@/lib/dashboard/pageSource'
 import type { SelectedTargets } from '@/lib/dashboard/selection'
 
 /**
  * What one page is pointed at, and how to point it somewhere else.
  *
- * Only the operator's explicit choice travels through the context; resolving it
- * against the host is `pageSelection()`, which the panel hooks call because they
- * already hold the snapshot. Keeping the context to the choice alone means a
- * page that has never been pointed anywhere costs nothing and re-renders for
- * nothing.
+ * Only the operator's explicit choice and the page's configured source travel
+ * through the context; resolving them against the host is `pageSelection()`,
+ * which the panel hooks call because they already hold the snapshot. Keeping
+ * the context to the choice alone means a page that has never been pointed
+ * anywhere costs nothing and re-renders for nothing.
  */
 export interface PageSelectionValue {
-  /** What the operator pointed this page at. Empty = follow the host. */
+  /** What the operator pointed this page at. Empty = follow the source, then the host. */
   chosen: SelectedTargets
+  /** The page's configured default (`DashboardPage.source`). Absent = automatic. */
+  source?: PageSource
   /** Point every following panel at one GPU; null goes back to the host default. */
   selectGpu: (index: number | null) => void
   /** Point every following panel at one engine; null goes back to the host default. */

--- a/frontend/src/lib/dashboard/bindings.test.ts
+++ b/frontend/src/lib/dashboard/bindings.test.ts
@@ -156,12 +156,31 @@ describe('resolveGpuBinding', () => {
 
 describe('resolveEngineBinding', () => {
   const engines = [engine('http://localhost:8000'), engine('http://localhost:8001')]
+  const pageOn = (endpoint: string) => ({ kind: 'engine', endpoint }) as const
 
   it('follows the page selection', () => {
-    expect(resolveEngineBinding(FOLLOW, engines, 'http://localhost:8001')).toEqual({
+    expect(resolveEngineBinding(FOLLOW, engines, pageOn('http://localhost:8001'))).toEqual({
       status: 'resolved',
       target: engines[1],
     })
+  })
+
+  it('follows a page configured for all models to the aggregate', () => {
+    expect(resolveEngineBinding(FOLLOW, engines, { kind: 'all' })).toEqual({
+      status: 'aggregate',
+    })
+  })
+
+  it('never routes a pinned engine to the aggregate', () => {
+    // A pin names one engine; the page showing all models is exactly when the
+    // pin is there to keep showing that one.
+    expect(
+      resolveEngineBinding(
+        { kind: 'engine', endpoint: 'http://localhost:8000' },
+        engines,
+        { kind: 'all' },
+      ),
+    ).toEqual({ status: 'resolved', target: engines[0] })
   })
 
   it('resolves a pinned engine that is running', () => {
@@ -179,7 +198,7 @@ describe('resolveEngineBinding', () => {
   })
 
   it('reports a followed selection that is gone as missing', () => {
-    expect(resolveEngineBinding(FOLLOW, engines, 'http://localhost:9999')).toEqual({
+    expect(resolveEngineBinding(FOLLOW, engines, pageOn('http://localhost:9999'))).toEqual({
       status: 'missing',
       requested: 'http://localhost:9999',
     })

--- a/frontend/src/lib/dashboard/bindings.ts
+++ b/frontend/src/lib/dashboard/bindings.ts
@@ -20,6 +20,7 @@
 import { findEngineByEndpoint, findGpuByIndex, type GpuIdentity } from '@/lib/identity'
 import type { EngineSnapshot } from '@/types/metrics'
 import { isRecord } from './json'
+import type { PageEngineTarget } from './selection'
 
 /**
  * Where a panel gets its target.
@@ -130,20 +131,40 @@ export function resolveGpuBinding<T extends GpuIdentity>(
 }
 
 /**
+ * What an engine binding turned into: any single-target resolution, or the
+ * aggregate — every engine at once, which only a following panel on a page
+ * configured for all models resolves to. A pin always names one engine, so the
+ * aggregate never reaches a pinned panel.
+ */
+export type EngineBindingResolution<T> = BindingResolution<T> | { status: 'aggregate' }
+
+/**
  * Resolves an engine panel's binding against the engines detected on this host.
  *
- * `pageEngineEndpoint` is the page-level selection. A host with no engines, or a
- * page with no engine selected, is `unselected` — hardware monitoring is still
- * useful there, so it is a graceful state rather than a failure.
+ * `pageTarget` is the page-level selection: one engine, or all of them
+ * combined. A host with no engines, or a page with no engine selected, is
+ * `unselected` — hardware monitoring is still useful there, so it is a graceful
+ * state rather than a failure.
  */
 export function resolveEngineBinding<T extends Pick<EngineSnapshot, 'endpoint'>>(
   binding: PanelBinding,
   engines: readonly T[],
-  pageEngineEndpoint: string | null | undefined,
-): BindingResolution<T> {
+  pageTarget: PageEngineTarget | null | undefined,
+): EngineBindingResolution<T> {
   if (binding.kind !== 'follow' && binding.kind !== 'engine') return { status: 'unreadable' }
 
-  const endpoint = binding.kind === 'engine' ? binding.endpoint : pageEngineEndpoint
+  if (binding.kind === 'follow' && pageTarget?.kind === 'all') {
+    // Whether an aggregate over a host with nothing running is worth rendering
+    // is the caller's question — this side only says what the binding names.
+    return { status: 'aggregate' }
+  }
+
+  const endpoint =
+    binding.kind === 'engine'
+      ? binding.endpoint
+      : pageTarget?.kind === 'engine'
+        ? pageTarget.endpoint
+        : null
   if (!endpoint) return { status: 'unselected' }
 
   const target = findEngineByEndpoint(engines, endpoint)

--- a/frontend/src/lib/dashboard/migrations.test.ts
+++ b/frontend/src/lib/dashboard/migrations.test.ts
@@ -25,7 +25,48 @@ interface MigrationFixture {
   expect: (document: NonNullable<ReturnType<typeof parseDashboardDocument>>) => void
 }
 
-const MIGRATION_FIXTURES: MigrationFixture[] = []
+const MIGRATION_FIXTURES: MigrationFixture[] = [
+  {
+    name: 'a v1 document, from before the per-page source',
+    // As the v1 build's serializer actually wrote it: full geometry, explicit
+    // binding and window, no `source` anywhere.
+    stored: {
+      version: 1,
+      pages: [
+        {
+          id: 'overview',
+          name: 'Overview',
+          panels: [
+            {
+              id: 'decode',
+              type: 'engine-decode-throughput',
+              geometry: { x: 0, y: 0, w: 6, h: 3 },
+              binding: { kind: 'follow' },
+              window: '5m',
+            },
+            {
+              id: 'pinned',
+              type: 'gpu-utilization',
+              title: 'My GPU',
+              geometry: { x: 6, y: 0, w: 3, h: 3 },
+              binding: { kind: 'gpu', index: 1 },
+              window: '15m',
+            },
+          ],
+        },
+      ],
+    },
+    from: 1,
+    expect: (document) => {
+      // The addition was the optional source, so a v1 page comes through
+      // whole and without one — absent is automatic, which is what it was.
+      expect(document.pages).toHaveLength(1)
+      expect(document.pages[0].source).toBeUndefined()
+      expect(document.pages[0].panels.map((panel) => panel.id)).toEqual(['decode', 'pinned'])
+      expect(document.pages[0].panels[1].binding).toEqual({ kind: 'gpu', index: 1 })
+    },
+  },
+]
 
 /** A stand-in migration, so the runner's chaining is covered before there is a real one. */
 function stub(from: number, mark: string): DashboardMigration {
@@ -71,7 +112,6 @@ describe('runMigrations against the real migration path', () => {
     })
   })
 
-  // Empty until the first migration exists; each fixture then becomes a spec.
   for (const fixture of MIGRATION_FIXTURES) {
     it(`migrates ${fixture.name} into a document that still parses`, () => {
       const outcome = runMigrations(fixture.stored, fixture.from)

--- a/frontend/src/lib/dashboard/migrations.ts
+++ b/frontend/src/lib/dashboard/migrations.ts
@@ -1,10 +1,12 @@
 /**
  * Bringing an older document forward to the version this build reads.
  *
- * There are no migrations yet, and there will not be one until a change is not
- * additive — this is the lazy half of the versioning decision. The eager half is
- * that the version field ships from day one, because it cannot be added later
- * without sniffing at a document's shape and guessing what wrote it.
+ * An additive change gets an identity migration — the bump is what protects the
+ * new field from an older build's lossy save, and the migration merely walks
+ * the version forward. Rewriting waits for a change that is not additive; this
+ * is the lazy half of the versioning decision. The eager half is that the
+ * version field ships from day one, because it cannot be added later without
+ * sniffing at a document's shape and guessing what wrote it.
  *
  * Two rules hold whatever the migrations end up doing:
  *
@@ -40,13 +42,23 @@ export interface MigrationPath {
 }
 
 /**
- * The real path: empty, targeting the current version.
+ * v1 → v2: the per-page `source` arrived. Additive — an absent source means
+ * automatic, which is exactly what every v1 page was — so nothing is rewritten;
+ * the runner stamps the version.
+ */
+const addPageSource: DashboardMigration = {
+  from: 1,
+  migrate: (document) => ({ ...document }),
+}
+
+/**
+ * The real path, targeting the current version.
  *
  * Adding a migration means appending it here, bumping
  * `DASHBOARD_SCHEMA_VERSION`, and adding a fixture to `migrations.test.ts`.
  */
 export const DASHBOARD_MIGRATION_PATH: MigrationPath = {
-  migrations: [],
+  migrations: [addPageSource],
   target: DASHBOARD_SCHEMA_VERSION,
 }
 

--- a/frontend/src/lib/dashboard/pageSource.test.ts
+++ b/frontend/src/lib/dashboard/pageSource.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ALL_MODELS,
+  pageSourceChoices,
+  pageSourceFromChoice,
+  readPageSource,
+} from './pageSource'
+import type { EngineSnapshot } from '@/types/metrics'
+
+function engine(endpoint: string, model: string | null): EngineSnapshot {
+  return {
+    engine_type: 'Vllm',
+    endpoint,
+    status: { type: 'Running' },
+    model: model
+      ? {
+          name: model,
+          parameter_size: null,
+          quantization: null,
+          precision: null,
+          tensor_type: null,
+          model_type: null,
+          pipeline_tag: null,
+        }
+      : null,
+    metrics: null,
+    recent_requests: [],
+    deployment_mode: 'Native',
+  }
+}
+
+describe('readPageSource', () => {
+  it('reads the two stored kinds', () => {
+    expect(readPageSource({ kind: 'all' })).toEqual({ kind: 'all' })
+    expect(readPageSource({ kind: 'engine', endpoint: 'http://localhost:8000' })).toEqual({
+      kind: 'engine',
+      endpoint: 'http://localhost:8000',
+    })
+  })
+
+  it('reads everything else as automatic', () => {
+    expect(readPageSource(undefined)).toBeUndefined()
+    expect(readPageSource(null)).toBeUndefined()
+    expect(readPageSource('all')).toBeUndefined()
+    expect(readPageSource({ kind: 'engine' })).toBeUndefined()
+    expect(readPageSource({ kind: 'engine', endpoint: '' })).toBeUndefined()
+    expect(readPageSource({ kind: 'everything' })).toBeUndefined()
+  })
+})
+
+describe('pageSourceChoices', () => {
+  const engines = [
+    engine('http://localhost:8000', 'Qwen/Qwen3-8B'),
+    engine('http://localhost:8001', null),
+  ]
+
+  it('offers automatic, all models, and every engine, named by its model', () => {
+    const { value, choices } = pageSourceChoices(undefined, engines)
+
+    expect(value).toBe('auto')
+    expect(choices.map((choice) => choice.label)).toEqual([
+      'Automatic — first serving model',
+      'All models — combined',
+      'Qwen3-8B — vLLM localhost:8000',
+      'No model loaded — vLLM localhost:8001',
+    ])
+  })
+
+  it('selects the stored source', () => {
+    expect(pageSourceChoices(ALL_MODELS, engines).value).toBe('all')
+    expect(
+      pageSourceChoices({ kind: 'engine', endpoint: 'http://localhost:8001' }, engines).value,
+    ).toBe('engine:http://localhost:8001')
+  })
+
+  it('keeps a configured engine that is not on this host, marked absent', () => {
+    // Hiding it is how a page would silently end up showing something else.
+    const { value, choices } = pageSourceChoices(
+      { kind: 'engine', endpoint: 'http://localhost:9999' },
+      engines,
+    )
+
+    expect(value).toBe('engine:http://localhost:9999')
+    expect(choices.at(-1)).toEqual({
+      value: 'engine:http://localhost:9999',
+      label: 'http://localhost:9999 (not on this host)',
+      absent: true,
+    })
+  })
+
+  it('round-trips every choice it offers', () => {
+    const { choices } = pageSourceChoices(undefined, engines)
+
+    expect(pageSourceFromChoice(choices[0].value)).toBeNull()
+    expect(pageSourceFromChoice(choices[1].value)).toEqual({ kind: 'all' })
+    expect(pageSourceFromChoice(choices[2].value)).toEqual({
+      kind: 'engine',
+      endpoint: 'http://localhost:8000',
+    })
+  })
+})
+
+describe('pageSourceFromChoice', () => {
+  it('reads anything outside the grammar as automatic', () => {
+    expect(pageSourceFromChoice('auto')).toBeNull()
+    expect(pageSourceFromChoice('engine:')).toBeNull()
+    expect(pageSourceFromChoice('gpu:0')).toBeNull()
+    expect(pageSourceFromChoice('')).toBeNull()
+  })
+})

--- a/frontend/src/lib/dashboard/pageSource.ts
+++ b/frontend/src/lib/dashboard/pageSource.ts
@@ -1,0 +1,136 @@
+/**
+ * What a page's following panels show by default: one model, every model
+ * combined, or whatever the host happens to be serving.
+ *
+ * This is the page-level half of the binding model in `bindings.ts`, made
+ * persistent. A panel bound `follow` defers to the page, and until now the page
+ * could only answer with the host's default — the first running engine. The
+ * source lets the operator author the answer into the document itself: a
+ * "Qwen page" that opens on Qwen for every colleague and kiosk, or an overview
+ * page whose engine panels show the combined figures across every engine.
+ *
+ * **Absent means automatic.** A page with no source follows the host's default
+ * exactly as every page did before the field existed, which is what lets the
+ * schema migration be a no-op and the shipped preset stay a single static
+ * document.
+ */
+
+import { engineDescription, shortModelName } from '@/lib/format'
+import type { EngineSnapshot } from '@/types/metrics'
+import { isRecord } from './json'
+
+/**
+ * The operator's choice, as stored on the page. Absent (`undefined`) is the
+ * third state — automatic — and is deliberately not a kind of its own: absent
+ * is what "never configured" looks like everywhere else in the document, and a
+ * stored `auto` would freeze the distinction between the two.
+ *
+ * Deeply readonly for the same reason a binding is: sources are values,
+ * replaced rather than edited.
+ */
+export type PageSource =
+  /** Every engine at once — following engine panels show the combined figures. */
+  | { readonly kind: 'all' }
+  /** One engine, named by its endpoint — the same identity a pinned panel uses. */
+  | { readonly kind: 'engine'; readonly endpoint: string }
+
+/** The all-models source. One value, so reads share it like `FOLLOW`. */
+export const ALL_MODELS: PageSource = { kind: 'all' }
+
+/**
+ * Reads a persisted source. Absent or malformed becomes `undefined` —
+ * automatic. Unlike a panel binding, a source that cannot be read is not kept
+ * as a state of its own: no panel label promises the lost target (a following
+ * panel's label is whatever the page resolves to, and says so), and automatic
+ * is the state every page began in.
+ */
+export function readPageSource(raw: unknown): PageSource | undefined {
+  if (!isRecord(raw)) return undefined
+  if (raw.kind === 'all') return ALL_MODELS
+  if (raw.kind === 'engine' && typeof raw.endpoint === 'string' && raw.endpoint.length > 0) {
+    return { kind: 'engine', endpoint: raw.endpoint }
+  }
+  return undefined
+}
+
+/** The option value of the automatic source, which is not stored. */
+const AUTO_CHOICE = 'auto'
+
+/** The option value of the all-models source. */
+const ALL_CHOICE = 'all'
+
+/** One thing the page could show, as the config control offers it. */
+export interface PageSourceChoice {
+  /** Round-trips through `pageSourceFromChoice`; safe as an option value. */
+  value: string
+  label: string
+  /** The engine is not on this host — a source left dangling. */
+  absent?: boolean
+}
+
+/** Everything the control needs: what to offer, and what is chosen now. */
+export interface PageSourceControlModel {
+  value: string
+  choices: PageSourceChoice[]
+}
+
+/**
+ * The sources a page can be pointed at, with the one it holds selected.
+ *
+ * Same prohibition as `bindingChoices`: a source naming an engine that is not
+ * on this host keeps its own option, marked absent and selected, rather than
+ * being quietly shown as something else.
+ */
+export function pageSourceChoices(
+  source: PageSource | undefined,
+  engines: readonly EngineSnapshot[],
+): PageSourceControlModel {
+  const choices: PageSourceChoice[] = [
+    { value: AUTO_CHOICE, label: 'Automatic — first serving model' },
+    { value: ALL_CHOICE, label: 'All models — combined' },
+    ...engines.map(engineChoice),
+  ]
+
+  const value =
+    source === undefined ? AUTO_CHOICE : source.kind === 'all' ? ALL_CHOICE : choiceOf(source.endpoint)
+
+  const missing =
+    source?.kind === 'engine' && !engines.some((engine) => engine.endpoint === source.endpoint)
+      ? { value, label: `${source.endpoint} (not on this host)`, absent: true }
+      : null
+
+  return { value, choices: missing ? [...choices, missing] : choices }
+}
+
+/**
+ * The source a chosen option means. Null is automatic — the caller removes the
+ * field rather than storing a sentinel. Anything not in this module's own
+ * grammar reads as automatic too; the values come from `pageSourceChoices`, so
+ * there is no legitimate third case.
+ */
+export function pageSourceFromChoice(value: string): PageSource | null {
+  if (value === ALL_CHOICE) return ALL_MODELS
+
+  const separator = value.indexOf(':')
+  if (value.slice(0, separator) === 'engine') {
+    const endpoint = value.slice(separator + 1)
+    if (endpoint.length > 0) return { kind: 'engine', endpoint }
+  }
+
+  return null
+}
+
+/**
+ * An engine as the control names it: the model first, because choosing a model
+ * is what an operator opens this control to do; the engine after it, because
+ * two engines can serve the same model.
+ */
+function engineChoice(engine: EngineSnapshot): PageSourceChoice {
+  const model = engine.model?.name ? shortModelName(engine.model.name) : 'No model loaded'
+  return { value: choiceOf(engine.endpoint), label: `${model} — ${engineDescription(engine)}` }
+}
+
+/** The one place an endpoint becomes an option value, mirroring `bindingChoices`. */
+function choiceOf(endpoint: string): string {
+  return `engine:${endpoint}`
+}

--- a/frontend/src/lib/dashboard/pages.test.ts
+++ b/frontend/src/lib/dashboard/pages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { addPage, removePage, renamePage } from './pages'
+import { addPage, removePage, renamePage, setPageSource } from './pages'
+import { ALL_MODELS } from './pageSource'
 import { DASHBOARD_SCHEMA_VERSION, type DashboardDocument, type DashboardPage } from './schema'
 
 function documentOf(...pages: Array<Partial<DashboardPage>>): DashboardDocument {
@@ -8,6 +9,7 @@ function documentOf(...pages: Array<Partial<DashboardPage>>): DashboardDocument 
     pages: pages.map((page, index) => ({
       id: page.id ?? `page-${index + 1}`,
       name: page.name ?? `Page ${index + 1}`,
+      ...(page.source === undefined ? {} : { source: page.source }),
       panels: page.panels ?? [],
     })),
   }
@@ -96,6 +98,53 @@ describe('renamePage', () => {
     const before = documentOf({ id: 'a', name: 'Overview' })
 
     expect(renamePage(before, 'gone', 'Anything')).toBe(before)
+  })
+})
+
+describe('setPageSource', () => {
+  it('stores the chosen source on the named page and only there', () => {
+    const next = setPageSource(
+      documentOf({ id: 'overview' }, { id: 'global' }),
+      'global',
+      ALL_MODELS,
+    )
+
+    expect(next.pages[0].source).toBeUndefined()
+    expect(next.pages[1].source).toEqual({ kind: 'all' })
+  })
+
+  it('replaces one engine with another', () => {
+    const configured = documentOf({
+      id: 'p',
+      source: { kind: 'engine', endpoint: 'http://localhost:8000' },
+    })
+    const next = setPageSource(configured, 'p', { kind: 'engine', endpoint: 'http://localhost:8001' })
+
+    expect(next.pages[0].source).toEqual({ kind: 'engine', endpoint: 'http://localhost:8001' })
+  })
+
+  it('removes the field on the way back to automatic, rather than storing a sentinel', () => {
+    // Absent is what "never configured" looks like everywhere else in the
+    // document, and it is what lets the page follow a host that changes.
+    const configured = documentOf({ id: 'p', source: ALL_MODELS })
+    const next = setPageSource(configured, 'p', null)
+
+    expect(next.pages[0]).not.toHaveProperty('source')
+  })
+
+  it('returns the same document when nothing would change', () => {
+    const document = documentOf({ id: 'p', source: ALL_MODELS }, { id: 'q' })
+
+    expect(setPageSource(document, 'p', { kind: 'all' })).toBe(document)
+    expect(setPageSource(document, 'q', null)).toBe(document)
+    expect(setPageSource(document, 'missing', ALL_MODELS)).toBe(document)
+  })
+
+  it('keeps the untouched pages by identity', () => {
+    const document = documentOf({ id: 'p' }, { id: 'q' })
+    const next = setPageSource(document, 'p', ALL_MODELS)
+
+    expect(next.pages[1]).toBe(document.pages[1])
   })
 })
 

--- a/frontend/src/lib/dashboard/pages.ts
+++ b/frontend/src/lib/dashboard/pages.ts
@@ -23,6 +23,7 @@
  */
 
 import { pageSlug } from './routes'
+import type { PageSource } from './pageSource'
 import type { DashboardDocument, DashboardPage } from './schema'
 
 /** A page was made; `pageId` is the one to navigate to. */
@@ -76,6 +77,45 @@ export function renamePage(
       candidate.id === pageId ? { ...candidate, name: trimmed } : candidate,
     ),
   }
+}
+
+/**
+ * The document with one page's source replaced — what it shows by default: one
+ * model, all of them combined, or (with `null`) back to automatic.
+ *
+ * A page edit like renaming, not a layout edit: choosing what a page shows is
+ * already the deliberate, named request that an edit session exists to
+ * distinguish a drag from, so the caller writes it when it is made.
+ *
+ * Null **removes** the field rather than storing a sentinel, because absent is
+ * what "never configured" looks like everywhere else in the document.
+ */
+export function setPageSource(
+  document: DashboardDocument,
+  pageId: string,
+  source: PageSource | null,
+): DashboardDocument {
+  const page = document.pages.find((candidate) => candidate.id === pageId)
+  if (!page || sameSource(page.source, source ?? undefined)) return document
+
+  return {
+    ...document,
+    pages: document.pages.map((candidate) => {
+      if (candidate.id !== pageId) return candidate
+      if (source === null) {
+        const cleared = { ...candidate }
+        delete cleared.source
+        return cleared
+      }
+      return { ...candidate, source }
+    }),
+  }
+}
+
+function sameSource(a: PageSource | undefined, b: PageSource | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b
+  if (a.kind !== b.kind) return false
+  return a.kind !== 'engine' || b.kind !== 'engine' || a.endpoint === b.endpoint
 }
 
 /** What became of a request to delete a page. */

--- a/frontend/src/lib/dashboard/schema.test.ts
+++ b/frontend/src/lib/dashboard/schema.test.ts
@@ -209,6 +209,39 @@ describe('parseDashboardDocument', () => {
     expect(document!.pages[0].panels[1].title).toBeUndefined()
   })
 
+  it('keeps a page source naming an engine or all models', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          { id: 'qwen', name: 'Qwen', source: { kind: 'engine', endpoint: 'http://localhost:8000' }, panels: [] },
+          { id: 'global', name: 'Global', source: { kind: 'all' }, panels: [] },
+        ],
+      }),
+    )
+
+    expect(document!.pages[0].source).toEqual({ kind: 'engine', endpoint: 'http://localhost:8000' })
+    expect(document!.pages[1].source).toEqual({ kind: 'all' })
+  })
+
+  it('reads an absent or unreadable page source as automatic', () => {
+    // Automatic is the state every page began in, and no panel label promises
+    // the lost target — a following panel names whatever it resolves to.
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          { id: 'a', name: 'A', panels: [] },
+          { id: 'b', name: 'B', source: { kind: 'engine' }, panels: [] },
+          { id: 'c', name: 'C', source: 'all', panels: [] },
+          { id: 'd', name: 'D', source: { kind: 'everything' }, panels: [] },
+        ],
+      }),
+    )
+
+    for (const page of document!.pages) {
+      expect(page.source).toBeUndefined()
+    }
+  })
+
   it('drops a panel that is not an object at all', () => {
     const document = parseDashboardDocument(
       rawDocument({
@@ -301,6 +334,24 @@ describe('serializeDashboardDocument', () => {
     expect(JSON.parse(serializeDashboardDocument(document)).pages[0].panels[0]).not.toHaveProperty(
       'title',
     )
+  })
+
+  it('round-trips a page source and omits one that was never set', () => {
+    const document = parseDashboardDocument(
+      rawDocument({
+        pages: [
+          { id: 'auto', name: 'Auto', panels: [] },
+          { id: 'global', name: 'Global', source: { kind: 'all' }, panels: [] },
+          { id: 'qwen', name: 'Qwen', source: { kind: 'engine', endpoint: 'http://localhost:8000' }, panels: [] },
+        ],
+      }),
+    )!
+    const written = JSON.parse(serializeDashboardDocument(document))
+
+    expect(written.pages[0]).not.toHaveProperty('source')
+    expect(written.pages[1].source).toEqual({ kind: 'all' })
+    expect(written.pages[2].source).toEqual({ kind: 'engine', endpoint: 'http://localhost:8000' })
+    expect(parseDashboardDocument(written)).toEqual(document)
   })
 })
 

--- a/frontend/src/lib/dashboard/schema.ts
+++ b/frontend/src/lib/dashboard/schema.ts
@@ -23,18 +23,23 @@
 import { readBinding, type PanelBinding } from './bindings'
 import { readGeometry, type PanelGeometry } from './grid'
 import { isRecord } from './json'
+import { readPageSource, type PageSource } from './pageSource'
 import { defaultPanelTitle } from './panels'
 import { TIME_WINDOW_SECONDS, type TimeWindow } from '@/types/events'
 
 /**
  * The schema version this build reads and writes.
  *
- * Bump it when a change is not additive, and add the migration that goes with
- * it. There is no down-migration: a document from a newer version falls back to
- * the preset with a banner, which is what makes rolling the dashboard back
- * recoverable.
+ * Bump it for **every** shape change, additive ones included, and add the
+ * migration that goes with it — an additive migration is a no-op, but the bump
+ * is what keeps an older build from parsing the document, dropping the field it
+ * has never heard of, and saving the loss. There is no down-migration: a
+ * document from a newer version falls back to the preset with a banner, which
+ * is what makes rolling the dashboard back recoverable.
+ *
+ * - v2 added the optional per-page `source` (`lib/dashboard/pageSource`).
  */
-export const DASHBOARD_SCHEMA_VERSION = 1
+export const DASHBOARD_SCHEMA_VERSION = 2
 
 /** Time window a panel's chart covers when the operator has not chosen one. */
 export const DEFAULT_TIME_WINDOW: TimeWindow = '5m'
@@ -53,6 +58,11 @@ export interface DashboardPage {
    */
   id: string
   name: string
+  /**
+   * What the page's following panels show by default. Absent means automatic —
+   * the host's own default — which is where every page starts.
+   */
+  source?: PageSource
   panels: DashboardPanel[]
 }
 
@@ -108,6 +118,16 @@ export function serializeDashboardDocument(document: DashboardDocument): string 
     pages: document.pages.map((page) => ({
       id: page.id,
       name: page.name,
+      // Omitted rather than written as a sentinel, so "never configured" stays
+      // what absence means everywhere else in the document.
+      ...(page.source === undefined
+        ? {}
+        : {
+            source:
+              page.source.kind === 'engine'
+                ? { kind: 'engine', endpoint: page.source.endpoint }
+                : { kind: 'all' },
+          }),
       panels: page.panels.map((panel) => ({
         id: panel.id,
         type: panel.type,
@@ -134,10 +154,12 @@ export function panelTitle(panel: Pick<DashboardPanel, 'type' | 'title'>): strin
 
 function readPage(raw: Record<string, unknown>): DashboardPage {
   const panels = Array.isArray(raw.panels) ? raw.panels.filter(isRecord).map(readPanel) : []
+  const source = readPageSource(raw.source)
 
   return {
     id: readId(raw.id),
     name: readText(raw.name) ?? '',
+    ...(source === undefined ? {} : { source }),
     panels: withUniqueIds(panels, 'panel'),
   }
 }

--- a/frontend/src/lib/dashboard/selection.test.ts
+++ b/frontend/src/lib/dashboard/selection.test.ts
@@ -5,6 +5,7 @@ import {
   withSelectedEngine,
   withSelectedGpu,
 } from './selection'
+import { ALL_MODELS } from './pageSource'
 import type { EngineSnapshot, GpuMetrics, MetricsSnapshot } from '@/types/metrics'
 
 function gpu(index: number | null): GpuMetrics {
@@ -44,13 +45,13 @@ function snapshot(gpus: GpuMetrics[], engines: EngineSnapshot[]): Pick<
 }
 
 describe('pageSelection', () => {
-  it('follows the primary GPU and the running engine when the operator has chosen neither', () => {
+  it('follows the primary GPU and the running engine when nothing is chosen or configured', () => {
     // This is what makes the shipped preset work unmodified on any machine.
     const host = snapshot([gpu(0), gpu(1)], [engine('http://localhost:8000')])
 
     expect(pageSelection(host, {})).toEqual({
       gpuIndex: 0,
-      engineEndpoint: 'http://localhost:8000',
+      engineTarget: { kind: 'engine', endpoint: 'http://localhost:8000' },
     })
   })
 
@@ -60,7 +61,10 @@ describe('pageSelection', () => {
       [engine('http://localhost:8000', { type: 'Stopped' }), engine('http://localhost:8001')],
     )
 
-    expect(pageSelection(host, {}).engineEndpoint).toBe('http://localhost:8001')
+    expect(pageSelection(host, {}).engineTarget).toEqual({
+      kind: 'engine',
+      endpoint: 'http://localhost:8001',
+    })
   })
 
   it('falls back to the first engine when none is running', () => {
@@ -72,7 +76,10 @@ describe('pageSelection', () => {
       ],
     )
 
-    expect(pageSelection(host, {}).engineEndpoint).toBe('http://localhost:8000')
+    expect(pageSelection(host, {}).engineTarget).toEqual({
+      kind: 'engine',
+      endpoint: 'http://localhost:8000',
+    })
   })
 
   it('normalizes the index of a GPU reported without one', () => {
@@ -82,7 +89,35 @@ describe('pageSelection', () => {
   it('selects nothing for an engine the host is not running', () => {
     // Engine panels degrade to an empty state here; the hardware panels beside
     // them keep working, which is the point.
-    expect(pageSelection(snapshot([gpu(0)], []), {}).engineEndpoint).toBeNull()
+    expect(pageSelection(snapshot([gpu(0)], []), {}).engineTarget).toBeNull()
+  })
+
+  it('resolves a page configured for one engine to that engine', () => {
+    const host = snapshot(
+      [gpu(0)],
+      [engine('http://localhost:8000'), engine('http://localhost:8001')],
+    )
+
+    expect(
+      pageSelection(host, {}, { kind: 'engine', endpoint: 'http://localhost:8001' }).engineTarget,
+    ).toEqual({ kind: 'engine', endpoint: 'http://localhost:8001' })
+  })
+
+  it('resolves a page configured for all models to the aggregate', () => {
+    const host = snapshot([gpu(0)], [engine('http://localhost:8000')])
+
+    expect(pageSelection(host, {}, ALL_MODELS).engineTarget).toEqual({ kind: 'all' })
+  })
+
+  it('keeps a configured engine whose target has gone away', () => {
+    // Panels report it as missing. Nudging the page back to whatever is
+    // running would hide from the operator that the engine their page names
+    // has stopped — and would show its numbers under the other engine's name.
+    const host = snapshot([gpu(0)], [engine('http://localhost:8000')])
+
+    expect(
+      pageSelection(host, {}, { kind: 'engine', endpoint: 'http://localhost:9999' }).engineTarget,
+    ).toEqual({ kind: 'engine', endpoint: 'http://localhost:9999' })
   })
 
   it('honours what the operator chose over the host defaults', () => {
@@ -93,18 +128,28 @@ describe('pageSelection', () => {
 
     expect(
       pageSelection(host, { gpuIndex: 1, engineEndpoint: 'http://localhost:8001' }),
-    ).toEqual({ gpuIndex: 1, engineEndpoint: 'http://localhost:8001' })
+    ).toEqual({ gpuIndex: 1, engineTarget: { kind: 'engine', endpoint: 'http://localhost:8001' } })
+  })
+
+  it('honours a session choice over the configured source', () => {
+    // The source is the page's default; a choice made while looking at the
+    // page is the operator asking to see something else right now.
+    const host = snapshot(
+      [gpu(0)],
+      [engine('http://localhost:8000'), engine('http://localhost:8001')],
+    )
+
+    expect(
+      pageSelection(host, { engineEndpoint: 'http://localhost:8000' }, ALL_MODELS).engineTarget,
+    ).toEqual({ kind: 'engine', endpoint: 'http://localhost:8000' })
   })
 
   it('keeps a choice whose target has gone away', () => {
-    // Panels report it as missing. Nudging the selection back to whatever is
-    // present would hide from the operator that the engine they picked has
-    // stopped — and would show its numbers under the other engine's name.
     const host = snapshot([gpu(0)], [engine('http://localhost:8000')])
 
     expect(pageSelection(host, { gpuIndex: 3, engineEndpoint: 'http://localhost:9999' })).toEqual({
       gpuIndex: 3,
-      engineEndpoint: 'http://localhost:9999',
+      engineTarget: { kind: 'engine', endpoint: 'http://localhost:9999' },
     })
   })
 
@@ -115,8 +160,14 @@ describe('pageSelection', () => {
   it('keeps a choice made before the first snapshot arrives', () => {
     expect(pageSelection(null, { gpuIndex: 1 })).toEqual({
       gpuIndex: 1,
-      engineEndpoint: null,
+      engineTarget: null,
     })
+  })
+
+  it('resolves a configured source before the first snapshot arrives', () => {
+    // A page configured for all models must not flash the host default while
+    // the socket connects.
+    expect(pageSelection(null, {}, ALL_MODELS).engineTarget).toEqual({ kind: 'all' })
   })
 })
 

--- a/frontend/src/lib/dashboard/selection.ts
+++ b/frontend/src/lib/dashboard/selection.ts
@@ -1,6 +1,6 @@
 /**
- * The page-level selection: the GPU and the engine a page's `follow` panels
- * point at.
+ * The page-level selection: the GPU and the engine target a page's `follow`
+ * panels point at.
  *
  * This is the other half of the binding model in `bindings.ts`. A pinned panel
  * names its own target; every other panel defers to the selection here, which is
@@ -9,29 +9,42 @@
  * page moves with it, coherently, because every following panel reads the same
  * value.
  *
- * The selection has two layers. What the operator **chose** is stored sparsely —
- * an absent key means they have never chosen, not that they chose nothing — and
- * the host's own defaults fill the gaps. Keeping them apart matters on a machine
- * whose engines come and go: an operator who chose nothing follows whatever is
- * running, while an operator who chose engine B keeps pointing at B, and the
- * panels say B is missing rather than quietly showing engine A.
+ * The selection has three layers, strongest first. What the operator **chose in
+ * this session** is stored sparsely — an absent key means they have never
+ * chosen, not that they chose nothing. Under that sits the page's **configured
+ * source** (`pageSource.ts`), which is the choice written into the document:
+ * one engine, or every engine combined. The host's own defaults fill what
+ * remains. Keeping the layers apart matters on a machine whose engines come and
+ * go: an unconfigured page follows whatever is running, while a page configured
+ * for engine B keeps pointing at B, and the panels say B is missing rather than
+ * quietly showing engine A.
  */
 
 import { gpuIndexOf, snapshotGpus } from '@/lib/identity'
 import type { EngineSnapshot, MetricsSnapshot } from '@/types/metrics'
+import type { PageSource } from './pageSource'
+
+/**
+ * What a page's following engine panels resolve to: one engine by endpoint, or
+ * the aggregate over all of them.
+ */
+export type PageEngineTarget =
+  | { kind: 'engine'; endpoint: string }
+  /** Every engine at once — the combined figures, not any one engine's. */
+  | { kind: 'all' }
 
 /** What a page's `follow` panels resolve against. */
 export interface PageSelection {
   /** The GPU index following panels show. Null when the host reports no GPU. */
   gpuIndex: number | null
-  /** The endpoint following panels show. Null when no engine is running. */
-  engineEndpoint: string | null
+  /** The engine target following panels show. Null when no engine is running. */
+  engineTarget: PageEngineTarget | null
 }
 
 /**
- * What the operator explicitly pointed the page at. A key is present only once
- * they have chosen; absent means "follow the host", which is where every page
- * starts.
+ * What the operator explicitly pointed the page at, for this session. A key is
+ * present only once they have chosen; absent means "defer to the page's source,
+ * then the host", which is where every page starts.
  */
 export interface SelectedTargets {
   readonly gpuIndex?: number
@@ -39,30 +52,25 @@ export interface SelectedTargets {
 }
 
 /** Nothing to point at: no snapshot, or a host with neither GPU nor engine. */
-export const NO_SELECTION: PageSelection = { gpuIndex: null, engineEndpoint: null }
+export const NO_SELECTION: PageSelection = { gpuIndex: null, engineTarget: null }
 
 /**
  * The selection a page resolves to on this host.
  *
- * An explicit choice is kept verbatim, including one naming a target that is no
- * longer here — panels report that as missing, which is the whole point: the
- * operator who changed an engine's port has to see which panels now point at
- * nothing. Only an unchosen target falls back to the host's default.
+ * An explicit choice — the session's, or the page's configured source — is kept
+ * verbatim, including one naming an engine that is no longer here: panels
+ * report that as missing, which is the whole point. The operator who changed an
+ * engine's port has to see which pages now point at nothing. Only an unchosen
+ * target falls back to the host's default.
  */
 export function pageSelection(
   snapshot: Pick<MetricsSnapshot, 'gpu' | 'gpus' | 'engines'> | null,
   chosen: SelectedTargets,
+  source?: PageSource,
 ): PageSelection {
-  if (!snapshot) {
-    return {
-      gpuIndex: chosen.gpuIndex ?? null,
-      engineEndpoint: chosen.engineEndpoint ?? null,
-    }
-  }
-
   return {
-    gpuIndex: chosen.gpuIndex ?? defaultGpuIndex(snapshot),
-    engineEndpoint: chosen.engineEndpoint ?? defaultEngineEndpoint(snapshot.engines),
+    gpuIndex: chosen.gpuIndex ?? (snapshot ? defaultGpuIndex(snapshot) : null),
+    engineTarget: engineTarget(snapshot, chosen, source),
   }
 }
 
@@ -79,6 +87,22 @@ export function withSelectedEngine(
   return endpoint === null
     ? without(chosen, 'engineEndpoint')
     : { ...chosen, engineEndpoint: endpoint }
+}
+
+/** The three layers, strongest first: session choice, configured source, host. */
+function engineTarget(
+  snapshot: Pick<MetricsSnapshot, 'engines'> | null,
+  chosen: SelectedTargets,
+  source: PageSource | undefined,
+): PageEngineTarget | null {
+  if (chosen.engineEndpoint !== undefined) {
+    return { kind: 'engine', endpoint: chosen.engineEndpoint }
+  }
+  if (source !== undefined) {
+    return source.kind === 'all' ? { kind: 'all' } : { kind: 'engine', endpoint: source.endpoint }
+  }
+  const endpoint = snapshot ? defaultEngineEndpoint(snapshot.engines) : null
+  return endpoint === null ? null : { kind: 'engine', endpoint }
 }
 
 /**

--- a/frontend/src/lib/engineAggregate.test.ts
+++ b/frontend/src/lib/engineAggregate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { aggregateEngines, groupRunningByProvider } from './engineAggregate'
+import { aggregateEngineMetrics, aggregateEngines, groupRunningByProvider } from './engineAggregate'
 import type { EngineMetrics, EngineSnapshot, EngineStatus } from '@/types/metrics'
 
 function fullMetrics(overrides: Partial<EngineMetrics> = {}): EngineMetrics {
@@ -301,6 +301,50 @@ function engineWithModel(
     deployment_mode: 'Docker',
   }
 }
+
+describe('aggregateEngineMetrics', () => {
+  it('returns null when no engine is running', () => {
+    // An aggregate over nothing is not a row of zeros.
+    expect(aggregateEngineMetrics([])).toBeNull()
+    expect(aggregateEngineMetrics([engine('Stopped')])).toBeNull()
+  })
+
+  it('reshapes the aggregate as one engine metrics object', () => {
+    const engines = [
+      engine('Running', fullMetrics({ tokens_per_sec: 100, tpot_ms: 20, total_requests: 10 })),
+      engine('Running', fullMetrics({ tokens_per_sec: 150, tpot_ms: 40, total_requests: 30 })),
+    ]
+    const metrics = aggregateEngineMetrics(engines)!
+
+    expect(metrics.tokens_per_sec).toBe(250)
+    // Weighted mean by total_requests, like the other latencies: (20·10 + 40·30) / 40.
+    expect(metrics.tpot_ms).toBe(35)
+  })
+
+  it('marks the KV figure estimated when any contributing pool is', () => {
+    const engines = [
+      engine('Running', fullMetrics({ kv_cache_is_estimated: false })),
+      engine('Running', fullMetrics({ kv_cache_is_estimated: true })),
+    ]
+    expect(aggregateEngineMetrics(engines)!.kv_cache_is_estimated).toBe(true)
+    expect(aggregateEngineMetrics([engine('Running')])!.kv_cache_is_estimated).toBe(false)
+  })
+
+  it('carries no histogram buckets, whose layouts differ per engine', () => {
+    // The SLO panel falls back to the backend-computed goodput percentages,
+    // which do aggregate — as weighted means.
+    const metrics = aggregateEngineMetrics([
+      engine('Running', fullMetrics({ ttft_buckets: [{ le_seconds: 1, cumulative_count: 5 }], ttft_goodput_pct: 90, itl_goodput_pct: 80 })),
+    ])!
+
+    expect(metrics.ttft_buckets).toBeNull()
+    expect(metrics.itl_buckets).toBeNull()
+    expect(metrics.e2e_buckets).toBeNull()
+    expect(metrics.tpot_buckets).toBeNull()
+    expect(metrics.ttft_goodput_pct).toBe(90)
+    expect(metrics.itl_goodput_pct).toBe(80)
+  })
+})
 
 describe('groupRunningByProvider', () => {
   it('returns [] for no engines', () => {

--- a/frontend/src/lib/engineAggregate.ts
+++ b/frontend/src/lib/engineAggregate.ts
@@ -1,4 +1,4 @@
-import type { EngineSnapshot, LatencyPercentiles } from '@/types/metrics'
+import type { EngineMetrics, EngineSnapshot, LatencyPercentiles } from '@/types/metrics'
 import { getProviderLogo, type ProviderLogo } from './providerLogo'
 
 /**
@@ -43,6 +43,7 @@ export interface AggregateSnapshot {
   e2e_latency_ms: number | null
   queue_time_ms: number | null
   inter_token_latency_ms: number | null
+  tpot_ms: number | null
   per_request_tps: number | null
   per_request_prompt_tps: number | null
 
@@ -59,11 +60,13 @@ export interface AggregateSnapshot {
   ttft_percentiles: LatencyPercentiles | null
   itl_percentiles: LatencyPercentiles | null
   e2e_percentiles: LatencyPercentiles | null
+  tpot_percentiles: LatencyPercentiles | null
 
   // Goodput (% meeting SLO), weighted mean by total_requests.
   ttft_goodput_pct: number | null
   itl_goodput_pct: number | null
   e2e_goodput_pct: number | null
+  tpot_goodput_pct: number | null
 }
 
 function sumOrNull(values: Array<number | null | undefined>): number | null {
@@ -138,6 +141,7 @@ function emptySnapshot(totalCount: number): AggregateSnapshot {
     e2e_latency_ms: null,
     queue_time_ms: null,
     inter_token_latency_ms: null,
+    tpot_ms: null,
     per_request_tps: null,
     per_request_prompt_tps: null,
     avg_batch_size: null,
@@ -146,9 +150,11 @@ function emptySnapshot(totalCount: number): AggregateSnapshot {
     ttft_percentiles: null,
     itl_percentiles: null,
     e2e_percentiles: null,
+    tpot_percentiles: null,
     ttft_goodput_pct: null,
     itl_goodput_pct: null,
     e2e_goodput_pct: null,
+    tpot_goodput_pct: null,
   }
 }
 
@@ -310,6 +316,7 @@ export function aggregateEngines(engines: readonly EngineSnapshot[]): AggregateS
     e2e_latency_ms: weightedBy('e2e_latency_ms'),
     queue_time_ms: weightedBy('queue_time_ms'),
     inter_token_latency_ms: weightedBy('inter_token_latency_ms'),
+    tpot_ms: weightedBy('tpot_ms'),
     per_request_tps: weightedBy('per_request_tps'),
     per_request_prompt_tps: weightedBy('per_request_prompt_tps'),
 
@@ -331,10 +338,78 @@ export function aggregateEngines(engines: readonly EngineSnapshot[]): AggregateS
       metrics.map((m) => m?.e2e_percentiles ?? null),
       weights,
     ),
+    tpot_percentiles: aggregatePercentiles(
+      metrics.map((m) => m?.tpot_percentiles ?? null),
+      weights,
+    ),
 
     // Goodput — weighted mean by total_requests, same caveat as percentiles.
     ttft_goodput_pct: weightedBy('ttft_goodput_pct'),
     itl_goodput_pct: weightedBy('itl_goodput_pct'),
     e2e_goodput_pct: weightedBy('e2e_goodput_pct'),
+    tpot_goodput_pct: weightedBy('tpot_goodput_pct'),
+  }
+}
+
+/**
+ * The aggregate reshaped as one engine's metrics, so a following engine panel
+ * on a page configured for all models renders the combined figures through the
+ * same reader and series it uses for a single engine. Null when no engine is
+ * running — an aggregate over nothing is not a row of zeros.
+ *
+ * The histogram buckets are deliberately null: engines can carry different
+ * bucket layouts, and merging mismatched histograms would manufacture a
+ * distribution nobody measured. The SLO panel already falls back to the
+ * backend-computed goodput percentages, which aggregate as weighted means.
+ */
+export function aggregateEngineMetrics(engines: readonly EngineSnapshot[]): EngineMetrics | null {
+  const aggregate = aggregateEngines(engines)
+  if (aggregate.running_count === 0) return null
+
+  const running = engines.filter((e) => e.status.type === 'Running')
+
+  return {
+    tokens_per_sec: aggregate.tokens_per_sec,
+    avg_tokens_per_sec: aggregate.avg_tokens_per_sec,
+    per_request_tps: aggregate.per_request_tps,
+    ttft_ms: aggregate.ttft_ms,
+    active_requests: aggregate.active_requests,
+    queued_requests: aggregate.queued_requests,
+    kv_cache_percent: aggregate.kv_cache_percent,
+    // Estimated if any contributing pool is: a mean over one estimate is one.
+    kv_cache_is_estimated: running.some((e) => e.metrics?.kv_cache_is_estimated === true),
+    total_requests: aggregate.total_requests,
+    e2e_latency_ms: aggregate.e2e_latency_ms,
+    prompt_tokens_per_sec: aggregate.prompt_tokens_per_sec,
+    avg_prompt_tokens_per_sec: aggregate.avg_prompt_tokens_per_sec,
+    per_request_prompt_tps: aggregate.per_request_prompt_tps,
+    swapped_requests: aggregate.swapped_requests,
+    prefix_cache_hit_rate: aggregate.prefix_cache_hit_rate,
+    queue_time_ms: aggregate.queue_time_ms,
+    inter_token_latency_ms: aggregate.inter_token_latency_ms,
+    preemptions_total: aggregate.preemptions_total,
+    total_prompt_tokens: aggregate.total_prompt_tokens,
+    total_generation_tokens: aggregate.total_generation_tokens,
+    prefix_cache_queries_total: aggregate.prefix_cache_queries_total,
+    avg_batch_size: aggregate.avg_batch_size,
+    ttft_percentiles: aggregate.ttft_percentiles,
+    itl_percentiles: aggregate.itl_percentiles,
+    e2e_percentiles: aggregate.e2e_percentiles,
+    ttft_goodput_pct: aggregate.ttft_goodput_pct,
+    itl_goodput_pct: aggregate.itl_goodput_pct,
+    e2e_goodput_pct: aggregate.e2e_goodput_pct,
+    ttft_buckets: null,
+    itl_buckets: null,
+    e2e_buckets: null,
+    tpot_ms: aggregate.tpot_ms,
+    tpot_percentiles: aggregate.tpot_percentiles,
+    tpot_goodput_pct: aggregate.tpot_goodput_pct,
+    tpot_buckets: null,
+    spec_decode_draft_tokens_total: aggregate.spec_decode_draft_tokens_total,
+    spec_decode_accepted_tokens_total: aggregate.spec_decode_accepted_tokens_total,
+    spec_decode_drafts_total: aggregate.spec_decode_drafts_total,
+    spec_decode_acceptance_rate: aggregate.spec_decode_acceptance_rate,
+    spec_decode_acceptance_rate_live: aggregate.spec_decode_acceptance_rate_live,
+    spec_decode_mean_acceptance_length: aggregate.spec_decode_mean_acceptance_length,
   }
 }

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -194,6 +194,16 @@ export function engineDescription(engine: EngineIdentity): string {
   return `${engineDisplayName(engine.engine_type)} ${formatEndpoint(engine.endpoint)}`
 }
 
+/**
+ * Strip the `Organization/` prefix off a HuggingFace-style id, leaving the
+ * model itself: `Qwen/Qwen3-8B` reads as `Qwen3-8B`. Used wherever the
+ * organization is already said by a provider mark or does not matter, so the
+ * width a long model id needs is not spent twice.
+ */
+export function shortModelName(name: string): string {
+  return name.includes('/') ? name.slice(name.lastIndexOf('/') + 1) : name
+}
+
 /** Apply a formatter to a nullable metric, rendering '--' when absent.
  *  The engine tiles' universal "no data yet" placeholder. */
 export function fmtVal(v: number | null, fmt: (n: number) => string): string {

--- a/frontend/src/lib/metricsHistoryStore.ts
+++ b/frontend/src/lib/metricsHistoryStore.ts
@@ -1,5 +1,6 @@
 import { CircularBuffer } from './circular-buffer'
 import { DEFAULT_TIME_WINDOW } from './dashboard/schema'
+import { aggregateEngineMetrics } from './engineAggregate'
 import { engineKey, gpuIndexOf, snapshotGpus } from './identity'
 import { TIME_WINDOW_SECONDS, type TimeWindow } from '@/types/events'
 import type { GpuEventData, InferenceRequestData, MetricsSnapshot } from '@/types/metrics'
@@ -121,6 +122,14 @@ export type EngineSeriesName = (typeof ENGINE_SERIES)[number][0]
 export function engineSeries(name: EngineSeriesName, key: string): string {
   return `${key}:${name}`
 }
+
+/**
+ * The engine-buffer key of the all-engines aggregate, ingested alongside the
+ * per-engine series so a page configured for all models has history to chart.
+ * Cannot collide with `engineKey()`, whose keys always start with the engine
+ * type (`Vllm-…`).
+ */
+export const ALL_ENGINES_KEY = 'all-engines'
 
 /** The series key of the event buffer, for subscriptions. */
 export const EVENTS_SERIES = 'events'
@@ -273,18 +282,8 @@ export class MetricsHistoryStore {
 
     for (const engine of metrics.engines) {
       const key = engineKey(engine)
-      if (!this.engineBuffers[key]) {
-        this.engineBuffers[key] = createEngineBuffers()
-      }
-      const eb = this.engineBuffers[key]
       if (engine.metrics) {
-        for (const [name, sample] of ENGINE_SERIES) {
-          const val = sample(engine.metrics)
-          if (val !== null) {
-            eb[name].push({ timestamp: ts, value: val })
-            changed.add(`${key}:${name}`)
-          }
-        }
+        this.pushEngineSamples(key, engine.metrics, ts, changed)
       }
 
       if (engine.recent_requests && engine.recent_requests.length > 0) {
@@ -299,6 +298,15 @@ export class MetricsHistoryStore {
         changed.add(requestsSeries(key))
         changed.add(requestsSeries())
       }
+    }
+
+    // The all-engines aggregate, as a series set of its own: a page configured
+    // for all models charts history like any single engine's, and recomputing
+    // fifteen minutes of sums at read time from N per-engine buffers would not
+    // survive an engine's buffer starting later than another's.
+    const aggregate = aggregateEngineMetrics(metrics.engines)
+    if (aggregate) {
+      this.pushEngineSamples(ALL_ENGINES_KEY, aggregate, ts, changed)
     }
 
     if (metrics.gpu_events && metrics.gpu_events.length > 0) {
@@ -319,6 +327,28 @@ export class MetricsHistoryStore {
       if (listeners) for (const listener of listeners) listener()
     }
     for (const listener of this.allListeners) listener()
+  }
+
+  /** Append one tick of engine-shaped metrics to the buffer set under `key` —
+   *  a real engine's, or the all-engines aggregate, which is what the shared
+   *  shape is for. */
+  private pushEngineSamples(
+    key: string,
+    metrics: EngineMetricsShape,
+    ts: number,
+    changed: Set<string>,
+  ): void {
+    if (!this.engineBuffers[key]) {
+      this.engineBuffers[key] = createEngineBuffers()
+    }
+    const eb = this.engineBuffers[key]
+    for (const [name, sample] of ENGINE_SERIES) {
+      const val = sample(metrics)
+      if (val !== null) {
+        eb[name].push({ timestamp: ts, value: val })
+        changed.add(`${key}:${name}`)
+      }
+    }
   }
 
   /** Subscribe to one series. The listener fires when that series gains data. */


### PR DESCRIPTION
## What

Each dashboard page can now be configured for which model it shows by default — or for **all models**, a combined / global-average view. A **Page config** button sits beside **Edit layout**.

- **Page config popover** offers: *Automatic — first serving model* (today's behaviour, still the default), *All models — combined*, and each engine on the host named by its model. The choice is written to the shared document the moment it is made, like a page rename — no edit session needed — and is withheld while a layout session is open, since the document under unsaved panels must hold still.
- **Persisted per page** as an optional `source` field: schema **v2**, with an identity migration from v1 (absent source = automatic, which is exactly what every v1 page was) and a real-document fixture in `migrations.test.ts`.
- **Selection layering**: session choice → page source → host default. A configured engine that is gone stays configured and panels report it missing — no silent substitution, same as pins.
- **Aggregate rendering**: following engine panels render the combined figures through the same `metric`/`series` interface a single engine uses. Sums for throughput/counters, request-weighted means for latencies (TPOT now aggregated too), and an `all-engines` series set ingested alongside the per-engine ones so charts have history. The identity row always says **All models — N of M serving**, single-engine hosts included.
- **Honest edges**: pins never aggregate; the logs and engine-identity panels explain that they are per-engine and how to pin; SLO thresholds (per-model, browser-local) read at defaults under the aggregate with the control disabled; histogram buckets are not merged across engines (layouts can differ), so SLO goodput falls back to the backend percentages, aggregated as weighted means.
- `CONTEXT.md` gains **Page source** and **All models** vocabulary entries.

## Why the version bump for an additive field

Reading is lossy for unknown keys, so a v1 build re-saving a document with `source` would silently drop it — the bump is what protects it, per the schema module's own doc. The migration is a no-op walk from 1 to 2.

## Testing

- `npm run lint` clean, `npm run build` clean, `npm test -- --run`: **707 passed** (54 files).
- New/extended specs: `pageSource`, schema round-trip of `source`, migration fixture, selection layering, `resolveEngineBinding` aggregate cases, `aggregateEngineMetrics`, all-engines series ingestion, panel rendering under the aggregate (`pageSelection.test.tsx`), and the full control flow through the app seam (`App.pageConfig.test.tsx`: choices, immediate write, kiosk reload, back-to-automatic clears the field, dangling engine kept and marked, read-only reasons, withheld during edit sessions).
- No `*.browser.test.tsx` changed, so the browser project was not run.