### PR TITLE
fix: surface vLLM /v1/models authentication failures in the dashboard

### DIFF
--- a/frontend/src/__tests__/App.enginePanels.test.tsx
+++ b/frontend/src/__tests__/App.enginePanels.test.tsx
@@ -343,6 +343,89 @@ describe('the engine panels on a grid page', () => {
     expect(within(status).getByText('Serving')).toBeInTheDocument()
   })
 
+  const AUTH_WARNING =
+    'Engine requires authentication — configure the provider API key to read the model name.'
+
+  it('warns beside the fallback name when /v1/models rejects the dashboard', async () => {
+    // Issue #90: the engine's /v1/models is auth-gated and the dashboard has
+    // no key. The name recovered from the launch command line still shows —
+    // it is the best guess there is — but the warning says it is only a
+    // guess, and what to configure to make it not one.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'who', type: 'engine-status', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [
+        makeEngine(ALPHA, {
+          model: modelNamed('google/gemma-4-31B-it'),
+          model_metadata_error: 'AuthRequired',
+        }),
+      ]),
+    )
+
+    const status = region('Engine')
+    expect(within(status).getByText('gemma-4-31B-it')).toBeInTheDocument()
+    expect(within(status).getByText(AUTH_WARNING)).toBeInTheDocument()
+    // The engine itself is fine — metrics flow, so it still reads as serving.
+    expect(within(status).getByText('Serving')).toBeInTheDocument()
+  })
+
+  it('lets the auth warning stand alone when no name resolved at all', async () => {
+    // No command-line hint either: nothing resolved, but "unavailable" is a
+    // better headline than "no model loaded" — the model may well be loaded,
+    // only its name is unreadable without the key.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'who', type: 'engine-status', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [
+        makeEngine(ALPHA, { model: null, model_metadata_error: 'AuthRequired' }),
+      ]),
+    )
+
+    const status = region('Engine')
+    expect(within(status).getByText('Model name unavailable')).toBeInTheDocument()
+    expect(within(status).getByText(AUTH_WARNING)).toBeInTheDocument()
+    expect(within(status).queryByText('No model loaded')).not.toBeInTheDocument()
+  })
+
+  it('does not warn when metadata resolved, or failed for non-auth reasons', async () => {
+    // A key would not fix an unreachable /v1/models, so no warning may send
+    // the operator configuring one. The resolved case is the everyday one:
+    // nothing to warn about at all.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        { id: 'who', type: 'engine-status', geometry: { x: 0, y: 0, w: 6, h: 4 } },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [
+        makeEngine(ALPHA, { model_metadata_error: 'Unavailable' }),
+      ]),
+    )
+
+    const status = region('Engine')
+    expect(within(status).getByText('Qwen3-8B')).toBeInTheDocument()
+    expect(within(status).queryByText(AUTH_WARNING)).not.toBeInTheDocument()
+
+    // Metadata resolves once the key is configured — the warning clears.
+    receive(makeSnapshot(2000, [makeEngine(ALPHA, { model_metadata_error: null })]))
+    expect(within(region('Engine')).queryByText(AUTH_WARNING)).not.toBeInTheDocument()
+  })
+
   it('sums every engine on the host into one overview', async () => {
     const fetchMock = serveConfiguration({
       document: storedDocument([
@@ -514,6 +597,47 @@ describe('the engine panels on a grid page', () => {
       'src',
       '/icons/providers/meta.svg',
     )
+  })
+
+  it('marks a provisional model name on the identity row too', async () => {
+    // The identity row a metric panel wears on a multi-engine host has no
+    // room for the warning's words, so it wears a mark carrying them — a
+    // panel must not present the command-line fallback as settled identity
+    // anywhere the name shows.
+    const fetchMock = serveConfiguration({
+      document: storedDocument([
+        {
+          id: 'alpha',
+          type: 'engine-decode-throughput',
+          title: 'Alpha decode',
+          binding: { kind: 'engine', endpoint: ALPHA },
+          geometry: { x: 0, y: 0, w: 6, h: 4 },
+        },
+        {
+          id: 'beta',
+          type: 'engine-decode-throughput',
+          title: 'Beta decode',
+          binding: { kind: 'engine', endpoint: BETA },
+          geometry: { x: 6, y: 0, w: 6, h: 4 },
+        },
+      ]),
+    })
+
+    render(<App />)
+    await configurationSettles(fetchMock)
+    receive(
+      makeSnapshot(1000, [
+        makeEngine(ALPHA),
+        makeEngine(BETA, {
+          model: modelNamed('meta-llama/Llama-3.1-8B'),
+          model_metadata_error: 'AuthRequired',
+        }),
+      ]),
+    )
+
+    // Only the engine whose metadata was refused wears the mark.
+    expect(within(region('Beta decode')).getByLabelText(AUTH_WARNING)).toBeInTheDocument()
+    expect(within(region('Alpha decode')).queryByLabelText(AUTH_WARNING)).not.toBeInTheDocument()
   })
 
   it('keeps the slot of a panel pinned to an engine that is gone, naming it', async () => {

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatAcceptanceLength,
   formatEndpoint,
   engineDescription,
+  modelMetadataWarning,
 } from '../lib/format'
 
 const GIB = 1_073_741_824
@@ -109,5 +110,22 @@ describe('engineDescription', () => {
     expect(engineDescription({ engine_type: 'Vllm', endpoint: 'http://localhost:8001' })).toBe(
       'vLLM localhost:8001',
     )
+  })
+})
+
+describe('modelMetadataWarning', () => {
+  it('warns only on the auth rejection, which the operator can fix dashboard-side', () => {
+    expect(modelMetadataWarning('AuthRequired')).toBe(
+      'Engine requires authentication — configure the provider API key to read the model name.',
+    )
+  })
+
+  it('stays silent for every non-auth reason', () => {
+    // A merely unreachable /v1/models is already told by the engine status,
+    // and a key would not help — warning here would send an operator fixing
+    // the wrong thing. Absent covers older backends without the field.
+    expect(modelMetadataWarning('Unavailable')).toBeNull()
+    expect(modelMetadataWarning(null)).toBeNull()
+    expect(modelMetadataWarning(undefined)).toBeNull()
   })
 })

--- a/frontend/src/components/grid/panels/EnginePanelBody.tsx
+++ b/frontend/src/components/grid/panels/EnginePanelBody.tsx
@@ -28,7 +28,12 @@ interface EnginePanelBodyProps {
  * alone does not say whose.
  */
 export function EnginePanelBody({ identity, actions, tiles, chart }: EnginePanelBodyProps) {
-  const { label, model, logo } = identity ?? { label: null, model: null, logo: null }
+  const { label, model, logo, modelWarning } = identity ?? {
+    label: null,
+    model: null,
+    logo: null,
+    modelWarning: null,
+  }
   const [ref, size] = useElementSize<HTMLDivElement>()
   const mode = enginePanelMode(size)
 
@@ -47,8 +52,20 @@ export function EnginePanelBody({ identity, actions, tiles, chart }: EnginePanel
             // The model first, because that is what an operator is thinking
             // about; the endpoint after it, because that is what actually tells
             // two engines apart when both serve the same model.
-            <span className="flex items-center gap-1.5 min-w-0" title={model ? `${model} — ${label}` : label}>
+            <span
+              className="flex items-center gap-1.5 min-w-0"
+              title={
+                [model, label, modelWarning].filter(Boolean).join(' — ') || undefined
+              }
+            >
               {logo && <ProviderMark logo={logo} />}
+              {/* The row has no room for the warning's words, so it wears the
+                  mark and carries the words in the row's tooltip. */}
+              {modelWarning && (
+                <span aria-label={modelWarning} className="text-[10px] leading-none text-amber-400">
+                  ⚠
+                </span>
+              )}
               {model && (
                 <span className="text-[10px] font-medium text-zinc-300 truncate">{model}</span>
               )}

--- a/frontend/src/components/grid/panels/EngineStatusPanel.tsx
+++ b/frontend/src/components/grid/panels/EngineStatusPanel.tsx
@@ -1,5 +1,11 @@
 import { getProviderLogo } from '@/lib/providerLogo'
-import { engineDisplayName, formatEndpoint, formatGpuIndexes, shortModelName } from '@/lib/format'
+import {
+  engineDisplayName,
+  formatEndpoint,
+  formatGpuIndexes,
+  modelMetadataWarning,
+  shortModelName,
+} from '@/lib/format'
 import type { EngineSnapshot } from '@/types/metrics'
 import { DeploymentChip, EngineChip, ProviderMark } from './engineIdentity'
 import { EnginePanelNotice, PanelNotice } from './PanelNotice'
@@ -47,11 +53,18 @@ export function EngineStatusPanel({ panel }: PanelContentProps) {
 function EngineIdentity({ engine }: { engine: EngineSnapshot }) {
   const { model } = engine
   const logo = getProviderLogo(model?.name)
+  const warning = modelMetadataWarning(engine.model_metadata_error)
   // The model is the headline; the endpoint is already on the frame's title
   // row, so repeating it here would spend the panel's widest line on it twice.
   // With no model to name, the absence is the headline — it is the thing an
-  // operator has to act on, not a footnote under a blank line.
-  const headline = model?.name ? shortModelName(model.name) : 'No model loaded'
+  // operator has to act on, not a footnote under a blank line. When the
+  // engine refused to say, the refusal is a better headline than a generic
+  // absence: the model may well be loaded, only its name is unreadable.
+  const headline = model?.name
+    ? shortModelName(model.name)
+    : warning
+      ? 'Model name unavailable'
+      : 'No model loaded'
 
   return (
     <div className="h-full min-h-0 flex flex-col gap-2 overflow-y-auto">
@@ -69,6 +82,16 @@ function EngineIdentity({ engine }: { engine: EngineSnapshot }) {
           </p>
         </div>
       </div>
+
+      {/* The warning accompanies whatever name resolved rather than replacing
+          it: the fallback from the launch command line is still the best
+          guess there is, but an operator has to know it is only a guess —
+          and how to make it not one. */}
+      {warning && (
+        <p role="alert" className="shrink-0 text-[11px] leading-snug text-amber-200">
+          {warning}
+        </p>
+      )}
 
       {/* Everything the backend could tell us about the deployment and the
           weights, in the order the fixed dashboard showed it. Each is omitted

--- a/frontend/src/components/grid/panels/engineLabel.ts
+++ b/frontend/src/components/grid/panels/engineLabel.ts
@@ -1,4 +1,4 @@
-import { engineDescription, shortModelName } from '@/lib/format'
+import { engineDescription, modelMetadataWarning, shortModelName } from '@/lib/format'
 import { getProviderLogo, type ProviderLogo } from '@/lib/providerLogo'
 import type { AggregateEngineTarget, ResolvedEngineTarget } from './useEnginePanel'
 
@@ -33,6 +33,10 @@ export interface EngineIdentity {
   /** The provider of that model. Null on a single-engine host, and for a model
    *  no shipped provider is recognized from. */
   logo: ProviderLogo | null
+  /** Why `model` may be wrong: the engine refused to say what it serves, so
+   *  the name (if any) is only the launch command line's word for it. Null
+   *  when there is nothing to warn about. */
+  modelWarning: string | null
 }
 
 /**
@@ -57,15 +61,19 @@ export function engineIdentity(
       label: `${resolution.running} of ${resolution.total} serving`,
       model: 'All models',
       logo: null,
+      modelWarning: null,
     }
   }
 
-  if (!resolution.multiEngine) return { label: null, model: null, logo: null }
+  if (!resolution.multiEngine) {
+    return { label: null, model: null, logo: null, modelWarning: null }
+  }
 
   const { model } = resolution.engine
   return {
     label: engineDescription(resolution.engine),
     model: model?.name ? shortModelName(model.name) : null,
     logo: getProviderLogo(model?.name),
+    modelWarning: modelMetadataWarning(resolution.engine.model_metadata_error),
   }
 }

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,5 +1,5 @@
 import type { EngineIdentity } from '@/lib/identity'
-import type { EngineType } from '@/types/metrics'
+import type { EngineType, ModelMetadataError } from '@/types/metrics'
 
 const KIB = 1024
 const MIB = 1024 * 1024
@@ -202,6 +202,22 @@ export function engineDescription(engine: EngineIdentity): string {
  */
 export function shortModelName(name: string): string {
   return name.includes('/') ? name.slice(name.lastIndexOf('/') + 1) : name
+}
+
+/**
+ * Why the model name beside this warning may be wrong, in words an operator
+ * can act on. Only the authentication rejection gets one: it is the failure
+ * fixed on the dashboard's side (configure a provider API key), and telling
+ * an operator to configure a key for an engine that is merely unreachable
+ * would send them fixing the wrong thing. Null means nothing to warn about —
+ * metadata resolved, the engine is merely down (its status already says so),
+ * or an older backend that does not report the field.
+ */
+export function modelMetadataWarning(
+  error: ModelMetadataError | null | undefined,
+): string | null {
+  if (error !== 'AuthRequired') return null
+  return 'Engine requires authentication — configure the provider API key to read the model name.'
 }
 
 /** Apply a formatter to a nullable metric, rendering '--' when absent.

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -91,6 +91,12 @@ export type EngineStatus =
   | { type: 'Stopped' }
   | { type: 'Error'; message: string }
 
+/** Why model metadata could not be read from the engine's `/v1/models`
+ *  endpoint. `AuthRequired` means the request was rejected as unauthorized
+ *  (401/403) — the dashboard lacks the engine's API key; `Unavailable`
+ *  covers every non-auth cause (unreachable, error status, empty list). */
+export type ModelMetadataError = 'AuthRequired' | 'Unavailable'
+
 export interface ModelInfo {
   name: string
   parameter_size: string | null
@@ -196,6 +202,10 @@ export interface EngineSnapshot {
   endpoint: string
   status: EngineStatus
   model: ModelInfo | null
+  /** Why `model` is missing or only a command-line fallback. Null when
+   *  metadata resolved normally — optional so snapshots from older backends
+   *  still parse. */
+  model_metadata_error?: ModelMetadataError | null
   metrics: EngineMetrics | null
   recent_requests: InferenceRequestData[]
   deployment_mode: DeploymentMode

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -42,6 +42,32 @@ pub enum EngineStatus {
     Error(String),
 }
 
+/// Why model metadata could not be read from the engine's `/v1/models`
+/// endpoint. Travels on the wire next to `model` so the frontend can say
+/// *why* a name is missing (or provisional) instead of silently showing the
+/// command-line fallback. `None` on the snapshot means metadata resolved
+/// normally.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+pub enum ModelMetadataError {
+    /// `/v1/models` rejected the request as unauthorized (401/403) — the
+    /// dashboard lacks the engine's API key. Actionable: configure a
+    /// provider API key.
+    AuthRequired,
+    /// `/v1/models` could not be used for any non-auth reason: unreachable,
+    /// non-auth error status, unparseable body, or an empty model list.
+    Unavailable,
+}
+
+/// The outcome of a model-info fetch: what resolved (possibly from the
+/// command-line fallback) and why the engine's own answer is missing, if it
+/// is. Both can be populated at once — a fallback name accompanied by the
+/// reason it is only a fallback.
+#[derive(Clone, Debug, Default)]
+pub struct ModelResolution {
+    pub model: Option<ModelInfo>,
+    pub metadata_error: Option<ModelMetadataError>,
+}
+
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct ModelInfo {
     pub name: String,
@@ -204,6 +230,9 @@ pub struct EngineSnapshot {
     pub endpoint: String,
     pub status: EngineStatus,
     pub model: Option<ModelInfo>,
+    /// Why `model` is missing or only a command-line fallback. `None` when
+    /// metadata resolved normally (or has not been attempted yet).
+    pub model_metadata_error: Option<ModelMetadataError>,
     pub metrics: Option<EngineMetrics>,
     pub recent_requests: Vec<RecentRequest>,
     pub deployment_mode: DeploymentMode,
@@ -236,7 +265,7 @@ pub trait EngineAdapter: Send + Sync {
     fn engine_type(&self) -> EngineType;
     fn endpoint(&self) -> &str;
     async fn health_check(&self) -> EngineStatus;
-    async fn get_model_info(&self) -> Option<ModelInfo>;
+    async fn get_model_info(&self) -> ModelResolution;
     async fn get_metrics(&self) -> Option<EngineMetrics>;
 }
 
@@ -264,6 +293,10 @@ pub struct EngineState {
     /// Last successfully resolved model info. Reused every poll tick instead of
     /// re-hitting `/v1/models`; invalidated on engine restart.
     pub cached_model: Option<ModelInfo>,
+    /// Why the last fetch could not read metadata from the engine itself
+    /// (`cached_model` is then absent or a command-line fallback). Cleared by
+    /// the next fetch that resolves without error.
+    pub model_metadata_error: Option<ModelMetadataError>,
     /// When `cached_model` was last populated — drives the 10-minute refresh.
     pub model_fetched_at: Option<Instant>,
     /// When a fetch was last attempted (success or unresolved) — drives the
@@ -287,6 +320,7 @@ impl EngineState {
             stopped_at: None,
             deployment_mode,
             cached_model: None,
+            model_metadata_error: None,
             model_fetched_at: None,
             model_attempted_at: None,
             pids: Vec::new(),
@@ -295,9 +329,20 @@ impl EngineState {
     }
 
     /// Whether `/v1/models` should be hit on this poll tick. Returns `true`
-    /// only when there is no cached model and the unresolved cooldown has
-    /// elapsed, or when the cached model is older than the refresh interval.
+    /// only when there is no cleanly resolved model and the unresolved
+    /// cooldown has elapsed, or when the cached model is older than the
+    /// refresh interval. A resolution that carried a metadata error is
+    /// provisional even when it produced a name (the command-line fallback),
+    /// so it retries on the short cooldown rather than being trusted for the
+    /// full refresh interval — an operator who fixes the API key sees the
+    /// warning clear within the cooldown, not after ten minutes.
     pub fn should_fetch_model(&self) -> bool {
+        if self.model_metadata_error.is_some() {
+            return match self.model_attempted_at {
+                None => true,
+                Some(attempted) => attempted.elapsed() >= MODEL_UNRESOLVED_RETRY,
+            };
+        }
         match (&self.cached_model, self.model_fetched_at) {
             (Some(_), Some(fetched)) => fetched.elapsed() >= MODEL_REFRESH_INTERVAL,
             (Some(_), None) => true,
@@ -308,13 +353,17 @@ impl EngineState {
         }
     }
 
-    /// Record the outcome of a model-info fetch. Always stamps the attempt;
-    /// only updates the cache + refresh clock when something resolved.
-    pub fn cache_model(&mut self, model: Option<ModelInfo>) {
+    /// Record the outcome of a model-info fetch. Always stamps the attempt
+    /// and the metadata error (so a clean fetch clears a stale warning);
+    /// only updates the cache + refresh clock when something resolved. An
+    /// errored fetch that produced no name keeps the last-known model
+    /// visible, with the fresh error explaining why it may be stale.
+    pub fn cache_model(&mut self, resolution: ModelResolution) {
         let now = Instant::now();
         self.model_attempted_at = Some(now);
-        if model.is_some() {
-            self.cached_model = model;
+        self.model_metadata_error = resolution.metadata_error;
+        if resolution.model.is_some() {
+            self.cached_model = resolution.model;
             self.model_fetched_at = Some(now);
         }
     }
@@ -322,6 +371,7 @@ impl EngineState {
     /// Drop the cached model so the next successful probe re-resolves it.
     fn invalidate_model_cache(&mut self) {
         self.cached_model = None;
+        self.model_metadata_error = None;
         self.model_fetched_at = None;
         self.model_attempted_at = None;
     }
@@ -634,6 +684,7 @@ pub async fn engine_collector_loop(
                             endpoint: state.adapter.endpoint().to_string(),
                             status,
                             model,
+                            model_metadata_error: state.model_metadata_error,
                             metrics,
                             recent_requests: Vec::new(),
                             deployment_mode: state.deployment_mode.clone(),
@@ -674,8 +725,8 @@ mod tests {
         async fn health_check(&self) -> EngineStatus {
             EngineStatus::Running
         }
-        async fn get_model_info(&self) -> Option<ModelInfo> {
-            None
+        async fn get_model_info(&self) -> ModelResolution {
+            ModelResolution::default()
         }
         async fn get_metrics(&self) -> Option<EngineMetrics> {
             None
@@ -698,6 +749,23 @@ mod tests {
         }
     }
 
+    /// A fetch that resolved cleanly from the engine's own endpoint.
+    fn resolved(name: &str) -> ModelResolution {
+        ModelResolution {
+            model: Some(model(name)),
+            metadata_error: None,
+        }
+    }
+
+    /// A fetch that fell back to the command-line hint (or nothing) because
+    /// `/v1/models` could not be read.
+    fn errored(name: Option<&str>, error: ModelMetadataError) -> ModelResolution {
+        ModelResolution {
+            model: name.map(model),
+            metadata_error: Some(error),
+        }
+    }
+
     /// Back-date an instant by `d`; relies on CI monotonic-clock uptime.
     fn ago(d: Duration) -> Instant {
         Instant::now()
@@ -713,14 +781,14 @@ mod tests {
     #[test]
     fn cached_model_is_not_refetched_within_interval() {
         let mut s = state();
-        s.cache_model(Some(model("a/b")));
+        s.cache_model(resolved("a/b"));
         assert!(!s.should_fetch_model());
     }
 
     #[test]
     fn cached_model_refetched_after_refresh_interval() {
         let mut s = state();
-        s.cache_model(Some(model("a/b")));
+        s.cache_model(resolved("a/b"));
         s.model_fetched_at = Some(ago(MODEL_REFRESH_INTERVAL + Duration::from_secs(1)));
         assert!(s.should_fetch_model());
     }
@@ -728,16 +796,77 @@ mod tests {
     #[test]
     fn unresolved_model_respects_retry_cooldown() {
         let mut s = state();
-        s.cache_model(None);
+        s.cache_model(ModelResolution::default());
         assert!(!s.should_fetch_model(), "within cooldown");
         s.model_attempted_at = Some(ago(MODEL_UNRESOLVED_RETRY + Duration::from_secs(1)));
         assert!(s.should_fetch_model(), "cooldown elapsed");
     }
 
+    /// A fallback name that arrived with a metadata error is provisional: it
+    /// must retry on the short unresolved cooldown, not sit on the 10-minute
+    /// refresh interval — otherwise a fixed API key would leave the auth
+    /// warning standing for up to ten minutes.
+    #[test]
+    fn errored_resolution_retries_on_unresolved_cooldown() {
+        let mut s = state();
+        s.cache_model(errored(Some("a/b"), ModelMetadataError::AuthRequired));
+        assert_eq!(
+            s.model_metadata_error,
+            Some(ModelMetadataError::AuthRequired)
+        );
+        assert!(!s.should_fetch_model(), "within cooldown");
+        s.model_attempted_at = Some(ago(MODEL_UNRESOLVED_RETRY + Duration::from_secs(1)));
+        assert!(
+            s.should_fetch_model(),
+            "cooldown elapsed despite cached name"
+        );
+    }
+
+    /// The warning clears as soon as a fetch resolves cleanly — a cached
+    /// success must not keep showing a stale auth warning.
+    #[test]
+    fn clean_fetch_clears_metadata_error() {
+        let mut s = state();
+        s.cache_model(errored(Some("a/b"), ModelMetadataError::AuthRequired));
+        s.cache_model(resolved("a/b"));
+        assert_eq!(s.model_metadata_error, None);
+        assert!(!s.should_fetch_model(), "clean result trusted again");
+    }
+
+    /// An errored fetch that produced no name (no command-line hint) keeps
+    /// the last-known model visible; the fresh error explains why it may be
+    /// stale.
+    #[test]
+    fn errored_fetch_without_name_keeps_last_known_model() {
+        let mut s = state();
+        s.cache_model(resolved("a/b"));
+        s.cache_model(errored(None, ModelMetadataError::Unavailable));
+        assert_eq!(
+            s.cached_model.as_ref().map(|m| m.name.as_str()),
+            Some("a/b")
+        );
+        assert_eq!(
+            s.model_metadata_error,
+            Some(ModelMetadataError::Unavailable)
+        );
+    }
+
+    /// A restart invalidation drops the error along with the cached model —
+    /// the re-resolved engine starts from a clean slate.
+    #[test]
+    fn restart_clears_metadata_error() {
+        let mut s = state();
+        s.cache_model(errored(Some("a/b"), ModelMetadataError::AuthRequired));
+        s.record_probe_result(false);
+        s.record_probe_result(false);
+        s.record_probe_result(false);
+        assert_eq!(s.model_metadata_error, None);
+    }
+
     #[test]
     fn restart_invalidates_cached_model() {
         let mut s = state();
-        s.cache_model(Some(model("a/b")));
+        s.cache_model(resolved("a/b"));
         assert!(!s.should_fetch_model());
 
         // 3 consecutive failures => Stopped => cache cleared once.
@@ -753,7 +882,7 @@ mod tests {
     #[test]
     fn successful_probe_keeps_model_cache() {
         let mut s = state();
-        s.cache_model(Some(model("a/b")));
+        s.cache_model(resolved("a/b"));
         s.record_probe_result(true);
         assert!(s.cached_model.is_some());
         assert!(!s.should_fetch_model());

--- a/src/engines/vllm.rs
+++ b/src/engines/vllm.rs
@@ -3,7 +3,8 @@ use super::prometheus::parse_prometheus_text;
 use super::warmup::WarmupTracker;
 use super::{
     EngineAdapter, EngineMetrics, EngineStatus, EngineType, HistogramBucket, LatencyPercentiles,
-    ModelInfo, E2E_SLO_MS, ITL_SLO_MS, TPOT_SLO_MS, TTFT_SLO_MS,
+    ModelInfo, ModelMetadataError, ModelResolution, E2E_SLO_MS, ITL_SLO_MS, TPOT_SLO_MS,
+    TTFT_SLO_MS,
 };
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -146,11 +147,17 @@ impl VllmAdapter {
     /// lifetime. On failure, a 60-second cooldown prevents hammering the HF
     /// API on every 1-second poll cycle.
     async fn fetch_hf_model_info(&self, model_id: &str) -> Option<ModelInfo> {
-        // Cache hit — model metadata never changes at runtime.
+        // Cache hit — model metadata never changes at runtime. Only for the
+        // same id, though: the name can legitimately change once, when an
+        // auth-gated `/v1/models` starts answering and replaces the
+        // command-line fallback the cache was filled from. A stale entry
+        // must not keep renaming the model back.
         {
             let cache = self.hf_model_cache.lock().await;
             if let Some(cached) = cache.as_ref() {
-                return Some(cached.clone());
+                if cached.name == model_id {
+                    return Some(cached.clone());
+                }
             }
         }
 
@@ -336,6 +343,62 @@ fn is_expected_hf_miss(status: u16) -> bool {
     matches!(status, 401 | 403 | 404)
 }
 
+/// What the engine's `/v1/models` endpoint had to say, reduced to the cases
+/// the name resolution cares about.
+enum ModelsEndpointReply {
+    /// A model id was returned.
+    Resolved(String),
+    /// The endpoint answered successfully but listed no models.
+    Empty,
+    /// The endpoint could not be read; the error says why.
+    Failed(ModelMetadataError),
+}
+
+/// Classify a non-success `/v1/models` status. 401/403 mean the dashboard
+/// lacks the engine's API key — the one failure an operator fixes on the
+/// dashboard's side (configure a provider API key), so it gets its own
+/// reason; everything else is generic unavailability.
+fn classify_models_error_status(status: u16) -> ModelMetadataError {
+    match status {
+        401 | 403 => ModelMetadataError::AuthRequired,
+        _ => ModelMetadataError::Unavailable,
+    }
+}
+
+/// Resolve the display name from the `/v1/models` reply and the command-line
+/// hint, and say why the engine's own answer is missing when it is.
+///
+/// Precedence on a successful reply (unchanged from before the error
+/// plumbing):
+///   1. API id, if it already carries a `Provider/` prefix.
+///   2. Command-line hint captured during detection.
+///   3. API id as-is (bare slug).
+///   4. None (nothing resolved).
+///
+/// When the endpoint failed or listed nothing, the hint is all there is, and
+/// the metadata error travels with it — the fallback name is shown, but the
+/// frontend can say it is only a fallback.
+fn resolve_model_name(
+    reply: &ModelsEndpointReply,
+    hint: Option<&str>,
+) -> (Option<String>, Option<ModelMetadataError>) {
+    match reply {
+        ModelsEndpointReply::Resolved(id) => {
+            let name = if id.contains('/') {
+                id.clone()
+            } else {
+                hint.map(str::to_string).unwrap_or_else(|| id.clone())
+            };
+            (Some(name), None)
+        }
+        ModelsEndpointReply::Empty => (
+            hint.map(str::to_string),
+            Some(ModelMetadataError::Unavailable),
+        ),
+        ModelsEndpointReply::Failed(error) => (hint.map(str::to_string), Some(*error)),
+    }
+}
+
 #[derive(Deserialize)]
 struct OpenAIModelsResponse {
     #[serde(default)]
@@ -402,37 +465,76 @@ impl EngineAdapter for VllmAdapter {
         }
     }
 
-    async fn get_model_info(&self) -> Option<ModelInfo> {
+    async fn get_model_info(&self) -> ModelResolution {
         // Try the OpenAI-compatible models endpoint first. vLLM returns
         // whatever id it was launched with, but downstream model routers can
         // strip the HF-style `Provider/` prefix before replying — which is
         // exactly the case we want to recover from via the command-line hint.
-        let api_id: Option<String> = async {
-            let resp = self
-                .auth(
-                    self.client
-                        .get(format!("{}/v1/models", self.endpoint))
-                        .timeout(Duration::from_secs(2)),
-                )
-                .send()
-                .await
-                .ok()?;
-            let models: OpenAIModelsResponse = resp.json().await.ok()?;
-            models.data.first().map(|m| m.id.clone())
-        }
-        .await;
+        // The status is inspected rather than piped through "parse or None":
+        // an auth-gated deployment answers 401/403 here while `/metrics`
+        // keeps working, and that rejection must reach the operator instead
+        // of silently degrading to the command-line fallback (issue #90).
+        let reply = match self
+            .auth(
+                self.client
+                    .get(format!("{}/v1/models", self.endpoint))
+                    .timeout(Duration::from_secs(2)),
+            )
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                match resp.json::<OpenAIModelsResponse>().await {
+                    Ok(models) => match models.data.first() {
+                        Some(m) => ModelsEndpointReply::Resolved(m.id.clone()),
+                        None => ModelsEndpointReply::Empty,
+                    },
+                    Err(e) => {
+                        tracing::debug!(
+                            endpoint = %self.endpoint,
+                            error = %e,
+                            "/v1/models response deserialization failed",
+                        );
+                        ModelsEndpointReply::Failed(ModelMetadataError::Unavailable)
+                    }
+                }
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let error = classify_models_error_status(status.as_u16());
+                if error == ModelMetadataError::AuthRequired {
+                    tracing::warn!(
+                        endpoint = %self.endpoint,
+                        status = %status,
+                        "/v1/models rejected the request as unauthorized — \
+                         configure a provider API key to read model metadata",
+                    );
+                } else {
+                    tracing::debug!(
+                        endpoint = %self.endpoint,
+                        status = %status,
+                        "/v1/models returned non-success",
+                    );
+                }
+                ModelsEndpointReply::Failed(error)
+            }
+            Err(e) => {
+                tracing::debug!(
+                    endpoint = %self.endpoint,
+                    error = %e,
+                    "/v1/models request failed",
+                );
+                ModelsEndpointReply::Failed(ModelMetadataError::Unavailable)
+            }
+        };
 
-        // Precedence:
-        //   1. API id, if it already carries a `Provider/` prefix.
-        //   2. Command-line hint captured during detection.
-        //   3. API id as-is (bare slug).
-        //   4. None (nothing resolved).
-        let name = match (&api_id, &self.served_model) {
-            (Some(id), _) if id.contains('/') => Some(id.clone()),
-            (_, Some(hint)) => Some(hint.clone()),
-            (Some(id), None) => Some(id.clone()),
-            (None, None) => None,
-        }?;
+        let (name, metadata_error) = resolve_model_name(&reply, self.served_model.as_deref());
+        let Some(name) = name else {
+            return ModelResolution {
+                model: None,
+                metadata_error,
+            };
+        };
 
         // An offline launch (`HF_HUB_OFFLINE` + `--model <local dir>`) makes
         // vLLM report the filesystem path as its model id. Recover the real
@@ -442,19 +544,23 @@ impl EngineAdapter for VllmAdapter {
 
         // Try HF enrichment — fetch_hf_model_info caches successes and
         // throttles retries internally.
-        if let Some(enriched) = self.fetch_hf_model_info(&name).await {
-            return Some(enriched);
-        }
+        let model = match self.fetch_hf_model_info(&name).await {
+            Some(enriched) => enriched,
+            None => ModelInfo {
+                name,
+                parameter_size: None,
+                quantization: None,
+                precision: None,
+                tensor_type: None,
+                model_type: None,
+                pipeline_tag: None,
+            },
+        };
 
-        Some(ModelInfo {
-            name,
-            parameter_size: None,
-            quantization: None,
-            precision: None,
-            tensor_type: None,
-            model_type: None,
-            pipeline_tag: None,
-        })
+        ModelResolution {
+            model: Some(model),
+            metadata_error,
+        }
     }
 
     async fn get_metrics(&self) -> Option<EngineMetrics> {
@@ -1037,6 +1143,90 @@ mod tests {
         assert_eq!(
             normalize_model_id("/srv/snapshots/this-is-a-forty-char-model-name-not-hex"),
             "/srv/snapshots/this-is-a-forty-char-model-name-not-hex"
+        );
+    }
+
+    /// `/v1/models` auth rejections (401/403) get their own reason — the one
+    /// failure the operator fixes on the dashboard's side. Everything else
+    /// (missing endpoint, throttling, server errors) is generic
+    /// unavailability.
+    #[test]
+    fn models_auth_statuses_classified_apart_from_other_failures() {
+        for status in [401, 403] {
+            assert_eq!(
+                classify_models_error_status(status),
+                ModelMetadataError::AuthRequired,
+                "{status} should read as an auth rejection"
+            );
+        }
+        for status in [404, 429, 500, 502, 503] {
+            assert_eq!(
+                classify_models_error_status(status),
+                ModelMetadataError::Unavailable,
+                "{status} should read as generic unavailability"
+            );
+        }
+    }
+
+    /// A rejected `/v1/models` falls back to the command-line hint, and the
+    /// auth reason travels with the fallback name — the warning accompanies
+    /// the name rather than replacing it. Without a hint, the reason stands
+    /// alone.
+    #[test]
+    fn auth_rejection_reports_reason_beside_fallback_name() {
+        let reply = ModelsEndpointReply::Failed(ModelMetadataError::AuthRequired);
+        assert_eq!(
+            resolve_model_name(&reply, Some("google/gemma-4-31B-it")),
+            (
+                Some("google/gemma-4-31B-it".into()),
+                Some(ModelMetadataError::AuthRequired)
+            )
+        );
+        assert_eq!(
+            resolve_model_name(&reply, None),
+            (None, Some(ModelMetadataError::AuthRequired))
+        );
+    }
+
+    /// A connection failure / non-auth error status resolves the same way but
+    /// with the non-auth reason, so the frontend never tells an operator to
+    /// configure a key that would not help.
+    #[test]
+    fn non_auth_failure_reports_unavailable() {
+        let reply = ModelsEndpointReply::Failed(ModelMetadataError::Unavailable);
+        assert_eq!(
+            resolve_model_name(&reply, Some("org/model")),
+            (
+                Some("org/model".into()),
+                Some(ModelMetadataError::Unavailable)
+            )
+        );
+        // A successful reply listing no models is not an auth problem either.
+        assert_eq!(
+            resolve_model_name(&ModelsEndpointReply::Empty, None),
+            (None, Some(ModelMetadataError::Unavailable))
+        );
+    }
+
+    /// A successful `/v1/models` reply carries no error and keeps the
+    /// long-standing precedence: a `Provider/`-prefixed API id wins, the hint
+    /// beats a bare slug, and a bare slug still resolves without a hint.
+    #[test]
+    fn successful_reply_keeps_precedence_and_reports_no_error() {
+        let prefixed = ModelsEndpointReply::Resolved("google/gemma-4-31B-it_FP16".into());
+        assert_eq!(
+            resolve_model_name(&prefixed, Some("hint/model")),
+            (Some("google/gemma-4-31B-it_FP16".into()), None)
+        );
+
+        let bare = ModelsEndpointReply::Resolved("gemma".into());
+        assert_eq!(
+            resolve_model_name(&bare, Some("google/gemma-4-31B-it")),
+            (Some("google/gemma-4-31B-it".into()), None)
+        );
+        assert_eq!(
+            resolve_model_name(&bare, None),
+            (Some("gemma".into()), None)
         );
     }
 

--- a/src/engines/vllm.rs
+++ b/src/engines/vllm.rs
@@ -1230,6 +1230,47 @@ mod tests {
         );
     }
 
+    /// The HF enrichment cache is keyed by model id: it serves the same id
+    /// without a refetch, but must not hand a different id the stale entry —
+    /// the id legitimately changes once, when an auth-gated `/v1/models`
+    /// starts answering and replaces the command-line fallback the cache was
+    /// filled from. Both calls run inside the retry cooldown, so neither can
+    /// touch the network: whatever comes back is the cache's answer.
+    #[tokio::test]
+    async fn hf_cache_serves_only_the_id_it_was_filled_from() {
+        let adapter = VllmAdapter::new(
+            reqwest::Client::new(),
+            "http://localhost:8000".into(),
+            None,
+            None,
+        );
+        *adapter.hf_model_cache.lock().await = Some(ModelInfo {
+            name: "google/gemma-4-31B-it".into(),
+            parameter_size: Some("31.0B params".into()),
+            quantization: None,
+            precision: None,
+            tensor_type: None,
+            model_type: None,
+            pipeline_tag: None,
+        });
+        *adapter.last_hf_error.lock().await = Some(Instant::now());
+
+        let hit = adapter.fetch_hf_model_info("google/gemma-4-31B-it").await;
+        assert_eq!(
+            hit.map(|m| m.name),
+            Some("google/gemma-4-31B-it".to_string()),
+            "same id is served from the cache"
+        );
+
+        let miss = adapter
+            .fetch_hf_model_info("google/gemma-4-31B-it_FP16")
+            .await;
+        assert!(
+            miss.is_none(),
+            "a different id must not be renamed to the stale cache entry"
+        );
+    }
+
     /// Sanity check: percentiles flow from the parser through the adapter.
     /// We don't spin up an HTTP mock here — `parse_prometheus_text` is the
     /// boundary we care about, so we assert the percentile pipeline against

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -359,6 +359,7 @@ mod tests {
             endpoint: endpoint.to_string(),
             status: EngineStatus::Running,
             model: None,
+            model_metadata_error: None,
             metrics: None,
             recent_requests: Vec::new(),
             deployment_mode: match container_id {


### PR DESCRIPTION
Closes #90.

The vLLM adapter swallowed every `/v1/models` failure, so an auth-gated deployment (vLLM `--api-key`) with no key configured on the dashboard silently fell back to the `--model` command-line path with nothing saying anything went wrong.

## What changed

**Backend** (`fix(engines)`): `get_model_info` now inspects the response status and returns a `ModelResolution` — the resolved (possibly fallback) `ModelInfo` plus an optional `ModelMetadataError`: `AuthRequired` for 401/403, `Unavailable` for every non-auth cause (unreachable, error status, unparseable body, empty list). The error travels on `EngineSnapshot` next to `model`. Cache semantics keep the warning honest: an errored resolution retries on the 30-second cooldown instead of being trusted for the 10-minute refresh, a clean fetch clears a stale error, and the HF enrichment cache is now keyed by model id so a stale fallback entry cannot rename the model back after the real id resolves.

**Frontend** (`fix(frontend)`): the engine status panel shows an auth warning beside the fallback model name — or as the headline ("Model name unavailable") when nothing resolved — and the multi-engine identity row wears a compact ⚠ mark carrying the same words. Only `AuthRequired` warns: a merely unreachable `/v1/models` is already told by the engine status, and pointing at a key there would send an operator fixing the wrong thing. `/metrics`-derived panels are unaffected either way.

## Metrics contract

All five sites ship in this PR: Rust unit tests (`src/engines/`), TS types (`frontend/src/types/metrics.ts`, optional field so older backends still parse), formatter wording (`frontend/src/lib/format.ts`), Vitest specs (warning-with-name, warning-alone, no-warning, identity-row mark), components (`EngineStatusPanel`, `EnginePanelBody`, `engineLabel`).

## Verification

- `cargo fmt --check`, `cargo test --locked` (175 passed); clippy shows only the known macOS dead-code false positives in Linux-gated code — Linux CI is the source of truth.
- `cd frontend && npm run lint && npm run build && npm test -- --run` (713 passed). No `*.browser.test.tsx` changed.
- Rebase-merge as usual; every commit is a valid Conventional Commit.