### PR TITLE
feat(frontend): remove a panel with one click on its frame in edit mode

### DIFF
--- a/frontend/src/__tests__/App.panelEditing.test.tsx
+++ b/frontend/src/__tests__/App.panelEditing.test.tsx
@@ -287,6 +287,42 @@ describe('removing a panel', () => {
 
     expect(screen.queryByRole('region', { name: 'CPU' })).not.toBeInTheDocument()
   })
+
+  it('is one click on the frame’s X, and the save writes it out', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await userEvent.click(screen.getByRole('button', { name: 'Remove CPU' }))
+
+    expect(screen.queryByRole('region', { name: 'CPU' })).not.toBeInTheDocument()
+
+    await saveAndReload(fetchMock)
+
+    expect(screen.queryByRole('region', { name: 'CPU' })).not.toBeInTheDocument()
+  })
+
+  it('offers the X only while the page is being edited', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await openPage(fetchMock)
+
+    expect(screen.queryByRole('button', { name: 'Remove CPU' })).not.toBeInTheDocument()
+  })
+
+  it('closes the removed panel’s settings, and leaves another panel’s open', async () => {
+    const fetchMock = serveConfiguration({ document: storedDocument(onePanel()) })
+    await editPage(fetchMock)
+    await addPanelOfType('GPU Power')
+
+    await configure('CPU')
+    await userEvent.click(screen.getByRole('button', { name: 'Remove GPU Power' }))
+
+    // The removal was of another panel; the open settings are still about a
+    // panel that exists and stay put.
+    expect(screen.getByRole('region', { name: 'Panel settings' })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove CPU' }))
+
+    expect(screen.queryByRole('region', { name: 'Panel settings' })).not.toBeInTheDocument()
+  })
 })
 
 describe('renaming a panel', () => {

--- a/frontend/src/components/grid/GridPage.tsx
+++ b/frontend/src/components/grid/GridPage.tsx
@@ -80,6 +80,8 @@ export interface PanelChrome {
   /** The panel whose settings are open, or null while none are. */
   configuringId: string | null
   onConfigure: (panelId: string) => void
+  /** The red X on the frame: take this panel off the page being edited. */
+  onRemove: (panelId: string) => void
 }
 
 /**
@@ -227,6 +229,7 @@ export function GridPage({
                 editing={Boolean(editing)}
                 configuring={chrome?.configuringId === panel.id}
                 onConfigure={chrome && (() => chrome.onConfigure(panel.id))}
+                onRemove={chrome && (() => chrome.onRemove(panel.id))}
               />
             </GridStackItem>
           ))}

--- a/frontend/src/components/grid/GridPageEditor.tsx
+++ b/frontend/src/components/grid/GridPageEditor.tsx
@@ -66,9 +66,9 @@ interface GridPageEditorProps {
  * experimental layout and one every colleague on this instance loads.
  *
  * There is no undo. Discarding the session is the substitute — an undo stack
- * over a grid that reflows on collision is far deeper than what it would buy —
- * which is also why removing a panel is behind its settings rather than one
- * click on the frame.
+ * over a grid that reflows on collision is far deeper than what it would buy.
+ * That makes the one-click X on each frame safe enough to offer: a removal
+ * gone wrong costs the session, never the stored page.
  */
 export function GridPageEditor({
   page,
@@ -145,15 +145,20 @@ export function GridPageEditor({
     [],
   )
 
-  const remove = useCallback(() => {
-    // The settings close with the panel: there is nothing left to configure,
-    // and a refusal about it is no longer about anything.
+  const remove = useCallback((panelId: string) => {
     setSession((current) =>
-      current?.configuringId
+      current
         ? {
-            panels: removePanel(current.panels, current.configuringId),
-            configuringId: null,
-            refused: null,
+            panels: removePanel(current.panels, panelId),
+            // The settings close with their panel — there is nothing left to
+            // configure — while another panel's stay open.
+            configuringId: current.configuringId === panelId ? null : current.configuringId,
+            // A refusal about the removed panel is no longer about anything;
+            // one about a different panel, or a refused addition, still is.
+            refused:
+              current.refused?.kind === 'drop' && current.refused.panelId === panelId
+                ? null
+                : current.refused,
           }
         : current,
     )
@@ -168,8 +173,9 @@ export function GridPageEditor({
             ? { ...current, configuringId: current.configuringId === panelId ? null : panelId }
             : current,
         ),
+      onRemove: remove,
     }),
-    [session?.configuringId],
+    [session?.configuringId, remove],
   )
 
   const shown = useMemo(
@@ -245,7 +251,7 @@ export function GridPageEditor({
             onRepoint={(binding: PanelBinding) =>
               editConfigured((panels, id) => repointPanel(panels, id, binding))
             }
-            onRemove={remove}
+            onRemove={() => remove(configured.id)}
             onClose={() =>
               setSession((current) => (current ? { ...current, configuringId: null } : current))
             }

--- a/frontend/src/components/grid/GridPanel.tsx
+++ b/frontend/src/components/grid/GridPanel.tsx
@@ -1,4 +1,4 @@
-import { Settings2 } from 'lucide-react'
+import { Settings2, X } from 'lucide-react'
 import { useState } from 'react'
 import { isKnownPanelType } from '@/lib/dashboard/panels'
 import { panelTitle, type DashboardPanel } from '@/lib/dashboard/schema'
@@ -16,7 +16,7 @@ import { renderPanelContent } from './panelRegistry'
  * pointer — the drag would start either way, since the grid listens on the frame
  * and the event bubbles, but a chart that pops a tooltip under a panel in flight
  * is noise the operator did not ask for. The header keeps its pointer, because
- * that is where the panel's own settings are opened from; the grid library
+ * that is where the panel's own settings and removal live; the grid library
  * declines to start a drag on a button, so the two do not fight.
  */
 export function GridPanel({
@@ -24,12 +24,14 @@ export function GridPanel({
   editing = false,
   configuring = false,
   onConfigure,
+  onRemove,
 }: {
   panel: DashboardPanel
   editing?: boolean
   /** This panel's settings are the ones open, so its frame says so. */
   configuring?: boolean
   onConfigure?: () => void
+  onRemove?: () => void
 }) {
   const title = panelTitle(panel)
   // Reported up by the content, which is the only thing that knows what its
@@ -67,6 +69,16 @@ export function GridPanel({
             }`}
           >
             <Settings2 aria-hidden="true" className="w-3 h-3" />
+          </button>
+        )}
+        {editing && onRemove && (
+          <button
+            type="button"
+            aria-label={`Remove ${title}`}
+            onClick={onRemove}
+            className={`${onConfigure ? '' : 'ml-auto '}shrink-0 rounded p-0.5 text-red-500 hover:text-red-400 transition-colors`}
+          >
+            <X aria-hidden="true" className="w-3 h-3" />
           </button>
         )}
       </div>

--- a/frontend/src/lib/dashboard/editing.ts
+++ b/frontend/src/lib/dashboard/editing.ts
@@ -227,8 +227,8 @@ export function addPanel(panels: readonly DashboardPanel[], type: PanelType): Ad
 
 /**
  * The page without the panel named. There is no undo — discarding the session
- * is the substitute — so removal is offered from the panel's own settings
- * rather than as a one-click affordance on the frame.
+ * is the substitute, which is what makes the one-click X on the frame (and the
+ * button in the panel's settings) safe: nothing is written until the save.
  */
 export function removePanel(
   panels: readonly DashboardPanel[],


### PR DESCRIPTION
## What

In edit mode, every panel frame now carries a red X in its top-right corner (beside the settings gear) that removes the panel with one click.

## How

- `GridPanel` renders the X (lucide `X`, red) in the header — the one part of the frame that keeps pointer events during an edit session, and where the grid library declines to start a drag.
- `PanelChrome` gained `onRemove(panelId)`, passed down through `GridPage`.
- `GridPageEditor`'s `remove` callback was generalized from "the panel whose settings are open" to any panel id: it closes the settings row only when it belonged to the removed panel, and clears a standing out-of-room refusal only when it was about that panel. The settings row's own **Remove panel** button routes through the same callback.
- Removal still only touches the in-browser session — nothing is written until Save, and Discard undoes it. The doc comments in `GridPageEditor.tsx` and `editing.ts` that argued for keeping removal off the frame are updated, since the no-undo concern is covered by the session being the undo.

## Tests

Three new specs in `App.panelEditing.test.tsx`: removal via the X survives a save + reload, the X is absent outside edit mode, and removing a panel closes its own settings while leaving another panel's open. No browser spec needed — nothing depends on real layout.

`npm run lint`, `npm test -- --run` (716 passing), and `npm run build` are clean.